### PR TITLE
fsevent: use `RenameMode::Any` for renaming events

### DIFF
--- a/src/fsevent.rs
+++ b/src/fsevent.rs
@@ -172,9 +172,11 @@ fn translate_flags(flags: StreamFlags, precise: bool) -> Vec<Event> {
         });
     }
 
+    // FSEvents provides no mechanism to associate the old and new sides of a
+    // rename event.
     if flags.contains(StreamFlags::ITEM_RENAMED) {
         evs.push(Event::new(EventKind::Modify(ModifyKind::Name(
-            RenameMode::From,
+            RenameMode::Any,
         ))));
     }
 


### PR DESCRIPTION
> FSEvents provides no mechanism to associate the old and new sides of a rename event. It only produces an event at the old and new paths with `kFSEventStreamEventFlagItemRenamed` bit set.

Ref: https://github.com/atom/watcher/blob/master/docs/macos.md