### PR TITLE
Address clippy lints, hide some fsevents functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,9 +11,11 @@
 - CHANGE: Avoid stating the watched path for non-recursive watches with inotify [#256]
 - FIX: Report events promptly on Linux, even when many occur in rapid succession. [#268]
 - FIX: Remove `anymap`, and replace event attributes with an opaque type. [#306]
+- CHANGE: Hide fsevent::{CFRunLoopIsWaiting,callback}, fix clippy lint warnings [#312]
 
 [#268]: https://github.com/notify-rs/notify/pull/268
 [#306]: https://github.com/notify-rs/notify/pull/306
+[#312]: https://github.com/notify-rs/notify/pull/312
 
 ## unreleased
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,10 @@
 
 ## unreleased
 
+- CHANGE: Hide fsevent::{CFRunLoopIsWaiting,callback}, fix clippy lint warnings [#312]
+
+[#312]: https://github.com/notify-rs/notify/pull/312
+
 ## 5.0.0-pre.8 (2021-05-12)
 
 - HOTFIX: Fix breaking change in fsevent-sys in minor version destroying builds [#316]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,6 +42,7 @@ winapi = { version = "0.3.8", features = ["fileapi", "handleapi", "ioapiset", "m
 
 [dev-dependencies]
 serde_json = "1.0.39"
+tempfile = "3.2.0"
 
 [features]
 timing_tests = []

--- a/src/event.rs
+++ b/src/event.rs
@@ -246,42 +246,27 @@ pub enum EventKind {
 impl EventKind {
     /// Indicates whether an event is an Access variant.
     pub fn is_access(&self) -> bool {
-        match *self {
-            EventKind::Access(_) => true,
-            _ => false,
-        }
+        matches!(self, EventKind::Access(_))
     }
 
     /// Indicates whether an event is a Create variant.
     pub fn is_create(&self) -> bool {
-        match *self {
-            EventKind::Create(_) => true,
-            _ => false,
-        }
+        matches!(self, EventKind::Create(_))
     }
 
     /// Indicates whether an event is a Modify variant.
     pub fn is_modify(&self) -> bool {
-        match *self {
-            EventKind::Modify(_) => true,
-            _ => false,
-        }
+        matches!(self, EventKind::Modify(_))
     }
 
     /// Indicates whether an event is a Remove variant.
     pub fn is_remove(&self) -> bool {
-        match *self {
-            EventKind::Remove(_) => true,
-            _ => false,
-        }
+        matches!(self, EventKind::Remove(_))
     }
 
     /// Indicates whether an event is an Other variant.
     pub fn is_other(&self) -> bool {
-        match *self {
-            EventKind::Other => true,
-            _ => false,
-        }
+        matches!(self, EventKind::Other)
     }
 }
 

--- a/src/fsevent.rs
+++ b/src/fsevent.rs
@@ -526,17 +526,19 @@ fn test_fsevent_watcher_drop() {
     use super::*;
     use std::time::Duration;
 
+    let dir = tempfile::tempdir().unwrap();
+
     let (tx, rx) = std::sync::mpsc::channel();
     let event_fn = move |res| tx.send(res).unwrap();
 
     {
         let mut watcher: RecommendedWatcher = Watcher::new_immediate(event_fn).unwrap();
-        watcher.watch("../../", RecursiveMode::Recursive).unwrap();
+        watcher.watch(dir.path(), RecursiveMode::Recursive).unwrap();
         thread::sleep(Duration::from_millis(2000));
         println!("is running -> {}", watcher.is_running());
 
         thread::sleep(Duration::from_millis(1000));
-        watcher.unwatch("../..").unwrap();
+        watcher.unwatch(dir.path()).unwrap();
         println!("is running -> {}", watcher.is_running());
     }
 

--- a/src/fsevent.rs
+++ b/src/fsevent.rs
@@ -205,7 +205,7 @@ struct StreamContextInfo {
 
 extern "C" {
     /// Indicates whether the run loop is waiting for an event.
-    pub fn CFRunLoopIsWaiting(runloop: cf::CFRunLoopRef) -> bool;
+    fn CFRunLoopIsWaiting(runloop: cf::CFRunLoopRef) -> bool;
 }
 
 impl FsEventWatcher {
@@ -419,9 +419,7 @@ impl FsEventWatcher {
     }
 }
 
-#[allow(unused_variables)]
-#[doc(hidden)]
-pub extern "C" fn callback(
+extern "C" fn callback(
     stream_ref: fs::FSEventStreamRef,
     info: *mut libc::c_void,
     num_events: libc::size_t,         // size_t numEvents

--- a/src/fsevent.rs
+++ b/src/fsevent.rs
@@ -296,6 +296,8 @@ impl FsEventWatcher {
                 }
             }
 
+            cf::CFRelease(cf_path);
+
             for idx in to_remove.iter().rev() {
                 cf::CFArrayRemoveValueAtIndex(self.paths, *idx);
             }

--- a/src/poll.rs
+++ b/src/poll.rs
@@ -205,8 +205,9 @@ impl PollWatcher {
                     emit_event(&self.event_fn, Err(err));
                 }
                 Ok(metadata) => {
+                    let mut paths = HashMap::new();
+
                     if !metadata.is_dir() {
-                        let mut paths = HashMap::new();
                         let mtime = FileTime::from_last_modification_time(&metadata).seconds();
                         paths.insert(
                             watch.clone(),
@@ -215,15 +216,7 @@ impl PollWatcher {
                                 last_check: current_time,
                             },
                         );
-                        watches.insert(
-                            watch,
-                            WatchData {
-                                is_recursive: recursive_mode.is_recursive(),
-                                paths,
-                            },
-                        );
                     } else {
-                        let mut paths = HashMap::new();
                         let depth = if recursive_mode.is_recursive() {
                             usize::max_value()
                         } else {
@@ -254,14 +247,15 @@ impl PollWatcher {
                                 }
                             }
                         }
-                        watches.insert(
-                            watch,
-                            WatchData {
-                                is_recursive: recursive_mode.is_recursive(),
-                                paths,
-                            },
-                        );
                     }
+
+                    watches.insert(
+                        watch,
+                        WatchData {
+                            is_recursive: recursive_mode.is_recursive(),
+                            paths,
+                        },
+                    );
                 }
             }
         }

--- a/tests/race-with-remove-dir.rs
+++ b/tests/race-with-remove-dir.rs
@@ -1,4 +1,4 @@
-use std::{env, fs, thread, time::Duration};
+use std::{fs, thread, time::Duration};
 
 use notify::{immediate_watcher, RecursiveMode, Watcher};
 
@@ -6,11 +6,10 @@ use notify::{immediate_watcher, RecursiveMode, Watcher};
 /// Note: This test will fail if your temp directory is not writable.
 #[test]
 fn test_race_with_remove_dir() {
-    let tmpdir = env::temp_dir().join(".tmprPcUcB");
-    fs::create_dir_all(&tmpdir).unwrap();
+    let tmpdir = tempfile::tempdir().unwrap();
 
     {
-        let tmpdir = tmpdir.clone();
+        let tmpdir = tmpdir.path().to_path_buf();
         thread::spawn(move || {
             let mut watcher = immediate_watcher(move |result| {
                 eprintln!("received event: {:?}", result);
@@ -21,7 +20,7 @@ fn test_race_with_remove_dir() {
         });
     }
 
-    let subdir = tmpdir.join("146d921d.tmp");
+    let subdir = tmpdir.path().join("146d921d.tmp");
     fs::create_dir_all(&subdir).unwrap();
     fs::remove_dir_all(&tmpdir).unwrap();
     thread::sleep(Duration::from_secs(1));


### PR DESCRIPTION
This addresses all the items found by `clippy 0.1.54 (ca82264e 2021-05-09)`. In addition, it hides the functions `fsevents::Callback` and `fsevents::CFRunLoopIsWaiting`, which I don't think were intended to be made public.