### PR TITLE
Do not stat a path if not recursive.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@
 - CHANGE: Make `Notice` events opt-in.
 - CHANGE: Remove `Sender`s from watcher API in favour of `EventFn` [#214]
 - META: The project maintainers have changed from @passcod to notify-rs.
+- CHANGE: Avoid stating the watched path for non-recursive watches with inotify [#256]
+
+[#256]: https://github.com/notify-rs/notify/pull/256
 
 ## 5.0.0-pre.3 (2020-06-22)
 

--- a/src/inotify.rs
+++ b/src/inotify.rs
@@ -404,9 +404,7 @@ impl EventLoop {
     }
 
     fn add_watch(&mut self, path: PathBuf, is_recursive: bool, mut watch_self: bool) -> Result<()> {
-        let metadata = metadata(&path).map_err(Error::io)?;
-
-        if !metadata.is_dir() || !is_recursive {
+        if !is_recursive || !metadata(&path).map_err(Error::io)?.is_dir() {
             return self.add_single_watch(path, false, true);
         }
 

--- a/src/inotify.rs
+++ b/src/inotify.rs
@@ -404,6 +404,8 @@ impl EventLoop {
     }
 
     fn add_watch(&mut self, path: PathBuf, is_recursive: bool, mut watch_self: bool) -> Result<()> {
+        // If the watch is not recursive, or if we determine (by stat'ing the path to get its
+        // metadata) that the watched path is not a directory, add a single path watch.
         if !is_recursive || !metadata(&path).map_err(Error::io)?.is_dir() {
             return self.add_single_watch(path, false, true);
         }


### PR DESCRIPTION
Changing the order of the checks in `EventLoop::add_watch` avoids a stat for non-recursive watches.