### PR TITLE
Remove tempdir from dev-dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,7 +45,6 @@ winapi = { version = "0.3.8", features = ["fileapi", "handleapi", "ioapiset", "m
 
 [dev-dependencies]
 serde_json = "1.0.39"
-tempdir = "0.3.4"
 
 [features]
 timing_tests = []


### PR DESCRIPTION
At a glance, `tempdir` dev-dependency is unnecessary