### PR TITLE
set fsevent-sys crate minor version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,7 @@ mio = { version = "0.7.7", features = ["os-ext"] }
 
 [target.'cfg(target_os="macos")'.dependencies]
 fsevent = "2.0.1"
-fsevent-sys = "3"
+fsevent-sys = "3.1"
 
 [target.'cfg(windows)'.dependencies]
 winapi = { version = "0.3.8", features = ["fileapi", "handleapi", "ioapiset", "minwinbase", "synchapi", "winbase", "winnt"] }


### PR DESCRIPTION
Fixes #314

`fsevent-sys` recently released version "3.2", however this had a breaking change changing two parameters of their `callback` function from two `*mut c_void` to a `u32` and `u64` pointer.
Setting the version major & minor will help prevent breaking changes released in minor versions.

Note:
Another alternative is to update to "3.2" and fix the API accordingly, however this PR was the simplest. 