### PR TITLE
fsevent: return error on canonicalize failure

### DIFF
--- a/src/fsevent.rs
+++ b/src/fsevent.rs
@@ -347,6 +347,7 @@ impl FsEventWatcher {
         if !path.exists() {
             return Err(Error::path_not_found().add_path(path.into()));
         }
+        let canonical_path = path.to_path_buf().canonicalize()?;
         let str_path = path.to_str().unwrap();
         unsafe {
             let mut err: cf::CFErrorRef = ptr::null_mut();
@@ -361,7 +362,7 @@ impl FsEventWatcher {
             cf::CFRelease(cf_path);
         }
         self.recursive_info.insert(
-            path.to_path_buf().canonicalize().unwrap(),
+            canonical_path,
             recursive_mode.is_recursive(),
         );
         Ok(())


### PR DESCRIPTION
Removes a panic that can occur in `append_path` when a file is removed
after passing the `exists` check, but before canonicalization. This
change moves `canonicalize` before appending the path, so that it can
safely bail on error without leaking state.

Fixes #368.