### PR TITLE
kqueue: emit EventKind::Modify on kqueue write event

### DIFF
--- a/src/kqueue.rs
+++ b/src/kqueue.rs
@@ -161,7 +161,7 @@ impl EventLoop {
 
                         //data was written to this file
                         kqueue::Vnode::Write => {
-                            Event::new(EventKind::Access(AccessKind::Close(AccessMode::Write)))
+                            Event::new(EventKind::Modify(ModifyKind::Data(DataChange::Any)))
                         }
 
                         /*


### PR DESCRIPTION
This should make the event emitted by the kqueue backend to be more in
line with the inotify backend and the documentation on `EventKind`.

<!-- By contributing, you agree to the terms of the license, available in the LICENSE.ARTISTIC file, and of the code of conduct, available in the CODE_OF_CONDUCT.md file. Furthermore, you agree to release under CC0, also available in the LICENSE file, until Notify has fully transitioned to Artistic 2.0. -->

<!-- After creating this pull request, the test suite will run.

It is expected that if any failures occur in the builds, you either:

- fix the errors,
- ask for help, or
- note that the failures are expected with a detailed explanation.

If you do not, a maintainer may prompt you and/or do it themselves, but do note that it will take longer for your contribution to be reviewed if the build does not pass.

Running `cargo fmt` and/or `cargo clippy` is NOT required but appreciated!

You can remove this text. -->
