### PR TITLE
Fix/suppress warnings

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,9 +22,6 @@ exclude = [
   ".github/*"
 ]
 
-[badges]
-travis-ci = { repository = "notify-rs/notify", branch = "main" }
-
 [dependencies]
 anymap = "0.12.1"
 bitflags = "1.0.4"

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,9 +1,6 @@
 //! Error types
 
 use crate::Config;
-use crossbeam_channel;
-#[cfg(target_os = "linux")]
-use mio_extras;
 use std::error::Error as StdError;
 use std::path::PathBuf;
 use std::result::Result as StdResult;

--- a/src/fsevent.rs
+++ b/src/fsevent.rs
@@ -20,7 +20,6 @@ use crossbeam_channel::{unbounded, Receiver, Sender};
 use fsevent as fse;
 use fsevent_sys as fs;
 use fsevent_sys::core_foundation as cf;
-use libc;
 use std::collections::HashMap;
 use std::convert::AsRef;
 use std::ffi::CStr;

--- a/src/inotify.rs
+++ b/src/inotify.rs
@@ -9,8 +9,6 @@ use super::{Config, Error, EventFn, RecursiveMode, Result, Watcher};
 use crossbeam_channel::{bounded, unbounded, Sender};
 use inotify as inotify_sys;
 use inotify_sys::{EventMask, Inotify, WatchDescriptor, WatchMask};
-use mio;
-use mio_extras;
 use std::collections::HashMap;
 use std::env;
 use std::ffi::OsStr;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -95,6 +95,8 @@
 //! # }
 //! ```
 
+// FIXME: `anymap` crate triggers this lint and we cannot do anything here.
+#![allow(where_clauses_object_safety)]
 #![deny(missing_docs)]
 
 pub use config::{Config, RecursiveMode};

--- a/src/poll.rs
+++ b/src/poll.rs
@@ -201,7 +201,7 @@ impl PollWatcher {
 
             match fs::metadata(path) {
                 Err(e) => {
-                    let err = Error::io(e).add_path(watch.clone());
+                    let err = Error::io(e).add_path(watch);
                     emit_event(&self.event_fn, Err(err));
                 }
                 Ok(metadata) => {

--- a/tests/serialise-events.rs
+++ b/tests/serialise-events.rs
@@ -1,7 +1,11 @@
 // This file is dual-licensed under the Artistic License 2.0 as per the
 // LICENSE.ARTISTIC file, and the Creative Commons Zero 1.0 license.
 
+// FIXME: `anymap` crate triggers this lint and we cannot do anything here.
+#![allow(where_clauses_object_safety)]
+
 use notify::event::*;
+#[cfg(feature = "serde")]
 use serde_json::json;
 
 #[test]


### PR DESCRIPTION
Fixes #251, along with some clippy lint fixes.
Also, crates.io doesn't display CI badges anymore, so dropped it from our `Cargo.toml`.