### PR TITLE
Fix StreamContextInfo to be Send

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,10 @@
 
 ## unreleased
 
+- FIX: Make StreamContextInfo Send to fix soundness issue [#325]
+
+[#325]: https://github.com/notify-rs/notify/pull/325
+
 ## 5.0.0-pre.9 (2021-05-21)
 
 - DEPS: Upgrade fsevent-sys dependency to 4.0 [#322]

--- a/src/fsevent.rs
+++ b/src/fsevent.rs
@@ -457,7 +457,7 @@ impl FsEventWatcher {
                 .send(())
                 .expect("error while signal run loop is done");
         });
-        // block until runloop has been set
+        // block until runloop has been sent
         self.runloop = Some((rl_rx.recv().unwrap().0, done_rx));
 
         Ok(())

--- a/src/fsevent.rs
+++ b/src/fsevent.rs
@@ -534,7 +534,8 @@ unsafe fn callback_impl(
         for ev in translate_flags(flag, true).into_iter() {
             // TODO: precise
             let ev = ev.add_path(path.clone());
-            (event_fn.lock().unwrap())(Ok(ev));
+            let event_fn = event_fn.lock().expect("lock not to be poisoned");
+            (event_fn)(Ok(ev));
         }
     }
 }


### PR DESCRIPTION
In #324, we found that we were passing StreamContextInfo to another thread, even though the type is not actually Send. This makes sure that StreamContextInfo is actually Send by wrapping it in a mutex.

Fixes #324
