### PR TITLE
Prepare release for 4.0.15

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,12 @@
 # Changelog
 
-## 4.0.15 (2020)
+## 4.0.15 (2020-01-07)
 
 - DEPS: Update inotify to 0.7.
 - DEPS(DEV): Replace tempdir with tempfile since tempdir is deprecated.
+- DEPS: Update winapi to 0.3 and remove kernel32-sys. [#232]
+
+[#232]: https://github.com/notify-rs/notify/pull/232
 
 ## 4.0.14 (2019-10-17)
 


### PR DESCRIPTION
I'll release notify v4.0.15 once this is merged.
This release aims to update winapi and remove kernel32-sys (note that we cannot remove it completely at now because mio v0.6 depends on it).