### PR TITLE
Update to mio 0.7, remove mio-extras

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,8 +32,7 @@ walkdir = "2.0.1"
 
 [target.'cfg(target_os="linux")'.dependencies]
 inotify = { version = "0.8", default-features = false }
-mio = "0.6.15"
-mio-extras = "2.0.5"
+mio = { version = "0.7.7", features = ["os-ext"] }
 
 [target.'cfg(target_os="macos")'.dependencies]
 fsevent = "2.0.1"

--- a/src/error.rs
+++ b/src/error.rs
@@ -145,13 +145,6 @@ impl<T> From<std::sync::PoisonError<T>> for Error {
     }
 }
 
-#[cfg(target_os = "linux")]
-impl<T> From<mio_extras::channel::SendError<T>> for Error {
-    fn from(err: mio_extras::channel::SendError<T>) -> Self {
-        Error::generic(&format!("internal channel error: {:?}", err))
-    }
-}
-
 #[test]
 fn display_formatted_errors() {
     let expected = "Some error";


### PR DESCRIPTION
This MR updates mio to version 0.7 and removes mio-extras.

To replace the channel used by mio-extras, we use crossbeam_channel along with a mio::Waker that will be used to wake up the mio event loop whenever we send a message through the crossbeam channel.

Note that  mio 0.7 has no level triggering (see https://github.com/tokio-rs/mio/issues/928 ). As such, we need another solution for #267. What I implemented is simply looping over `inotify.read_buffer` until it returns an empty iterator, at which point we can safely go back to waiting.

Fixes #248 