### PR TITLE
inotify: Ignore any error sending the `RenameTimeout` event.

### DIFF
--- a/src/inotify.rs
+++ b/src/inotify.rs
@@ -416,9 +416,11 @@ impl EventLoop {
                             let cookie = rename_event.tracker().unwrap(); // unwrap is safe because rename_event is always set with some cookie
                             thread::spawn(move || {
                                 thread::sleep(Duration::from_millis(10)); // wait up to 10 ms for a subsequent event
-                                event_loop_tx
-                                    .send(EventLoopMsg::RenameTimeout(cookie))
-                                    .unwrap();
+
+                                // An error here means the other end of the channel was closed, a thing that can
+                                // happen normally.
+                                let _ = event_loop_tx
+                                    .send(EventLoopMsg::RenameTimeout(cookie));
                                 waker.wake().unwrap();
                             });
                         }

--- a/src/inotify.rs
+++ b/src/inotify.rs
@@ -419,9 +419,8 @@ impl EventLoop {
 
                                 // An error here means the other end of the channel was closed, a thing that can
                                 // happen normally.
-                                let _ = event_loop_tx
-                                    .send(EventLoopMsg::RenameTimeout(cookie));
-                                waker.wake().unwrap();
+                                let _ = event_loop_tx.send(EventLoopMsg::RenameTimeout(cookie));
+                                let _ = waker.wake();
                             });
                         }
                     }


### PR DESCRIPTION
The `unwrap()` call here causes thread panics in our application. We notice them because we use `set_panic_hook`. I think ordinarily a panic here would be printed to stderr and otherwise ignored.

For us, I think the usual pattern is that several files are renamed at once, and as soon as we notice the first rename, we drop the watcher. Therefore, when this thread wakes up, it's trying to send an event to a queue that has been closed.