### PR TITLE
Fix GHA trigger event name

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,7 +11,7 @@ on:
       - next
   pull_request:
   release:
-    types: [released, pre-released]
+    types: [released, prereleased]
 
 jobs:
   ci:


### PR DESCRIPTION
I mistakenly set the type name, the correct one is `prereleased`: https://docs.github.com/en/actions/reference/events-that-trigger-workflows#release
