### PR TITLE
Move creation of watcher into trait

### DIFF
--- a/src/fsevent.rs
+++ b/src/fsevent.rs
@@ -249,11 +249,6 @@ extern "C" {
 }
 
 impl FsEventWatcher {
-    /// Create a new watcher.
-    pub fn new<F: EventFn>(event_fn: F) -> Result<Self> {
-        Self::from_event_fn(Arc::new(Mutex::new(event_fn)))
-    }
-
     fn from_event_fn(event_fn: Arc<Mutex<dyn EventFn>>) -> Result<Self> {
         Ok(FsEventWatcher {
             paths: unsafe {
@@ -533,6 +528,11 @@ unsafe fn callback_impl(
 }
 
 impl Watcher for FsEventWatcher {
+    /// Create a new watcher.
+    fn new<F: EventFn>(event_fn: F) -> Result<Self> {
+        Self::from_event_fn(Arc::new(Mutex::new(event_fn)))
+    }
+
     fn watch(&mut self, path: &Path, recursive_mode: RecursiveMode) -> Result<()> {
         self.watch_inner(path, recursive_mode)
     }

--- a/src/inotify.rs
+++ b/src/inotify.rs
@@ -554,11 +554,6 @@ fn filter_dir(e: walkdir::Result<walkdir::DirEntry>) -> Option<walkdir::DirEntry
 }
 
 impl INotifyWatcher {
-    /// Create a new watcher.
-    pub fn new<F: EventFn>(event_fn: F) -> Result<Self> {
-        Self::from_event_fn(Box::new(event_fn))
-    }
-
     fn from_event_fn(event_fn: Box<dyn EventFn>) -> Result<Self> {
         let inotify = Inotify::init()?;
         let event_loop = EventLoop::new(inotify, event_fn)?;
@@ -602,6 +597,11 @@ impl INotifyWatcher {
 }
 
 impl Watcher for INotifyWatcher {
+    /// Create a new watcher.
+    fn new<F: EventFn>(event_fn: F) -> Result<Self> {
+        Self::from_event_fn(Box::new(event_fn))
+    }
+
     fn watch(&mut self, path: &Path, recursive_mode: RecursiveMode) -> Result<()> {
         self.watch_inner(path, recursive_mode)
     }

--- a/src/kqueue.rs
+++ b/src/kqueue.rs
@@ -320,11 +320,6 @@ fn filter_dir(e: walkdir::Result<walkdir::DirEntry>) -> Option<walkdir::DirEntry
 }
 
 impl KqueueWatcher {
-    /// Create a new watcher.
-    pub fn new<F: EventFn>(event_fn: F) -> Result<Self> {
-        Self::from_event_fn(Box::new(event_fn))
-    }
-
     fn from_event_fn(event_fn: Box<dyn EventFn>) -> Result<Self> {
         let kqueue = kqueue::Watcher::new()?;
         let event_loop = EventLoop::new(kqueue, event_fn)?;
@@ -378,6 +373,11 @@ impl KqueueWatcher {
 }
 
 impl Watcher for KqueueWatcher {
+    /// Create a new watcher.
+    fn new<F: EventFn>(event_fn: F) -> Result<Self> {
+        Self::from_event_fn(Box::new(event_fn))
+    }
+
     fn watch(&mut self, path: &Path, recursive_mode: RecursiveMode) -> Result<()> {
         self.watch_inner(path, recursive_mode)
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -149,6 +149,8 @@ impl<F> EventFn for F where F: 'static + FnMut(Result<Event>) + Send {}
 /// In addition to such event driven implementations, a polling implementation is also provided
 /// that should work on any platform.
 pub trait Watcher {
+    /// Create a new watcher.
+    fn new<F: EventFn>(event_fn: F) -> Result<Self> where Self: Sized;
     /// Begin watching a new path.
     ///
     /// If the `path` is a directory, `recursive_mode` will be evaluated. If `recursive_mode` is

--- a/src/null.rs
+++ b/src/null.rs
@@ -18,4 +18,8 @@ impl Watcher for NullWatcher {
     fn unwatch(&mut self, path: &Path) -> Result<()> {
         Ok(())
     }
+
+    fn new<F: crate::EventFn>(event_fn: F) -> Result<Self> where Self: Sized {
+        Ok(NullWatcher)
+    }
 }

--- a/src/poll.rs
+++ b/src/poll.rs
@@ -43,13 +43,6 @@ fn emit_event(event_fn: &Mutex<dyn EventFn>, res: Result<Event>) {
 }
 
 impl PollWatcher {
-    /// Create a new [PollWatcher].
-    pub fn new<F: EventFn>(event_fn: F) -> Result<Self> {
-        let event_fn = Arc::new(Mutex::new(event_fn));
-        let delay = Duration::from_secs(30);
-        Self::with_delay(event_fn, delay)
-    }
-
     /// Create a [PollWatcher] which polls every `delay` milliseconds
     pub fn with_delay(event_fn: Arc<Mutex<dyn EventFn>>, delay: Duration) -> Result<PollWatcher> {
         let mut p = PollWatcher {
@@ -279,6 +272,13 @@ impl PollWatcher {
 }
 
 impl Watcher for PollWatcher {
+    /// Create a new [PollWatcher].
+    fn new<F: EventFn>(event_fn: F) -> Result<Self> {
+        let event_fn = Arc::new(Mutex::new(event_fn));
+        let delay = Duration::from_secs(30);
+        Self::with_delay(event_fn, delay)
+    }
+
     fn watch(&mut self, path: &Path, recursive_mode: RecursiveMode) -> Result<()> {
         self.watch_inner(path, recursive_mode)
     }

--- a/src/windows.rs
+++ b/src/windows.rs
@@ -403,13 +403,6 @@ pub struct ReadDirectoryChangesWatcher {
 }
 
 impl ReadDirectoryChangesWatcher {
-    pub fn new<F: EventFn>(event_fn: F) -> Result<Self> {
-        // create dummy channel for meta event
-        // TODO: determine the original purpose of this - can we remove it?
-        let (meta_tx, _) = unbounded();
-        let event_fn = Arc::new(Mutex::new(event_fn));
-        Self::create(event_fn, meta_tx)
-    }
 
     pub fn create(
         event_fn: Arc<Mutex<dyn EventFn>>,
@@ -499,6 +492,14 @@ impl ReadDirectoryChangesWatcher {
 }
 
 impl Watcher for ReadDirectoryChangesWatcher {
+    fn new<F: EventFn>(event_fn: F) -> Result<Self> {
+        // create dummy channel for meta event
+        // TODO: determine the original purpose of this - can we remove it?
+        let (meta_tx, _) = unbounded();
+        let event_fn = Arc::new(Mutex::new(event_fn));
+        Self::create(event_fn, meta_tx)
+    }
+
     fn watch(&mut self, path: &Path, recursive_mode: RecursiveMode) -> Result<()> {
         self.watch_inner(path, recursive_mode)
     }


### PR DESCRIPTION
I don't know why we haven't done this earlier, but I think unifying the creation of the watcher by moving it into the trait shouldn't be a problem, if I'm not missing some lifetime problem.