### PR TITLE
Change CFRunLoopIsWaiting to return cf::Boolean

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,10 +12,12 @@
 - FIX: Report events promptly on Linux, even when many occur in rapid succession. [#268]
 - FIX: Remove `anymap`, and replace event attributes with an opaque type. [#306]
 - CHANGE: Hide fsevent::{CFRunLoopIsWaiting,callback}, fix clippy lint warnings [#312]
+- FIX: Correct the return type for `CFRunLoopIsWaiting` to be `Boolean` [#314]
 
 [#268]: https://github.com/notify-rs/notify/pull/268
 [#306]: https://github.com/notify-rs/notify/pull/306
 [#312]: https://github.com/notify-rs/notify/pull/312
+[#314]: https://github.com/notify-rs/notify/pull/314
 
 ## unreleased
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,8 +21,10 @@
 
 ## unreleased
 
+- FIX: Correct the return type for `CFRunLoopIsWaiting` to be `Boolean` [#314]
 - CHANGE: Hide fsevent::{CFRunLoopIsWaiting,callback}, fix clippy lint warnings [#312]
 
+[#314]: https://github.com/notify-rs/notify/pull/314
 [#312]: https://github.com/notify-rs/notify/pull/312
 
 ## 5.0.0-pre.8 (2021-05-12)

--- a/src/fsevent.rs
+++ b/src/fsevent.rs
@@ -202,7 +202,7 @@ struct StreamContextInfo {
 
 extern "C" {
     /// Indicates whether the run loop is waiting for an event.
-    fn CFRunLoopIsWaiting(runloop: cf::CFRunLoopRef) -> bool;
+    fn CFRunLoopIsWaiting(runloop: cf::CFRunLoopRef) -> cf::Boolean;
 }
 
 impl FsEventWatcher {
@@ -250,7 +250,7 @@ impl FsEventWatcher {
             unsafe {
                 let runloop = runloop as *mut raw::c_void;
 
-                while !CFRunLoopIsWaiting(runloop) {
+                while CFRunLoopIsWaiting(runloop) == 0 {
                     thread::yield_now();
                 }
 


### PR DESCRIPTION
According to this [doc], it's undefined behavior for a `bool` to be any
value other than `0` or `1`. Since `Boolean` is ultimately an
`unsigned char`, this avoids the risk that this function could return a
`true` value that's non-zero but not `1`.

[doc]: https://doc.rust-lang.org/reference/behavior-considered-undefined.html