### PR TITLE
Fix typo in documentation link in lib.rs

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -44,7 +44,7 @@
 //! By default, Notify emits non-descript events containing only the affected path and some
 //! metadata. To get richer details about _what_ the events are about, you need to enable
 //! [`Config::PreciseEvents`](config/enum.Config.html#variant.PreciseEvents). The full event
-//! classification is described in the [`event`](event/index.html`) module documentation.
+//! classification is described in the [`event`](event/index.html) module documentation.
 //!
 //! ```
 //! # use notify::{Watcher, RecommendedWatcher, RecursiveMode, Result};


### PR DESCRIPTION
<!-- By contributing, you agree to the terms of the license, available in the LICENSE.ARTISTIC file, and of the code of conduct, available in the CODE_OF_CONDUCT.md file. Furthermore, you agree to release under CC0, also available in the LICENSE file, until Notify has fully transitioned to Artistic 2.0. -->

<!-- After creating this pull request, the test suite will run.

It is expected that if any failures occur in the builds, you either:

- fix the errors,
- ask for help, or
- note that the failures are expected with a detailed explanation.

If you do not, a maintainer may prompt you and/or do it themselves, but do note that it will take longer for your contribution to be reviewed if the build does not pass.

Running `cargo fmt` and/or `cargo clippy` is NOT required but appreciated!

You can remove this text. -->

While browsing through the docs [here](https://docs.rs/notify/5.0.0-pre.3/notify/), I noticed a broken link pointing to https://docs.rs/notify/5.0.0-pre.3/notify/event/index.html%60 caused by a stray backtick in the link target.