### PR TITLE
Remove channel in favour of accepting `Fn` in Watcher constructors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - CHANGE: Remove `Op` and `DebouncedEvent` event classification. [#187]
 - CHANGE: Make it opt-in to receive information about event kind. [#187]
 - CHANGE: Make `Notice` events opt-in.
+- CHANGE: Remove `Sender`s from watcher API in favour of `EventFn` [#214]
 
 ## 5.0.0-pre.2
 

--- a/examples/monitor_raw.rs
+++ b/examples/monitor_raw.rs
@@ -2,20 +2,24 @@ use notify::{RecommendedWatcher, RecursiveMode, Watcher};
 use std::path::Path;
 
 fn watch<P: AsRef<Path>>(path: P) -> notify::Result<()> {
+    let (tx, rx) = std::sync::mpsc::channel();
+
     // Automatically select the best implementation for your platform.
     // You can also access each implementation directly e.g. INotifyWatcher.
-    let mut watcher: RecommendedWatcher = Watcher::new_immediate(|res| {
-        match res {
-            Ok(event) => println!("changed: {:?}", event),
-            Err(e) => println!("watch error: {:?}", e),
-        }
-    })?;
+    let mut watcher: RecommendedWatcher = Watcher::new_immediate(move |res| tx.send(res).unwrap())?;
 
     // Add a path to be watched. All files and directories at that path and
     // below will be monitored for changes.
     watcher.watch(path, RecursiveMode::Recursive)?;
 
-    loop {}
+    for res in rx {
+        match res {
+            Ok(event) => println!("changed: {:?}", event),
+            Err(e) => println!("watch error: {:?}", e),
+        }
+    }
+
+    Ok(())
 }
 
 fn main() {

--- a/examples/monitor_raw.rs
+++ b/examples/monitor_raw.rs
@@ -1,27 +1,21 @@
-use crossbeam_channel::unbounded;
 use notify::{RecommendedWatcher, RecursiveMode, Watcher};
 use std::path::Path;
 
 fn watch<P: AsRef<Path>>(path: P) -> notify::Result<()> {
-    // Create a channel to receive the events.
-    let (tx, rx) = unbounded();
-
     // Automatically select the best implementation for your platform.
     // You can also access each implementation directly e.g. INotifyWatcher.
-    let mut watcher: RecommendedWatcher = Watcher::new_immediate(tx)?;
+    let mut watcher: RecommendedWatcher = Watcher::new_immediate(|res| {
+        match res {
+            Ok(event) => println!("changed: {:?}", event),
+            Err(e) => println!("watch error: {:?}", e),
+        }
+    })?;
 
     // Add a path to be watched. All files and directories at that path and
     // below will be monitored for changes.
     watcher.watch(path, RecursiveMode::Recursive)?;
 
-    // This is a simple loop, but you may want to use more complex logic here,
-    // for example to handle I/O.
-    loop {
-        match rx.recv() {
-            Ok(event) => println!("changed: {:?}", event),
-            Err(e) => println!("watch error: {:?}", e),
-        }
-    }
+    loop {}
 }
 
 fn main() {

--- a/src/inotify.rs
+++ b/src/inotify.rs
@@ -5,7 +5,7 @@
 //! will return events for the directory itself, and for files inside the directory.
 
 use super::event::*;
-use super::{Config, Error, EventTx, RecursiveMode, Result, Watcher};
+use super::{Config, Error, EventFn, RecursiveMode, Result, Watcher};
 use crossbeam_channel::{bounded, unbounded, Sender};
 use inotify as inotify_sys;
 use inotify_sys::{EventMask, Inotify, WatchDescriptor, WatchMask};
@@ -30,13 +30,13 @@ const MESSAGE: mio::Token = mio::Token(1);
 // -  messages telling it what to do
 //
 // -  events telling it that something has happened on one of the watched files.
-struct EventLoop {
+struct EventLoop<F> {
     running: bool,
     poll: mio::Poll,
     event_loop_tx: mio_extras::channel::Sender<EventLoopMsg>,
     event_loop_rx: mio_extras::channel::Receiver<EventLoopMsg>,
     inotify: Option<Inotify>,
-    event_tx: EventTx,
+    event_fn: F,
     watches: HashMap<PathBuf, (WatchDescriptor, WatchMask, bool)>,
     paths: HashMap<WatchDescriptor, PathBuf>,
     rename_event: Option<Event>,
@@ -54,9 +54,9 @@ enum EventLoopMsg {
 }
 
 #[inline]
-fn send_pending_rename_event(rename_event: &mut Option<Event>, event_tx: &EventTx) {
+fn send_pending_rename_event(rename_event: &mut Option<Event>, event_fn: &dyn EventFn) {
     if let Some(e) = rename_event.take() {
-        event_tx.send(Ok(e)).ok();
+        event_fn(Ok(e));
     }
 }
 
@@ -93,8 +93,8 @@ fn remove_watch_by_event(
     }
 }
 
-impl EventLoop {
-    pub fn new(inotify: Inotify, event_tx: EventTx) -> Result<EventLoop> {
+impl<F: EventFn> EventLoop<F> {
+    pub fn new(inotify: Inotify, event_fn: F) -> Result<Self> {
         let (event_loop_tx, event_loop_rx) = mio_extras::channel::channel::<EventLoopMsg>();
         let poll = mio::Poll::new()?;
         poll.register(
@@ -119,16 +119,12 @@ impl EventLoop {
             event_loop_tx,
             event_loop_rx,
             inotify: Some(inotify),
-            event_tx,
+            event_fn,
             watches: HashMap::new(),
             paths: HashMap::new(),
             rename_event: None,
         };
         Ok(event_loop)
-    }
-
-    fn channel(&self) -> mio_extras::channel::Sender<EventLoopMsg> {
-        self.event_loop_tx.clone()
     }
 
     // Run the event loop.
@@ -152,6 +148,10 @@ impl EventLoop {
                 break;
             }
         }
+    }
+
+    fn channel(&self) -> mio_extras::channel::Sender<EventLoopMsg> {
+        self.event_loop_tx.clone()
     }
 
     // Handle a single event.
@@ -190,7 +190,7 @@ impl EventLoop {
                     let current_cookie = self.rename_event.as_ref().and_then(|e| e.tracker());
                     // send pending rename event only if the rename event for which the timer has been created hasn't been handled already; otherwise ignore this timeout
                     if current_cookie == Some(cookie) {
-                        send_pending_rename_event(&mut self.rename_event, &self.event_tx);
+                        send_pending_rename_event(&mut self.rename_event, &self.event_fn);
                     }
                 }
                 EventLoopMsg::Configure(config, tx) => {
@@ -215,9 +215,8 @@ impl EventLoop {
                 Ok(events) => {
                     for event in events {
                         if event.mask.contains(EventMask::Q_OVERFLOW) {
-                            self.event_tx
-                                .send(Ok(Event::new(EventKind::Other).set_flag(Flag::Rescan)))
-                                .ok();
+                            let ev = Ok(Event::new(EventKind::Other).set_flag(Flag::Rescan));
+                            (self.event_fn)(ev);
                         }
 
                         let path = match event.name {
@@ -226,7 +225,7 @@ impl EventLoop {
                         };
 
                         if event.mask.contains(EventMask::MOVED_FROM) {
-                            send_pending_rename_event(&mut self.rename_event, &self.event_tx);
+                            send_pending_rename_event(&mut self.rename_event, &self.event_fn);
                             remove_watch_by_event(&path, &self.watches, &mut remove_watches);
                             self.rename_event = Some(
                                 Event::new(EventKind::Modify(ModifyKind::Name(RenameMode::From)))
@@ -238,7 +237,7 @@ impl EventLoop {
                             if event.mask.contains(EventMask::MOVED_TO) {
                                 if let Some(e) = self.rename_event.take() {
                                     if e.tracker() == Some(event.cookie as usize) {
-                                        self.event_tx.send(Ok(e.clone())).ok();
+                                        (self.event_fn)(Ok(e.clone()));
                                         evs.push(
                                             Event::new(EventKind::Modify(ModifyKind::Name(
                                                 RenameMode::To,
@@ -363,11 +362,11 @@ impl EventLoop {
                             }
 
                             if !evs.is_empty() {
-                                send_pending_rename_event(&mut self.rename_event, &self.event_tx);
+                                send_pending_rename_event(&mut self.rename_event, &self.event_fn);
                             }
 
                             for ev in evs {
-                                self.event_tx.send(Ok(ev)).ok();
+                                (self.event_fn)(Ok(ev));
                             }
                         }
                     }
@@ -392,7 +391,7 @@ impl EventLoop {
                     }
                 }
                 Err(e) => {
-                    self.event_tx.send(Err(Error::io(e))).ok();
+                    (self.event_fn)(Err(Error::io(e)));
                 }
             }
         }
@@ -517,9 +516,9 @@ fn filter_dir(e: walkdir::Result<walkdir::DirEntry>) -> Option<walkdir::DirEntry
 }
 
 impl Watcher for INotifyWatcher {
-    fn new_immediate(tx: Sender<Result<Event>>) -> Result<INotifyWatcher> {
+    fn new_immediate<F: EventFn>(event_fn: F) -> Result<INotifyWatcher> {
         let inotify = Inotify::init()?;
-        let event_loop = EventLoop::new(inotify, tx)?;
+        let event_loop = EventLoop::new(inotify, event_fn)?;
         let channel = event_loop.channel();
         event_loop.run();
         Ok(INotifyWatcher(Mutex::new(channel)))

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -127,11 +127,11 @@ mod config;
 mod error;
 
 /// The set of requirements for watcher event handling functions.
-pub trait EventFn: 'static + Fn(Result<Event>) + Send + Sync {}
+pub trait EventFn: 'static + Fn(Result<Event>) + Send {}
 
 impl<F> EventFn for F
 where
-    F: 'static + Fn(Result<Event>) + Send + Sync {}
+    F: 'static + Fn(Result<Event>) + Send {}
 
 /// Type that can deliver file activity notifications
 ///

--- a/src/null.rs
+++ b/src/null.rs
@@ -2,8 +2,7 @@
 
 #![allow(unused_variables)]
 
-use super::{Event, RecursiveMode, Result, Watcher};
-use crossbeam_channel::Sender;
+use super::{EventFn, RecursiveMode, Result, Watcher};
 use std::path::Path;
 
 /// Stub `Watcher` implementation
@@ -12,7 +11,7 @@ use std::path::Path;
 pub struct NullWatcher;
 
 impl Watcher for NullWatcher {
-    fn new_immediate(tx: Sender<Result<Event>>) -> Result<NullWatcher> {
+    fn new_immediate<F: EventFn>(_event_fn: F) -> Result<NullWatcher> {
         Ok(NullWatcher)
     }
 

--- a/src/poll.rs
+++ b/src/poll.rs
@@ -37,8 +37,7 @@ pub struct PollWatcher {
 
 impl PollWatcher {
     /// Create a PollWatcher which polls every `delay` milliseconds
-    pub fn with_delay<F: EventFn>(event_fn: F, delay: Duration) -> Result<PollWatcher> {
-        let event_fn = Arc::new(event_fn);
+    pub fn with_delay(event_fn: Arc<dyn EventFn>, delay: Duration) -> Result<PollWatcher> {
         let mut p = PollWatcher {
             event_fn,
             watches: Arc::new(Mutex::new(HashMap::new())),
@@ -188,7 +187,7 @@ impl PollWatcher {
 
 impl Watcher for PollWatcher {
     fn new_immediate<F: EventFn>(event_fn: F) -> Result<PollWatcher> {
-        PollWatcher::with_delay(event_fn, Duration::from_secs(30))
+        PollWatcher::with_delay(Arc::new(event_fn), Duration::from_secs(30))
     }
 
     fn watch<P: AsRef<Path>>(&mut self, path: P, recursive_mode: RecursiveMode) -> Result<()> {


### PR DESCRIPTION
This implements the changes described in #213.

~~This PR is a **work-in-progress**.~~

TODO:

- [x] Make API change.
- [x] Update inotify watcher.
- [x] Update poll watcher.
- [x] Update fsevents watcher.
- [x] Update windows watcher.

Closes #213.
Closes #160.