### PR TITLE
EventLoop::new: Use level-triggered events for inotify fd. (backport to v4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 4.0.16 (future)
+
+- FIX: Report events promptly on Linux, even when many occur in rapid succession. [#268]
+
+[#268]: https://github.com/notify-rs/notify/pull/268
+
 ## 4.0.15 (2020-01-07)
 
 - DEPS: Update inotify to 0.7.

--- a/src/inotify.rs
+++ b/src/inotify.rs
@@ -118,7 +118,10 @@ impl EventLoop {
             &evented_inotify,
             INOTIFY,
             mio::Ready::readable(),
-            mio::PollOpt::edge(),
+            // Use level-sensitive polling (issue #267): `Inotify::read_events`
+            // only consumes one buffer's worth of events at a time, so events
+            // may remain in the inotify fd after calling handle_inotify.
+            mio::PollOpt::level(),
         )?;
 
         let event_loop = EventLoop {


### PR DESCRIPTION
This is #268, rebased onto v4.0.15.

The `inotify` crate's `Inotify::read_events` method does not read all available
events from inotify (see hannobraun/inotify#156), only one buffer's worth. Using
level-triggered events tells Mio to report events on the inotify fd until all
events have been read.

Fixes #267.
