### PR TITLE
Update `inotify` to 0.9

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       matrix:
         version:
-          - 1.36.0 # MSRV
+          - 1.47.0 # MSRV
           - stable
           - nightly
         os: [ubuntu-latest, macos-latest, windows-latest]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,10 +14,13 @@
 [#268]: https://github.com/notify-rs/notify/pull/268
 
 ## unreleased
-- RUSTC: Push the minimum version to 1.36.0 [#276]
+- RUSTC: Push the minimum version to 1.47.0 [#280]
+- DEPS: Update `inotify` to 0.9 [#280]
+- DEPS: Update `mio` to 0.7 and remove `mio-extras` [#278]
 - FIX: Report events promptly on Linux, even when many occur in rapid succession. [#268]
 
-[#276]: https://github.com/notify-rs/notify/pull/276
+[#280]: https://github.com/notify-rs/notify/pull/280
+[#278]: https://github.com/notify-rs/notify/pull/278
 
 ## 5.0.0-pre.4 (2020-10-31)
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ serde = { version = "1.0.89", features = ["derive"], optional = true }
 walkdir = "2.0.1"
 
 [target.'cfg(target_os="linux")'.dependencies]
-inotify = { version = "0.8", default-features = false }
+inotify = { version = "0.9", default-features = false }
 mio = { version = "0.7.7", features = ["os-ext"] }
 
 [target.'cfg(target_os="macos")'.dependencies]

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ You likely want either [the latest 4.0 release] or [5.0.0-pre.3].
 - [API Documentation][docs]
 - [Crate page][crate]
 - [Changelog][changelog]
-- Earliest supported Rust version: **1.36.0**
+- Earliest supported Rust version: **1.47.0**
 
 As used by: [alacritty], [cargo watch], [cobalt], [docket], [mdBook], [pax]
 [rdiff], [rust-analyzer], [timetrack], [watchexec], [xi-editor], and others.


### PR DESCRIPTION
This bumps MSRV to 1.47 (https://github.com/hannobraun/inotify/blob/master/CHANGELOG.md#v090-2020-11-06). I'm going to make a new pre-release once this gets merged.