### PR TITLE
EventLoop::new: Use level-triggered events for inotify fd.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@
 - CHANGE: Remove `Sender`s from watcher API in favour of `EventFn` [#214]
 - META: The project maintainers have changed from @passcod to notify-rs.
 - CHANGE: Avoid stating the watched path for non-recursive watches with inotify [#256]
+- FIX: Report events promptly on Linux, even when many occur in rapid succession. [#268]
+
+[#268]: https://github.com/notify-rs/notify/pull/268
 
 ## 5.0.0-pre.4 (2020-10-31)
 

--- a/src/inotify.rs
+++ b/src/inotify.rs
@@ -108,7 +108,10 @@ impl EventLoop {
             &evented_inotify,
             INOTIFY,
             mio::Ready::readable(),
-            mio::PollOpt::edge(),
+            // Use level-sensitive polling (issue #267): `Inotify::read_events`
+            // only consumes one buffer's worth of events at a time, so events
+            // may remain in the inotify fd after calling handle_inotify.
+            mio::PollOpt::level(),
         )?;
 
         let event_loop = EventLoop {


### PR DESCRIPTION
The `inotify` crate's `Inotify::read_events` method does not read all available
events from inotify (see hannobraun/inotify#156), only one buffer's worth. Using
level-triggered events tells Mio to report events on the inotify fd until all
events have been read.

Fixes #267.
