### PR TITLE
Add `EventHandler` trait to replace `EventFn`

### DIFF
--- a/examples/async_monitor.rs
+++ b/examples/async_monitor.rs
@@ -1,6 +1,9 @@
-use notify::{RecommendedWatcher, RecursiveMode, Event, Watcher};
+use futures::{
+    channel::mpsc::{channel, Receiver},
+    SinkExt, StreamExt,
+};
+use notify::{Event, RecommendedWatcher, RecursiveMode, Watcher};
 use std::path::Path;
-use futures::{SinkExt, StreamExt, channel::mpsc::{channel, Receiver}};
 
 fn async_watcher() -> notify::Result<(RecommendedWatcher, Receiver<notify::Result<Event>>)> {
     let (mut tx, rx) = channel(1);

--- a/examples/hot_reload_tide/src/main.rs
+++ b/examples/hot_reload_tide/src/main.rs
@@ -1,12 +1,10 @@
-
 // Imagine this is a web app that remembers information about audio messages.
 // It has a config.json file that acts as a database,
 // you can edit the configuration and the app will pick up changes without the need to restart it.
 // This concept is known as hot-reloading.
 use hot_reload_tide::messages::{load_config, Config};
 use notify::{
-    event::ModifyKind,
-    Error, Event, EventKind, RecommendedWatcher, RecursiveMode, Watcher,
+    event::ModifyKind, Error, Event, EventKind, RecommendedWatcher, RecursiveMode, Watcher,
 };
 use std::path::Path;
 use std::sync::{Arc, Mutex};

--- a/examples/monitor_raw.rs
+++ b/examples/monitor_raw.rs
@@ -6,7 +6,7 @@ fn watch<P: AsRef<Path>>(path: P) -> notify::Result<()> {
 
     // Automatically select the best implementation for your platform.
     // You can also access each implementation directly e.g. INotifyWatcher.
-    let mut watcher = RecommendedWatcher::new(move |res| tx.send(res).unwrap())?;
+    let mut watcher = RecommendedWatcher::new(tx)?;
 
     // Add a path to be watched. All files and directories at that path and
     // below will be monitored for changes.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -139,6 +139,23 @@ mod config;
 mod error;
 
 /// The set of requirements for watcher event handling functions.
+///
+/// # Example implementation
+///
+/// ```no_run
+/// use notify::{Event, Result, EventHandler};
+///
+/// /// Prints received events
+/// struct EventPrinter;
+///
+/// impl EventHandler for EventPrinter {
+///     fn handle_event(&mut self, event: Result<Event>) {
+///         if let Ok(event) = event {
+///             println!("Event: {:?}", event);
+///         }
+///     }
+/// }
+/// ```
 pub trait EventHandler: Send + 'static {
     /// Handles an event.
     fn handle_event(&mut self, event: Result<Event>);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -139,9 +139,31 @@ mod config;
 mod error;
 
 /// The set of requirements for watcher event handling functions.
-pub trait EventFn: 'static + FnMut(Result<Event>) + Send {}
+pub trait EventHandler: Send + 'static {
+    /// Handles an event.
+    fn handle_event(&mut self, event: Result<Event>);
+}
 
-impl<F> EventFn for F where F: 'static + FnMut(Result<Event>) + Send {}
+impl<F> EventHandler for F
+where
+    F: FnMut(Result<Event>) + Send + 'static,
+{
+    fn handle_event(&mut self, event: Result<Event>) {
+        (self)(event);
+    }
+}
+
+impl EventHandler for crossbeam_channel::Sender<Result<Event>> {
+    fn handle_event(&mut self, event: Result<Event>) {
+        let _ = self.send(event);
+    }
+}
+
+impl EventHandler for std::sync::mpsc::Sender<Result<Event>> {
+    fn handle_event(&mut self, event: Result<Event>) {
+        let _ = self.send(event);
+    }
+}
 
 /// Type that can deliver file activity notifications
 ///
@@ -150,7 +172,7 @@ impl<F> EventFn for F where F: 'static + FnMut(Result<Event>) + Send {}
 /// that should work on any platform.
 pub trait Watcher {
     /// Create a new watcher.
-    fn new<F: EventFn>(event_fn: F) -> Result<Self> where Self: Sized;
+    fn new<F: EventHandler>(event_handler: F) -> Result<Self> where Self: Sized;
     /// Begin watching a new path.
     ///
     /// If the `path` is a directory, `recursive_mode` will be evaluated. If `recursive_mode` is
@@ -215,12 +237,12 @@ pub type RecommendedWatcher = PollWatcher;
 /// _immediate_ mode.
 ///
 /// See [`Watcher::new_immediate`](trait.Watcher.html#tymethod.new_immediate).
-pub fn recommended_watcher<F>(event_fn: F) -> Result<RecommendedWatcher>
+pub fn recommended_watcher<F>(event_handler: F) -> Result<RecommendedWatcher>
 where
-    F: EventFn,
+    F: EventHandler,
 {
     // All recommended watchers currently implement `new`, so just call that.
-    RecommendedWatcher::new(event_fn)
+    RecommendedWatcher::new(event_handler)
 }
 
 #[cfg(test)]

--- a/src/null.rs
+++ b/src/null.rs
@@ -19,7 +19,7 @@ impl Watcher for NullWatcher {
         Ok(())
     }
 
-    fn new<F: crate::EventFn>(event_fn: F) -> Result<Self> where Self: Sized {
+    fn new<F: crate::EventHandler>(event_handler: F) -> Result<Self> where Self: Sized {
         Ok(NullWatcher)
     }
 }


### PR DESCRIPTION
Replace `EventFn`trait with `EventHandler`.

The new trait has new capabilities but can be implemented for more types, such as channel receivers which are very commonly used.