### PR TITLE
Only check for ENOSPC on inotify_add_watch

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -78,11 +78,6 @@ impl Error {
 
     /// Creates a new i/o Error from a stdlib `io::Error`.
     pub fn io(err: io::Error) -> Self {
-        // do not report inotify limits as "no more space" on linux #266
-        #[cfg(target_os = "linux")]
-        if err.raw_os_error() == Some(28) {
-            return Self::new(ErrorKind::MaxFilesWatch);
-        }
         Self::new(ErrorKind::Io(err))
     }
 


### PR DESCRIPTION
According to the inotify documentation, the only function that returns `ENOSPC` is `inotify_add_watch`, so this moves the check for this error code to the `inotify.add_watch()` call point. This makes sure someone using a different watcher like PollWatcher on linux won't reinterpret this error.

Also, this uses `libc::ENOSPC` instead of `28` because it's easier to interpret from the inotify documentation.