### PR TITLE
Do not self-update rustup to avoid permission failure

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -28,9 +28,10 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: setup toolchain
+        # `--no-self-update` is needed due to a permission issue on the GHA env.
         run: |
           rustup set profile minimal
-          rustup toolchain install ${{ matrix.version }}
+          rustup toolchain install ${{ matrix.version }} --no-self-update
           rustup override set ${{ matrix.version }}
 
       - name: check build


### PR DESCRIPTION
The current Rustup version on GHA is 1.23.1 so rustup tries to self-update when installing a toolchain but it can cause a permission issue on Windows env. `--no-self-update` is needed to avoid it.