### PR TITLE
Update to fsevent-sys 4.0.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,7 @@ inotify = { version = "0.9", default-features = false }
 mio = { version = "0.7.7", features = ["os-ext"] }
 
 [target.'cfg(target_os="macos")'.dependencies]
-fsevent-sys = "~3.1"
+fsevent-sys = "4"
 
 [target.'cfg(windows)'.dependencies]
 winapi = { version = "0.3.8", features = ["fileapi", "handleapi", "ioapiset", "minwinbase", "synchapi", "winbase", "winnt"] }

--- a/src/fsevent.rs
+++ b/src/fsevent.rs
@@ -469,10 +469,10 @@ impl FsEventWatcher {
 extern "C" fn callback(
     stream_ref: fs::FSEventStreamRef,
     info: *mut libc::c_void,
-    num_events: libc::size_t,         // size_t numEvents
-    event_paths: *mut libc::c_void,   // void *eventPaths
-    event_flags: *const libc::c_void, // const FSEventStreamEventFlags eventFlags[]
-    event_ids: *const libc::c_void,   // const FSEventStreamEventId eventIds[]
+    num_events: libc::size_t,                        // size_t numEvents
+    event_paths: *mut libc::c_void,                  // void *eventPaths
+    event_flags: *const fs::FSEventStreamEventFlags, // const FSEventStreamEventFlags eventFlags[]
+    event_ids: *const fs::FSEventStreamEventId,      // const FSEventStreamEventId eventIds[]
 ) {
     unsafe {
         callback_impl(
@@ -489,13 +489,12 @@ extern "C" fn callback(
 unsafe fn callback_impl(
     _stream_ref: fs::FSEventStreamRef,
     info: *mut libc::c_void,
-    num_events: libc::size_t,         // size_t numEvents
-    event_paths: *mut libc::c_void,   // void *eventPaths
-    event_flags: *const libc::c_void, // const FSEventStreamEventFlags eventFlags[]
-    _event_ids: *const libc::c_void,  // const FSEventStreamEventId eventIds[]
+    num_events: libc::size_t,                        // size_t numEvents
+    event_paths: *mut libc::c_void,                  // void *eventPaths
+    event_flags: *const fs::FSEventStreamEventFlags, // const FSEventStreamEventFlags eventFlags[]
+    _event_ids: *const fs::FSEventStreamEventId,     // const FSEventStreamEventId eventIds[]
 ) {
     let event_paths = event_paths as *const *const libc::c_char;
-    let e_ptr = event_flags as *mut u32;
     let info = info as *const StreamContextInfo;
     let event_fn = &(*info).event_fn;
 
@@ -505,7 +504,7 @@ unsafe fn callback_impl(
             .expect("Invalid UTF8 string.");
         let path = PathBuf::from(path);
 
-        let flag = *e_ptr.add(p);
+        let flag = *event_flags.add(p);
         let flag = StreamFlags::from_bits(flag).unwrap_or_else(|| {
             panic!("Unable to decode StreamFlags: {}", flag);
         });


### PR DESCRIPTION
I just noticed fsevent-sys bumped a major version to pick up the API change around the callbacks. This means we no longer need to pin to fsevent-sys versions <3.2.