### PR TITLE
Use windows-sdk-10.1 to avoid installation failure

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -48,7 +48,7 @@ before_install:
   - set -e
   - |
     if [ $TRAVIS_OS_NAME = windows ]; then
-      choco install windows-sdk-10.0
+      choco install windows-sdk-10.1
     fi
     if [[ ! -z "$CARGO_SMOKE" ]]; then
       which cargo-audit || cargo install --debug cargo-audit


### PR DESCRIPTION
Install windows-sdk-10.1 instead of 10.0 to avoid installation failure.