### PR TITLE
Make `Watcher` object safe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 
 ## unreleased
 
+- CHANGE: Make `Watcher` object safe
 - CHANGE: Change EventFn to take FnMut [#333]
 
 [#333]: https://github.com/notify-rs/notify/pull/333

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,10 +19,11 @@
 
 ## unreleased
 
-- CHANGE: Make `Watcher` object safe
+- CHANGE: Make `Watcher` object safe [#336]
 - CHANGE: Change EventFn to take FnMut [#333]
 
 [#333]: https://github.com/notify-rs/notify/pull/333
+[#336]: https://github.com/notify-rs/notify/pull/336
 
 ## 5.0.0-pre.10 (2021-06-04)
 

--- a/examples/async_monitor.rs
+++ b/examples/async_monitor.rs
@@ -7,7 +7,7 @@ fn async_watcher() -> notify::Result<(RecommendedWatcher, Receiver<notify::Resul
 
     // Automatically select the best implementation for your platform.
     // You can also access each implementation directly e.g. INotifyWatcher.
-    let watcher = Watcher::new_immediate(move |res| {
+    let watcher = RecommendedWatcher::new(move |res| {
         futures::executor::block_on(async {
             tx.send(res).await.unwrap();
         })
@@ -21,7 +21,7 @@ async fn async_watch<P: AsRef<Path>>(path: P) -> notify::Result<()> {
 
     // Add a path to be watched. All files and directories at that path and
     // below will be monitored for changes.
-    watcher.watch(path, RecursiveMode::Recursive)?;
+    watcher.watch(path.as_ref(), RecursiveMode::Recursive)?;
 
     while let Some(res) = rx.next().await {
         match res {

--- a/examples/hot_reload_tide/src/main.rs
+++ b/examples/hot_reload_tide/src/main.rs
@@ -8,6 +8,7 @@ use notify::{
     event::ModifyKind,
     Error, Event, EventKind, RecommendedWatcher, RecursiveMode, Watcher,
 };
+use std::path::Path;
 use std::sync::{Arc, Mutex};
 use tide::{Body, Response};
 
@@ -43,7 +44,7 @@ async fn main() -> tide::Result<()> {
             }
         })?;
 
-    watcher.watch(CONFIG_PATH, RecursiveMode::Recursive)?;
+    watcher.watch(Path::new(CONFIG_PATH), RecursiveMode::Recursive)?;
 
     // We set up a web server using [Tide](https://github.com/http-rs/tide)
     let mut app = tide::with_state(config);

--- a/examples/hot_reload_tide/src/main.rs
+++ b/examples/hot_reload_tide/src/main.rs
@@ -28,11 +28,11 @@ async fn main() -> tide::Result<()> {
 
     // We listen to file changes by giving Notify
     // a function that will get called when events happen
-    let mut watcher: RecommendedWatcher =
+    let mut watcher =
         // To make sure that the config lives as long as the function
         // we need to move the ownership of the config inside the function
         // To learn more about move please read [Using move Closures with Threads](https://doc.rust-lang.org/book/ch16-01-threads.html?highlight=move#using-move-closures-with-threads)
-        Watcher::new_immediate(move |result: Result<Event, Error>| {
+        RecommendedWatcher::new(move |result: Result<Event, Error>| {
             let event = result.unwrap();
 
             if event.kind == EventKind::Modify(ModifyKind::Any) {

--- a/examples/monitor_raw.rs
+++ b/examples/monitor_raw.rs
@@ -6,11 +6,11 @@ fn watch<P: AsRef<Path>>(path: P) -> notify::Result<()> {
 
     // Automatically select the best implementation for your platform.
     // You can also access each implementation directly e.g. INotifyWatcher.
-    let mut watcher: RecommendedWatcher = Watcher::new_immediate(move |res| tx.send(res).unwrap())?;
+    let mut watcher = RecommendedWatcher::new(move |res| tx.send(res).unwrap())?;
 
     // Add a path to be watched. All files and directories at that path and
     // below will be monitored for changes.
-    watcher.watch(path, RecursiveMode::Recursive)?;
+    watcher.watch(path.as_ref(), RecursiveMode::Recursive)?;
 
     for res in rx {
         match res {

--- a/src/inotify.rs
+++ b/src/inotify.rs
@@ -554,6 +554,11 @@ fn filter_dir(e: walkdir::Result<walkdir::DirEntry>) -> Option<walkdir::DirEntry
 }
 
 impl INotifyWatcher {
+    /// Create a new watcher.
+    pub fn new<F: EventFn>(event_fn: F) -> Result<Self> {
+        Self::from_event_fn(Box::new(event_fn)))
+    }
+
     fn from_event_fn(event_fn: Box<dyn EventFn>) -> Result<Self> {
         let inotify = Inotify::init()?;
         let event_loop = EventLoop::new(inotify, event_fn)?;
@@ -597,16 +602,12 @@ impl INotifyWatcher {
 }
 
 impl Watcher for INotifyWatcher {
-    fn new_immediate<F: EventFn>(event_fn: F) -> Result<INotifyWatcher> {
-        INotifyWatcher::from_event_fn(Box::new(event_fn))
+    fn watch(&mut self, path: &Path, recursive_mode: RecursiveMode) -> Result<()> {
+        self.watch_inner(path, recursive_mode)
     }
 
-    fn watch<P: AsRef<Path>>(&mut self, path: P, recursive_mode: RecursiveMode) -> Result<()> {
-        self.watch_inner(path.as_ref(), recursive_mode)
-    }
-
-    fn unwatch<P: AsRef<Path>>(&mut self, path: P) -> Result<()> {
-        self.unwatch_inner(path.as_ref())
+    fn unwatch(&mut self, path: &Path) -> Result<()> {
+        self.unwatch_inner(path)
     }
 
     fn configure(&mut self, config: Config) -> Result<bool> {
@@ -623,4 +624,10 @@ impl Drop for INotifyWatcher {
         self.channel.send(EventLoopMsg::Shutdown).unwrap();
         self.waker.wake().unwrap();
     }
+}
+
+#[test]
+fn inotify_watcher_is_send_and_sync() {
+    fn check<T: Send + Sync>() {}
+    check::<INotifyWatcher>();
 }

--- a/src/inotify.rs
+++ b/src/inotify.rs
@@ -556,7 +556,7 @@ fn filter_dir(e: walkdir::Result<walkdir::DirEntry>) -> Option<walkdir::DirEntry
 impl INotifyWatcher {
     /// Create a new watcher.
     pub fn new<F: EventFn>(event_fn: F) -> Result<Self> {
-        Self::from_event_fn(Box::new(event_fn)))
+        Self::from_event_fn(Box::new(event_fn))
     }
 
     fn from_event_fn(event_fn: Box<dyn EventFn>) -> Result<Self> {

--- a/src/null.rs
+++ b/src/null.rs
@@ -2,7 +2,7 @@
 
 #![allow(unused_variables)]
 
-use super::{EventFn, RecursiveMode, Result, Watcher};
+use super::{RecursiveMode, Result, Watcher};
 use std::path::Path;
 
 /// Stub `Watcher` implementation
@@ -11,15 +11,11 @@ use std::path::Path;
 pub struct NullWatcher;
 
 impl Watcher for NullWatcher {
-    fn new_immediate<F: EventFn>(_event_fn: F) -> Result<NullWatcher> {
-        Ok(NullWatcher)
-    }
-
-    fn watch<P: AsRef<Path>>(&mut self, path: P, recursive_mode: RecursiveMode) -> Result<()> {
+    fn watch(&mut self, path: &Path, recursive_mode: RecursiveMode) -> Result<()> {
         Ok(())
     }
 
-    fn unwatch<P: AsRef<Path>>(&mut self, path: P) -> Result<()> {
+    fn unwatch(&mut self, path: &Path) -> Result<()> {
         Ok(())
     }
 }

--- a/src/poll.rs
+++ b/src/poll.rs
@@ -43,7 +43,14 @@ fn emit_event(event_fn: &Mutex<dyn EventFn>, res: Result<Event>) {
 }
 
 impl PollWatcher {
-    /// Create a PollWatcher which polls every `delay` milliseconds
+    /// Create a new [PollWatcher].
+    pub fn new<F: EventFn>(event_fn: F) -> Result<Self> {
+        let event_fn = Arc::new(Mutex::new(event_fn));
+        let delay = Duration::from_secs(30);
+        Self::with_delay(event_fn, delay)
+    }
+
+    /// Create a [PollWatcher] which polls every `delay` milliseconds
     pub fn with_delay(event_fn: Arc<Mutex<dyn EventFn>>, delay: Duration) -> Result<PollWatcher> {
         let mut p = PollWatcher {
             event_fn,
@@ -272,18 +279,12 @@ impl PollWatcher {
 }
 
 impl Watcher for PollWatcher {
-    fn new_immediate<F: EventFn>(event_fn: F) -> Result<PollWatcher> {
-        let event_fn = Arc::new(Mutex::new(event_fn));
-        let delay = Duration::from_secs(30);
-        PollWatcher::with_delay(event_fn, delay)
+    fn watch(&mut self, path: &Path, recursive_mode: RecursiveMode) -> Result<()> {
+        self.watch_inner(path, recursive_mode)
     }
 
-    fn watch<P: AsRef<Path>>(&mut self, path: P, recursive_mode: RecursiveMode) -> Result<()> {
-        self.watch_inner(path.as_ref(), recursive_mode)
-    }
-
-    fn unwatch<P: AsRef<Path>>(&mut self, path: P) -> Result<()> {
-        self.unwatch_inner(path.as_ref())
+    fn unwatch(&mut self, path: &Path) -> Result<()> {
+        self.unwatch_inner(path)
     }
 }
 
@@ -293,5 +294,8 @@ impl Drop for PollWatcher {
     }
 }
 
-// Because all public methods are `&mut self` it's also perfectly safe to share references.
-unsafe impl Sync for PollWatcher {}
+#[test]
+fn poll_watcher_is_send_and_sync() {
+    fn check<T: Send + Sync>() {}
+    check::<PollWatcher>();
+}

--- a/src/windows.rs
+++ b/src/windows.rs
@@ -499,12 +499,12 @@ impl ReadDirectoryChangesWatcher {
 }
 
 impl Watcher for ReadDirectoryChangesWatcher {
-    fn watch<P: AsRef<Path>>(&mut self, path: P, recursive_mode: RecursiveMode) -> Result<()> {
-        self.watch_inner(path.as_ref(), recursive_mode)
+    fn watch(&mut self, path: &Path, recursive_mode: RecursiveMode) -> Result<()> {
+        self.watch_inner(path, recursive_mode)
     }
 
-    fn unwatch<P: AsRef<Path>>(&mut self, path: P) -> Result<()> {
-        self.unwatch_inner(path.as_ref())
+    fn unwatch(&mut self, path: &Path) -> Result<()> {
+        self.unwatch_inner(path)
     }
 
     fn configure(&mut self, config: Config) -> Result<bool> {

--- a/src/windows.rs
+++ b/src/windows.rs
@@ -403,6 +403,14 @@ pub struct ReadDirectoryChangesWatcher {
 }
 
 impl ReadDirectoryChangesWatcher {
+    pub fn new<F: EventFn>(event_fn: F) -> Result<Self> {
+        // create dummy channel for meta event
+        // TODO: determine the original purpose of this - can we remove it?
+        let (meta_tx, _) = unbounded();
+        let event_fn = Arc::new(Mutex::new(event_fn));
+        Self::create(event_fn, meta_tx)
+    }
+
     pub fn create(
         event_fn: Arc<Mutex<dyn EventFn>>,
         meta_tx: Sender<MetaEvent>,
@@ -491,14 +499,6 @@ impl ReadDirectoryChangesWatcher {
 }
 
 impl Watcher for ReadDirectoryChangesWatcher {
-    fn new_immediate<F: EventFn>(event_fn: F) -> Result<ReadDirectoryChangesWatcher> {
-        // create dummy channel for meta event
-        // TODO: determine the original purpose of this - can we remove it?
-        let (meta_tx, _) = unbounded();
-        let event_fn = Arc::new(Mutex::new(event_fn));
-        ReadDirectoryChangesWatcher::create(event_fn, meta_tx)
-    }
-
     fn watch<P: AsRef<Path>>(&mut self, path: P, recursive_mode: RecursiveMode) -> Result<()> {
         self.watch_inner(path.as_ref(), recursive_mode)
     }

--- a/tests/race-with-remove-dir.rs
+++ b/tests/race-with-remove-dir.rs
@@ -1,6 +1,6 @@
 use std::{fs, thread, time::Duration};
 
-use notify::{immediate_watcher, RecursiveMode, Watcher};
+use notify::{RecursiveMode, Watcher};
 
 /// Test for <https://github.com/notify-rs/notify/issues/301>.
 /// Note: This test will fail if your temp directory is not writable.
@@ -11,12 +11,12 @@ fn test_race_with_remove_dir() {
     {
         let tmpdir = tmpdir.path().to_path_buf();
         thread::spawn(move || {
-            let mut watcher = immediate_watcher(move |result| {
+            let mut watcher = notify::recommended_watcher(move |result| {
                 eprintln!("received event: {:?}", result);
             })
             .unwrap();
 
-            watcher.watch(tmpdir, RecursiveMode::NonRecursive).unwrap();
+            watcher.watch(&tmpdir, RecursiveMode::NonRecursive).unwrap();
         });
     }
 


### PR DESCRIPTION
This changes the `Watcher` trait to be object safe, which allows users to
dynamically select which backend to use. This can be helpful on systems that
support multiple file watching systems that have different tradeoffs. For
example, Chromium's file watcher on OS X will use an fsevent backend
when watching recursive directories, and a kqueues backend when not.

In order to implement this, this makes a few changes to Watcher:

* removes `new_immediate` constructor.
* removes the `<P: AsRef<Path>>` from the `watch` and `unwatch`.

This then replaces (and renames) calls with `notify::recommended_watcher()`
to get similar behavior as the old constructor.