### PR TITLE
Prepare for 5.0.0-pre.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@
 
 ## unreleased
 
+
+
+## 5.0.0-pre.6 (2021-02-20)
+
 - FIX: Handle interrupted system call errors from mio [#281]
 
 [#281]: https://github.com/notify-rs/notify/pull/281

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "notify"
-version = "5.0.0-pre.5"
+version = "5.0.0-pre.6"
 
 description = "Cross-platform filesystem notification library"
 documentation = "https://docs.rs/notify"

--- a/README.md
+++ b/README.md
@@ -11,10 +11,10 @@ _Cross-platform filesystem notification library for Rust._
 
 **Caution! This is unstable code!**
 
-You likely want either [the latest 4.0 release] or [5.0.0-pre.5].
+You likely want either [the latest 4.0 release] or [5.0.0-pre.6].
 
 [the latest 4.0 release]: https://github.com/notify-rs/notify/tree/v4.0.15#notify
-[5.0.0-pre.5]: https://github.com/notify-rs/notify/tree/v5.0.0-pre.5#notify
+[5.0.0-pre.6]: https://github.com/notify-rs/notify/tree/v5.0.0-pre.6#notify
 
 (Looking for desktop notifications instead? Have a look at [notify-rust] or
 [alert-after]!)
@@ -33,7 +33,7 @@ As used by: [alacritty], [cargo watch], [cobalt], [docket], [mdBook], [pax]
 ```toml
 [dependencies]
 crossbeam-channel = "0.4.0"
-notify = "5.0.0-pre.5"
+notify = "5.0.0-pre.6"
 ```
 
 ## Usage
@@ -146,7 +146,7 @@ let mut watcher: RecommendedWatcher = Watcher::immediate_with_channel(tx)?;
 Events can be serialisable via [serde]. To enable the feature:
 
 ```toml
-notify = { version = "5.0.0-pre.5", features = ["serde"] }
+notify = { version = "5.0.0-pre.6", features = ["serde"] }
 ```
 
 ## Platforms
@@ -198,7 +198,7 @@ Written by [Félix Saparelli] and awesome [contributors].
 [contributors]: https://github.com/notify-rs/notify/graphs/contributors
 [crate]: https://crates.io/crates/notify
 [docket]: https://iwillspeak.github.io/docket/
-[docs]: https://docs.rs/notify/5.0.0-pre.5/notify/
+[docs]: https://docs.rs/notify/5.0.0-pre.6/notify/
 [fsnotify]: https://github.com/go-fsnotify/fsnotify
 [handlebars-iron]: https://github.com/sunng87/handlebars-iron
 [hotwatch]: https://github.com/francesca64/hotwatch

--- a/release_checklist.md
+++ b/release_checklist.md
@@ -1,0 +1,5 @@
+
+- update changelog
+- update readme
+- update lib.rs
+- update cargo.toml

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,7 +4,7 @@
 //!
 //! ```toml
 //! [dependencies]
-//! notify = "5.0.0-pre.2"
+//! notify = "5.0.0-pre.6"
 //! ```
 //!
 //! ## Serde
@@ -12,7 +12,7 @@
 //! Events are serialisable via [serde] if the `serde` feature is enabled:
 //!
 //! ```toml
-//! notify = { version = "5.0.0-pre.2", features = ["serde"] }
+//! notify = { version = "5.0.0-pre.6", features = ["serde"] }
 //! ```
 //!
 //! [serde]: https://serde.rs


### PR DESCRIPTION
This also updates the lib version in the docs, which we forgot to update since pre.2 apparently.