### PR TITLE
chore(deps): update crossbeam-channel to 0.5.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,11 +29,11 @@ jobs:
       os: osx
 
     - stage: check minimum version
-      rust: 1.32.0
+      rust: 1.36.0
       os: linux
-    - rust: 1.32.0
+    - rust: 1.36.0
       os: windows
-    - rust: 1.32.0
+    - rust: 1.36.0
       os: osx
 
     - stage: check nightlies

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,12 @@
 
 [#268]: https://github.com/notify-rs/notify/pull/268
 
+## unreleased
+- RUSTC: Push the minimum version to 1.36.0 [#276]
+- FIX: Report events promptly on Linux, even when many occur in rapid succession. [#268]
+
+[#276]: https://github.com/notify-rs/notify/pull/276
+
 ## 5.0.0-pre.4 (2020-10-31)
 
 - CHANGE: Avoid stating the watched path for non-recursive watches with inotify [#256]
@@ -47,7 +53,7 @@ _(no changes, just a new release because the old one failed to publish properly)
 ## 5.0.0-pre.0 (2019-06-22)
 
 - **yanked 2019-06-30**
-- RUSTC: Push the minimum version to 1.32.0 [#201]
+- RUSTC: Push the minimum version to 1.36.0 [#201]
 - RUSTC: Switch the crate to Rust 2018.
 - FIX: Implement `Sync` for PollWatcher to support FreeBSD. [#197]
 - FEATURE: Add new runtime configuration system.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ exclude = [
 [dependencies]
 anymap = "0.12.1"
 bitflags = "1.0.4"
-crossbeam-channel = "0.4.0"
+crossbeam-channel = "0.5.0"
 filetime = "0.2.6"
 libc = "0.2.4"
 serde = { version = "1.0.89", features = ["derive"], optional = true }

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ You likely want either [the latest 4.0 release] or [5.0.0-pre.3].
 - [API Documentation][docs]
 - [Crate page][crate]
 - [Changelog][changelog]
-- Earliest supported Rust version: **1.32.0**
+- Earliest supported Rust version: **1.36.0**
 
 As used by: [alacritty], [cargo watch], [cobalt], [docket], [mdBook], [pax]
 [rdiff], [rust-analyzer], [timetrack], [watchexec], [xi-editor], and others.


### PR DESCRIPTION
Supersedes #270 (closes #270) and closes #274
This bumps up MSRV to 1.36.0.