### PR TITLE
Remove unused `chashmap` dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,6 @@ filetime = "0.2.6"
 libc = "0.2.4"
 serde = { version = "1.0.89", features = ["derive"], optional = true }
 walkdir = "2.0.1"
-chashmap = "2.2.2"
 
 [target.'cfg(target_os="linux")'.dependencies]
 inotify = { version = "0.8", default-features = false }


### PR DESCRIPTION
The last use of `chashmap` was removed in 7ff572b98676a2f1050741d03a721db2897d160b.
