### PR TITLE
fix deadlock in debouncer

### DIFF
--- a/src/debounce/mod.rs
+++ b/src/debounce/mod.rs
@@ -12,8 +12,8 @@ use std::sync::mpsc;
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
-pub type OperationsBuffer =
-    Arc<Mutex<HashMap<PathBuf, (Option<op::Op>, Option<PathBuf>, Option<u64>)>>>;
+pub type OperationsBufferInner = HashMap<PathBuf, (Option<op::Op>, Option<PathBuf>, Option<u64>)>;
+pub type OperationsBuffer = Arc<Mutex<OperationsBufferInner>>;
 
 pub enum EventTx {
     Raw {

--- a/src/debounce/timer.rs
+++ b/src/debounce/timer.rs
@@ -39,12 +39,12 @@ impl ScheduleWorker {
             // events Mutex, and retry after yielding.
             match self.operations_buffer.try_lock() {
                 Ok(op_buf) => break (events, op_buf),
-                Err(std::sync::TryLockError::Poisoned {..}) => return None,
-                Err(std::sync::TryLockError::WouldBlock) => {
+                Err(::std::sync::TryLockError::Poisoned {..}) => return None,
+                Err(::std::sync::TryLockError::WouldBlock) => {
                     // drop the lock before yielding to give other threads a chance to complete
                     // their work.
                     drop(events);
-                    std::thread::yield_now();
+                    ::std::thread::yield_now();
                 }
             }
         };

--- a/tests/debounce.rs
+++ b/tests/debounce.rs
@@ -1415,6 +1415,7 @@ fn one_file_many_events() {
 // https://github.com/passcod/notify/issues/205
 #[test]
 fn delay_zero() {
+    let _timeout_test = fail_after("delay_zero", Duration::from_secs(2));
     let tdir = TempDir::new("temp_dir").expect("failed to create temporary directory");
 
     tdir.create("file1");
@@ -1427,9 +1428,7 @@ fn delay_zero() {
         .expect("failed to watch directory");
 
     let thread = thread::spawn(move || {
-        for e in rx.into_iter() {
-            println!("{:?}", e);
-        }
+        for _ in rx.into_iter() {}
     });
 
     for _ in 0..100 {

--- a/tests/debounce.rs
+++ b/tests/debounce.rs
@@ -1414,7 +1414,6 @@ fn one_file_many_events() {
 
 // https://github.com/passcod/notify/issues/205
 #[test]
-#[cfg_attr(not(target_os = "macos"), ignore)]
 fn delay_zero() {
     let tdir = TempDir::new("temp_dir").expect("failed to create temporary directory");
 


### PR DESCRIPTION
Works around the issue described in #205. Tested on the ~fsevent backend only~ linux/macos/windows.

I tried to change locking as little as possible as it's somewhat hard to follow, and instead use a simple backoff algorithm to workaround the deadlock.

These tests fail on both branch `origin/try-v4` and my fork.
```
test create_rename_overwrite_directory ... FAILED
test create_rename_overwrite_file ... FAILED
```

Would be nice to get a new version out with the fix as well!