### PR TITLE
Kqueue backend for use on BSD

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -22,10 +22,10 @@ jobs:
           - stable
           - nightly
         os: [ubuntu-latest, macos-latest, windows-latest]
-        feature: []
+        features: ["serde"]
         include:
           - os: macos-latest
-            feature: "macos_kqueue"
+            features: "serde, macos_kqueue"
     runs-on: ${{ matrix.os }}
 
     steps:
@@ -40,9 +40,8 @@ jobs:
 
       - name: check build
         env:
-          FEATURE: ${{ matrix.feature }}
         if: matrix.version != 'stable'
-        run: cargo check --features "serde $FEATURE" --examples
+        run: cargo check --features ${{ matrix.features }} --examples
 
       - name: check build hot reload tide
         if: matrix.version != 'stable'

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -22,6 +22,10 @@ jobs:
           - stable
           - nightly
         os: [ubuntu-latest, macos-latest, windows-latest]
+        feature: []
+        include:
+          - os: macos-latest
+            feature: "macos_kqueue"
     runs-on: ${{ matrix.os }}
 
     steps:
@@ -35,8 +39,10 @@ jobs:
           rustup override set ${{ matrix.version }}
 
       - name: check build
+        env:
+          FEATURE: ${{ matrix.feature }}
         if: matrix.version != 'stable'
-        run: cargo check --features serde --examples
+        run: cargo check --features "serde $FEATURE" --examples
 
       - name: test
         if: matrix.version == 'stable'

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -22,10 +22,6 @@ jobs:
           - stable
           - nightly
         os: [ubuntu-latest, macos-latest, windows-latest]
-        features: ["serde"]
-        include:
-          - os: macos-latest
-            features: "serde, macos_kqueue"
     runs-on: ${{ matrix.os }}
 
     steps:
@@ -39,8 +35,12 @@ jobs:
           rustup override set ${{ matrix.version }}
 
       - name: check build
-        if: matrix.version != 'stable'
-        run: cargo check --features ${{ matrix.features }} --examples
+        if: matrix.version != 'stable' && matrix.os == 'macos-latest'
+        run: cargo check --features=serde,macos_kqueue --examples
+
+      - name: check build
+        if: matrix.version != 'stable' && matrix.os != 'macos-latest'
+        run: cargo check --features=serde --examples
 
       - name: check build hot reload tide
         if: matrix.version != 'stable'

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -39,7 +39,6 @@ jobs:
           rustup override set ${{ matrix.version }}
 
       - name: check build
-        env:
         if: matrix.version != 'stable'
         run: cargo check --features ${{ matrix.features }} --examples
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,7 +41,7 @@ mio = { version = "0.7.7", features = ["os-ext"], optional = true }
 [target.'cfg(windows)'.dependencies]
 winapi = { version = "0.3.8", features = ["fileapi", "handleapi", "ioapiset", "minwinbase", "synchapi", "winbase", "winnt"] }
 
-[target.'cfg(target_os="freebsd")'.dependencies]
+[target.'cfg(any(target_os="freebsd", target_os="openbsd", target_os = "netbsd", target_os = "dragonflybsd"))'.dependencies]
 kqueue = "1.0"
 mio = { version = "0.7.7", features = ["os-ext"] }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,9 @@ inotify = { version = "0.9", default-features = false }
 mio = { version = "0.7.7", features = ["os-ext"] }
 
 [target.'cfg(target_os="macos")'.dependencies]
-fsevent-sys = "4"
+fsevent-sys = { version = "4", optional = true }
+kqueue = { version = "1.0", optional = true }
+mio = { version = "0.7.7", features = ["os-ext"], optional = true }
 
 [target.'cfg(windows)'.dependencies]
 winapi = { version = "0.3.8", features = ["fileapi", "handleapi", "ioapiset", "minwinbase", "synchapi", "winbase", "winnt"] }
@@ -48,5 +50,8 @@ serde_json = "1.0.39"
 tempfile = "3.2.0"
 
 [features]
+default = ["macos_fsevent"]
 timing_tests = []
 manual_tests = []
