### PR TITLE
Fix fsevents to <2.1 and fsevents-sys to <3.2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,8 +34,8 @@ inotify = { version = "0.9", default-features = false }
 mio = { version = "0.7.7", features = ["os-ext"] }
 
 [target.'cfg(target_os="macos")'.dependencies]
-fsevent = "2.0.1"
-fsevent-sys = "3"
+fsevent = "~2.0.1"
+fsevent-sys = "~3.1"
 
 [target.'cfg(windows)'.dependencies]
 winapi = { version = "0.3.8", features = ["fileapi", "handleapi", "ioapiset", "minwinbase", "synchapi", "winbase", "winnt"] }


### PR DESCRIPTION
The latest released fsevents 3.2 made a breaking change in a minor version. This is a stopgap fix until octplane/fsevent-rust#38 has landed.

Fixes #314