### PR TITLE
Handle interrupted error from mio

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,9 @@
 
 ## unreleased
 
+- FIX: Handle interrupted system call errors from mio [#281]
+
+[#281]: https://github.com/notify-rs/notify/pull/281
 
 ## 5.0.0-pre.5 (2020-01-28)
 


### PR DESCRIPTION
mio 0.7 was changed to no longer automatically retry on system call interruption, so we now must do it ourselves.  For example, the process receiving SIGINT could cause notify to panic, if the signal handler had been changed from default:
```
thread '<unnamed>' panicked at 'poll failed: Os { code: 4, kind: Interrupted, message: "Interrupted system call" }', /home/rschoon/.cargo/registry/src/github.com-1ecc6299db9ec823/notify-5.0.0-pre.5/src/inotify.rs:134:47
```

This change basically just ignores it (since we'll retry when we go through the loop again).