+macos_kqueue = ["kqueue", "mio"]
+macos_fsevent = ["fsevent-sys"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,6 +39,10 @@ fsevent-sys = "4"
 [target.'cfg(windows)'.dependencies]
 winapi = { version = "0.3.8", features = ["fileapi", "handleapi", "ioapiset", "minwinbase", "synchapi", "winbase", "winnt"] }
 
+[target.'cfg(target_os="freebsd")'.dependencies]
+kqueue = "1.0"
+mio = { version = "0.7.7", features = ["os-ext"] }
+
 [dev-dependencies]
 serde_json = "1.0.39"
 tempfile = "3.2.0"

--- a/README.md
+++ b/README.md
@@ -154,6 +154,7 @@ notify = { version = "5.0.0-pre.10", features = ["serde"] }
 - Linux / Android: inotify
 - macOS: FSEvents
 - Windows: ReadDirectoryChangesW
+- FreeBSD / NetBSD / OpenBSD / DragonflyBSD: kqueue
 - All platforms: polling
 
 ### FSEvents

--- a/src/kqueue.rs
+++ b/src/kqueue.rs
@@ -5,7 +5,7 @@
 //! pieces of kernel code termed filters.
 
 use super::event::*;
-use super::{Config, Error, EventFn, RecursiveMode, Result, Watcher};
+use super::{Error, EventFn, RecursiveMode, Result, Watcher};
 use crossbeam_channel::{unbounded, Sender};
 use kqueue::{EventData, EventFilter, FilterFlag, Ident};
 use std::collections::HashMap;

--- a/src/kqueue.rs
+++ b/src/kqueue.rs
@@ -163,7 +163,7 @@ impl EventLoop {
                                     Event::new(EventKind::Remove(RemoveKind::Any))
                                 }
 
-                                //data was write to this file
+                                //data was written to this file
                                 kqueue::Vnode::Write => Event::new(EventKind::Access(
                                     AccessKind::Close(AccessMode::Write),
                                 )),
@@ -190,7 +190,7 @@ impl EventLoop {
 
                                 /*
                                 The link count on a file changed => subdirectory created or
-                                delete. Currently now idea how to track this.
+                                delete. Currently no idea how to track this.
                                 */
                                 kqueue::Vnode::Link => {
                                     // readd this folder, this is currently the easiest way to

--- a/src/kqueue.rs
+++ b/src/kqueue.rs
@@ -1,0 +1,287 @@
+//! Watcher implementation for the inotify Linux API
+//!
+//! The inotify API provides a mechanism for monitoring filesystem events.  Inotify can be used to
+//! monitor individual files, or to monitor directories.  When a directory is monitored, inotify
+//! will return events for the directory itself, and for files inside the directory.
+
+use super::event::*;
+use super::{Config, Error, EventFn, RecursiveMode, Result, Watcher};
+use crossbeam_channel::{unbounded, Sender};
+use kqueue::{EventFilter, FilterFlag};
+use std::collections::HashMap;
+use std::env;
+use std::fs::metadata;
+use std::os::unix::io::AsRawFd;
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+use std::thread;
+use walkdir::WalkDir;
+
+const KQUEUE: mio::Token = mio::Token(0);
+const MESSAGE: mio::Token = mio::Token(1);
+
+// The EventLoop will set up a mio::Poll and use it to wait for the following:
+//
+// -  messages telling it what to do
+//
+// -  events telling it that something has happened on one of the watched files.
+struct EventLoop {
+    running: bool,
+    poll: mio::Poll,
+    event_loop_waker: Arc<mio::Waker>,
+    event_loop_tx: crossbeam_channel::Sender<EventLoopMsg>,
+    event_loop_rx: crossbeam_channel::Receiver<EventLoopMsg>,
+    kqueue: kqueue::Watcher,
+    event_fn: Box<dyn EventFn>,
+    watches: HashMap<PathBuf, bool>,
+}
+
+/// Watcher implementation based on inotify
+pub struct KqueueWatcher {
+    channel: crossbeam_channel::Sender<EventLoopMsg>,
+    waker: Arc<mio::Waker>,
+}
+
+enum EventLoopMsg {
+    AddWatch(PathBuf, RecursiveMode, Sender<Result<()>>),
+    RemoveWatch(PathBuf, Sender<Result<()>>),
+}
+
+impl EventLoop {
+    pub fn new(kqueue: kqueue::Watcher, event_fn: Box<dyn EventFn>) -> Result<Self> {
+        let (event_loop_tx, event_loop_rx) = crossbeam_channel::unbounded::<EventLoopMsg>();
+        let poll = mio::Poll::new()?;
+
+        let event_loop_waker = Arc::new(mio::Waker::new(poll.registry(), MESSAGE)?);
+
+        let kqueue_fd = kqueue.as_raw_fd();
+        let mut evented_kqueue = mio::unix::SourceFd(&kqueue_fd);
+        poll.registry()
+            .register(&mut evented_kqueue, KQUEUE, mio::Interest::READABLE)?;
+
+        let event_loop = EventLoop {
+            running: true,
+            poll,
+            event_loop_waker,
+            event_loop_tx,
+            event_loop_rx,
+            kqueue,
+            event_fn,
+            watches: HashMap::new(),
+        };
+        Ok(event_loop)
+    }
+
+    // Run the event loop.
+    pub fn run(self) {
+        thread::spawn(|| self.event_loop_thread());
+    }
+
+    fn event_loop_thread(mut self) {
+        let mut events = mio::Events::with_capacity(16);
+        loop {
+            // Wait for something to happen.
+            match self.poll.poll(&mut events, None) {
+                Err(ref e) if matches!(e.kind(), std::io::ErrorKind::Interrupted) => {
+                    // System call was interrupted, we will retry
+                    // TODO: Not covered by tests (to reproduce likely need to setup signal handlers)
+                }
+                Err(e) => panic!("poll failed: {}", e),
+                Ok(()) => {}
+            }
+
+            // Process whatever happened.
+            for event in &events {
+                self.handle_event(&event);
+            }
+
+            // Stop, if we're done.
+            if !self.running {
+                break;
+            }
+        }
+    }
+
+    // Handle a single event.
+    fn handle_event(&mut self, event: &mio::event::Event) {
+        match event.token() {
+            MESSAGE => {
+                // The channel is readable - handle messages.
+                self.handle_messages()
+            }
+            KQUEUE => {
+                // inotify has something to tell us.
+                self.handle_kqueue()
+            }
+            _ => unreachable!(),
+        }
+    }
+
+    fn handle_messages(&mut self) {
+        while let Ok(msg) = self.event_loop_rx.try_recv() {
+            match msg {
+                EventLoopMsg::AddWatch(path, recursive_mode, tx) => {
+                    let _ = tx.send(self.add_watch(path, recursive_mode.is_recursive()));
+                }
+                EventLoopMsg::RemoveWatch(path, tx) => {
+                    let _ = tx.send(self.remove_watch(path, false));
+                }
+            }
+        }
+    }
+
+    fn handle_kqueue(&mut self) {
+        let mut add_watches = Vec::new();
+        let mut remove_watches = Vec::new();
+
+        println!("hello");
+        loop {
+            match self.kqueue.poll(None) {
+                Some(event) => {
+                    dbg!(event);
+                    ()
+                }
+                None => break,
+            }
+        }
+
+        for path in remove_watches {
+            self.remove_watch(path, true).ok();
+        }
+
+        for path in add_watches {
+            self.add_watch(path, true).ok();
+        }
+    }
+
+    fn add_watch(&mut self, path: PathBuf, is_recursive: bool) -> Result<()> {
+        // If the watch is not recursive, or if we determine (by stat'ing the path to get its
+        // metadata) that the watched path is not a directory, add a single path watch.
+        if !is_recursive || !metadata(&path).map_err(Error::io)?.is_dir() {
+            return self.add_single_watch(path, false);
+        }
+
+        for entry in WalkDir::new(path)
+            .follow_links(true)
+            .into_iter()
+            .filter_map(filter_dir)
+        {
+            self.add_single_watch(entry.path().to_path_buf(), is_recursive)?;
+        }
+        self.kqueue.watch()?;
+
+        Ok(())
+    }
+
+    fn add_single_watch(&mut self, path: PathBuf, is_recursive: bool) -> Result<()> {
+        let event_filter = EventFilter::EVFILT_VNODE;
+        let filter_flags = FilterFlag::NOTE_DELETE
+            | FilterFlag::NOTE_WRITE
+            | FilterFlag::NOTE_EXTEND
+            | FilterFlag::NOTE_ATTRIB
+            | FilterFlag::NOTE_LINK
+            | FilterFlag::NOTE_RENAME
+            | FilterFlag::NOTE_REVOKE;
+
+        self.kqueue
+            .add_filename(&path, event_filter, filter_flags)?;
+        self.watches.insert(path, is_recursive);
+        self.kqueue.watch()?;
+        Ok(())
+    }
+
+    fn remove_watch(&mut self, path: PathBuf, remove_recursive: bool) -> Result<()> {
+        match self.watches.remove(&path) {
+            None => return Err(Error::watch_not_found()),
+            Some(is_recursive) => {
+                self.kqueue
+                    .remove_filename(&path, EventFilter::EVFILT_VNODE)
+                    .map_err(|e| Error::io(e))?;
+
+                if is_recursive || remove_recursive {
+                    for entry in WalkDir::new(path)
+                        .follow_links(true)
+                        .into_iter()
+                        .filter_map(filter_dir)
+                    {
+                        self.kqueue.remove_filename(
+                            entry.path().to_path_buf(),
+                            EventFilter::EVFILT_VNODE,
+                        )?;
+                    }
+                }
+                self.kqueue.watch()?;
+            }
+        }
+        Ok(())
+    }
+}
+
+/// return `DirEntry` when it is a directory
+fn filter_dir(e: walkdir::Result<walkdir::DirEntry>) -> Option<walkdir::DirEntry> {
+    if let Ok(e) = e {
+        if let Ok(metadata) = e.metadata() {
+            if metadata.is_dir() {
+                return Some(e);
+            }
+        }
+    }
+    None
+}
+
+impl KqueueWatcher {
+    fn from_event_fn(event_fn: Box<dyn EventFn>) -> Result<Self> {
+        let kqueue = kqueue::Watcher::new()?;
+        let event_loop = EventLoop::new(kqueue, event_fn)?;
+        let channel = event_loop.event_loop_tx.clone();
+        let waker = event_loop.event_loop_waker.clone();
+        event_loop.run();
+        Ok(KqueueWatcher { channel, waker })
+    }
+
+    fn watch_inner(&mut self, path: &Path, recursive_mode: RecursiveMode) -> Result<()> {
+        let pb = if path.is_absolute() {
+            path.to_owned()
+        } else {
+            let p = env::current_dir().map_err(Error::io)?;
+            p.join(path)
+        };
+        let (tx, rx) = unbounded();
+        let msg = EventLoopMsg::AddWatch(pb, recursive_mode, tx);
+
+        // we expect the event loop to live and reply => unwraps must not panic
+        self.channel.send(msg).unwrap();
+        self.waker.wake().unwrap();
+        rx.recv().unwrap()
+    }
+
+    fn unwatch_inner(&mut self, path: &Path) -> Result<()> {
+        let pb = if path.is_absolute() {
+            path.to_owned()
+        } else {
+            let p = env::current_dir().map_err(Error::io)?;
+            p.join(path)
+        };
+        let (tx, rx) = unbounded();
+        let msg = EventLoopMsg::RemoveWatch(pb, tx);
+
+        // we expect the event loop to live and reply => unwraps must not panic
+        self.channel.send(msg).unwrap();
+        self.waker.wake().unwrap();
+        rx.recv().unwrap()
+    }
+}
+
+impl Watcher for KqueueWatcher {
+    fn new_immediate<F: EventFn>(event_fn: F) -> Result<KqueueWatcher> {
+        KqueueWatcher::from_event_fn(Box::new(event_fn))
+    }
+
+    fn watch<P: AsRef<Path>>(&mut self, path: P, recursive_mode: RecursiveMode) -> Result<()> {
+        self.watch_inner(path.as_ref(), recursive_mode)
+    }
+
+    fn unwatch<P: AsRef<Path>>(&mut self, path: P) -> Result<()> {
+        self.unwatch_inner(path.as_ref())
+    }
+}

--- a/src/kqueue.rs
+++ b/src/kqueue.rs
@@ -139,7 +139,6 @@ impl EventLoop {
         let mut add_watches = Vec::new();
         let mut remove_watches = Vec::new();
 
-        println!("hello");
         loop {
             match self.kqueue.poll(None) {
                 Some(event) => {

--- a/src/kqueue.rs
+++ b/src/kqueue.rs
@@ -159,6 +159,7 @@ impl EventLoop {
                                 lookup.
                                 */
                                 kqueue::Vnode::Delete => {
+                                    remove_watches.push(path.clone());
                                     Event::new(EventKind::Remove(RemoveKind::Any))
                                 }
 
@@ -201,11 +202,13 @@ impl EventLoop {
 
                                 //TODO: is the anyway to track this with kqueue
                                 kqueue::Vnode::Rename => {
+                                    remove_watches.push(path.clone());
                                     Event::new(EventKind::Modify(ModifyKind::Name(RenameMode::Any)))
                                 }
 
                                 // Access to the file was revoked via revoke(2) or the underlying file system was unmounted.
                                 kqueue::Vnode::Revoke => {
+                                    remove_watches.push(path.clone());
                                     Event::new(EventKind::Remove(RemoveKind::Any))
                                 }
                             }

--- a/src/kqueue.rs
+++ b/src/kqueue.rs
@@ -276,9 +276,6 @@ impl EventLoop {
 
         self.kqueue
             .add_filename(&path, event_filter, filter_flags)?;
-        if path.is_dir() {
-            self.paths.insert(path.clone());
-        }
         self.watches.insert(path, is_recursive);
         self.kqueue.watch()?;
         Ok(())

--- a/src/kqueue.rs
+++ b/src/kqueue.rs
@@ -173,12 +173,9 @@ impl EventLoop {
                                 operation, extend is only used on FreeBSD, truncate everwhere
                                 else
                                 */
-                                kqueue::Vnode::Extend => Event::new(EventKind::Modify(
-                                    ModifyKind::Data(DataChange::Size),
-                                )),
-                                kqueue::Vnode::Truncate => Event::new(EventKind::Modify(
-                                    ModifyKind::Data(DataChange::Size),
-                                )),
+                                kqueue::Vnode::Extend | kqueue::Vnode::Truncate => Event::new(
+                                    EventKind::Modify(ModifyKind::Data(DataChange::Size)),
+                                ),
 
                                 /*
                                 this kevent has the same problem as the delete kevent. The

--- a/src/kqueue.rs
+++ b/src/kqueue.rs
@@ -230,7 +230,6 @@ impl EventLoop {
                         // as we don't add any other EVFILTER to kqueue we should never get here
                         kqueue::Event { ident: _, data: _ } => unreachable!(),
                     }
-                    ()
                 }
                 None => break,
             }
@@ -321,6 +320,11 @@ fn filter_dir(e: walkdir::Result<walkdir::DirEntry>) -> Option<walkdir::DirEntry
 }
 
 impl KqueueWatcher {
+    /// Create a new watcher.
+    pub fn new<F: EventFn>(event_fn: F) -> Result<Self> {
+        Self::from_event_fn(Box::new(event_fn))
+    }
+
     fn from_event_fn(event_fn: Box<dyn EventFn>) -> Result<Self> {
         let kqueue = kqueue::Watcher::new()?;
         let event_loop = EventLoop::new(kqueue, event_fn)?;

--- a/src/kqueue.rs
+++ b/src/kqueue.rs
@@ -170,7 +170,7 @@ impl EventLoop {
 
                                 /*
                                 Extend and Truncate are just different names for the same
-                                operation, truncate is only used on FreeBSD, extend everwhere
+                                operation, extend is only used on FreeBSD, truncate everwhere
                                 else
                                 */
                                 kqueue::Vnode::Extend => Event::new(EventKind::Modify(
@@ -195,8 +195,14 @@ impl EventLoop {
                                 The link count on a file changed => subdirectory created or
                                 delete. Currently now idea how to track this.
                                 */
-                                //TODO: Find new files and track them
                                 kqueue::Vnode::Link => {
+                                    // readd this folder, this is currently the easiest way to
+                                    // track new and removed subfolders
+
+                                    // TODO: This is really expensive, as we recursively walk through
+                                    // all subdirectories.
+                                    remove_watches.push(path.clone());
+                                    add_watches.push(path.clone());
                                     Event::new(EventKind::Modify(ModifyKind::Any))
                                 }
 

--- a/src/kqueue.rs
+++ b/src/kqueue.rs
@@ -364,16 +364,12 @@ impl KqueueWatcher {
 }
 
 impl Watcher for KqueueWatcher {
-    fn new_immediate<F: EventFn>(event_fn: F) -> Result<KqueueWatcher> {
-        KqueueWatcher::from_event_fn(Box::new(event_fn))
+    fn watch(&mut self, path: &Path, recursive_mode: RecursiveMode) -> Result<()> {
+        self.watch_inner(path, recursive_mode)
     }
 
-    fn watch<P: AsRef<Path>>(&mut self, path: P, recursive_mode: RecursiveMode) -> Result<()> {
-        self.watch_inner(path.as_ref(), recursive_mode)
-    }
-
-    fn unwatch<P: AsRef<Path>>(&mut self, path: P) -> Result<()> {
-        self.unwatch_inner(path.as_ref())
+    fn unwatch(&mut self, path: &Path) -> Result<()> {
+        self.unwatch_inner(path)
     }
 }
 

--- a/src/kqueue.rs
+++ b/src/kqueue.rs
@@ -166,7 +166,7 @@ impl EventLoop {
                                     // The link count on a file changed => subdirectory created or
                                     // delete. Currently now idea how to track this.
                                 Event::new(EventKind::Modify(ModifyKind::Any)),
-                                kqueue::Vnode::Rename => Event::new(EventKind::Modify(ModifyKind::Name(RenameMode::Other))),
+                                kqueue::Vnode::Rename => Event::new(EventKind::Modify(ModifyKind::Name(RenameMode::Any))),
                                 kqueue::Vnode::Revoke => Event::new(EventKind::Remove(RemoveKind::Any)),
                             }.add_path(path);
                             (self.event_fn)(Ok(event));

--- a/src/kqueue.rs
+++ b/src/kqueue.rs
@@ -8,7 +8,7 @@ use super::event::*;
 use super::{Error, EventFn, RecursiveMode, Result, Watcher};
 use crossbeam_channel::{unbounded, Sender};
 use kqueue::{EventData, EventFilter, FilterFlag, Ident};
-use std::collections::{HashMap, HashSet};
+use std::collections::HashMap;
 use std::env;
 use std::fs::metadata;
 use std::os::unix::io::AsRawFd;

--- a/src/kqueue.rs
+++ b/src/kqueue.rs
@@ -1,8 +1,8 @@
-//! Watcher implementation for the inotify Linux API
+//! Watcher implementation for the kqueue API
 //!
-//! The inotify API provides a mechanism for monitoring filesystem events.  Inotify can be used to
-//! monitor individual files, or to monitor directories.  When a directory is monitored, inotify
-//! will return events for the directory itself, and for files inside the directory.
+//! The kqueue() system call provides a generic method of notifying the user
+//! when an event happens or a condition holds, based on the results of small
+//! pieces of kernel code termed filters.
 
 use super::event::*;
 use super::{Config, Error, EventFn, RecursiveMode, Result, Watcher};

--- a/src/kqueue.rs
+++ b/src/kqueue.rs
@@ -340,10 +340,15 @@ impl KqueueWatcher {
         let (tx, rx) = unbounded();
         let msg = EventLoopMsg::AddWatch(pb, recursive_mode, tx);
 
-        // we expect the event loop to live and reply => unwraps must not panic
-        self.channel.send(msg).unwrap();
-        self.waker.wake().unwrap();
-        rx.recv().unwrap()
+        self.channel
+            .send(msg)
+            .map_err(|e| Error::generic(&e.to_string()))?;
+        self.waker
+            .wake()
+            .map_err(|e| Error::generic(&e.to_string()))?;
+        rx.recv()
+            .unwrap()
+            .map_err(|e| Error::generic(&e.to_string()))
     }
 
     fn unwatch_inner(&mut self, path: &Path) -> Result<()> {
@@ -356,10 +361,15 @@ impl KqueueWatcher {
         let (tx, rx) = unbounded();
         let msg = EventLoopMsg::RemoveWatch(pb, tx);
 
-        // we expect the event loop to live and reply => unwraps must not panic
-        self.channel.send(msg).unwrap();
-        self.waker.wake().unwrap();
-        rx.recv().unwrap()
+        self.channel
+            .send(msg)
+            .map_err(|e| Error::generic(&e.to_string()))?;
+        self.waker
+            .wake()
+            .map_err(|e| Error::generic(&e.to_string()))?;
+        rx.recv()
+            .unwrap()
+            .map_err(|e| Error::generic(&e.to_string()))
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -103,7 +103,7 @@ pub use event::{Event, EventKind};
 use std::convert::AsRef;
 use std::path::Path;
 
-#[cfg(target_os = "macos")]
+#[cfg(all(target_os = "macos", feature = "macos_fsevent"))]
 pub use crate::fsevent::FsEventWatcher;
 #[cfg(target_os = "linux")]
 pub use crate::inotify::INotifyWatcher;
@@ -118,7 +118,10 @@ pub use windows::ReadDirectoryChangesWatcher;
 pub mod fsevent;
 #[cfg(target_os = "linux")]
 pub mod inotify;
-#[cfg(target_os = "freebsd")]
+#[cfg(any(
+    target_os = "freebsd",
+    all(target_os = "macos", feature = "macos_kqueue")
+))]
 pub mod kqueue;
 #[cfg(target_os = "windows")]
 pub mod windows;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -107,6 +107,8 @@ use std::path::Path;
 pub use crate::fsevent::FsEventWatcher;
 #[cfg(target_os = "linux")]
 pub use crate::inotify::INotifyWatcher;
+#[cfg(target_os = "freebsd")]
+pub use crate::kqueue::KqueueWatcher;
 pub use null::NullWatcher;
 pub use poll::PollWatcher;
 #[cfg(target_os = "windows")]
@@ -116,6 +118,8 @@ pub use windows::ReadDirectoryChangesWatcher;
 pub mod fsevent;
 #[cfg(target_os = "linux")]
 pub mod inotify;
+#[cfg(target_os = "freebsd")]
+pub mod kqueue;
 #[cfg(target_os = "windows")]
 pub mod windows;
 
@@ -193,7 +197,15 @@ pub type RecommendedWatcher = FsEventWatcher;
 #[cfg(target_os = "windows")]
 pub type RecommendedWatcher = ReadDirectoryChangesWatcher;
 /// The recommended `Watcher` implementation for the current platform
-#[cfg(not(any(target_os = "linux", target_os = "macos", target_os = "windows")))]
+#[cfg(target_os = "freebsd")]
+pub type RecommendedWatcher = KqueueWatcher;
+/// The recommended `Watcher` implementation for the current platform
+#[cfg(not(any(
+    target_os = "linux",
+    target_os = "macos",
+    target_os = "windows",
+    target_os = "freebsd"
+)))]
 pub type RecommendedWatcher = PollWatcher;
 
 /// Convenience method for creating the `RecommendedWatcher` for the current platform in

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -120,6 +120,9 @@ pub mod fsevent;
 pub mod inotify;
 #[cfg(any(
     target_os = "freebsd",
+    target_os = "openbsd",
+    target_os = "dragonflybsd",
+    target_os = "netbsd",
     all(target_os = "macos", feature = "macos_kqueue")
 ))]
 pub mod kqueue;


### PR DESCRIPTION
Kqueue Backend for all the BSDs 🎉 

It's based on the kqueue crate and the in watcher implementation is based on the `INotifyWatcher`.

BSDs where this PR is check that it compiles: 

- [x] FreeBSD
- [ ] OpenBSD
- [ ] NetBSD
- [ ] DragonflyBSD

This relates to #327 and maybe #136 