### PR TITLE
Remove dependency on fsevent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,10 +12,12 @@
 - FIX: Report events promptly on Linux, even when many occur in rapid succession. [#268]
 - FIX: Remove `anymap`, and replace event attributes with an opaque type. [#306]
 - CHANGE: Hide fsevent::{CFRunLoopIsWaiting,callback}, fix clippy lint warnings [#312]
+- CHANGE: Remove dependency on `fsevent`. [#313]
 
 [#268]: https://github.com/notify-rs/notify/pull/268
 [#306]: https://github.com/notify-rs/notify/pull/306
 [#312]: https://github.com/notify-rs/notify/pull/312
+[#313]: https://github.com/notify-rs/notify/pull/313
 
 ## unreleased
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,6 @@ inotify = { version = "0.9", default-features = false }
 mio = { version = "0.7.7", features = ["os-ext"] }
 
 [target.'cfg(target_os="macos")'.dependencies]
-fsevent = "~2.0.1"
 fsevent-sys = "~3.1"
 
 [target.'cfg(windows)'.dependencies]


### PR DESCRIPTION
Notify doesn't really use the `fsevent` crate, so this patch removes the dependency. It still uses `fsevent-sys` to provide the C wrappers for the fsevent library.