### PR TITLE
Add Debug impl to fs/windows watchers

### DIFF
--- a/src/event.rs
+++ b/src/event.rs
@@ -346,14 +346,14 @@ pub struct Event {
 }
 
 /// Additional attributes of the event.
-#[derive(Clone, Default)]
+#[derive(Clone, Default, Debug)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct EventAttributes {
     #[cfg_attr(feature = "serde", serde(flatten))]
     inner: Option<Box<EventAttributesInner>>,
 }
 
-#[derive(Clone, Default)]
+#[derive(Clone, Default, Debug)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 struct EventAttributesInner {
     /// Tracking ID for events that are related.

--- a/src/fsevent.rs
+++ b/src/fsevent.rs
@@ -21,6 +21,7 @@ use fsevent_sys as fs;
 use fsevent_sys::core_foundation as cf;
 use std::collections::HashMap;
 use std::ffi::CStr;
+use std::fmt;
 use std::os::raw;
 use std::path::{Path, PathBuf};
 use std::ptr;
@@ -66,6 +67,20 @@ pub struct FsEventWatcher {
     event_handler: Arc<Mutex<dyn EventHandler>>,
     runloop: Option<(cf::CFRunLoopRef, thread::JoinHandle<()>)>,
     recursive_info: HashMap<PathBuf, bool>,
+}
+
+impl fmt::Debug for FsEventWatcher {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        f.debug_struct("FsEventWatcher")
+            .field("paths", &self.paths)
+            .field("since_when", &self.since_when)
+            .field("latency", &self.latency)
+            .field("flags", &self.flags)
+            .field("event_handler", &Arc::as_ptr(&self.event_handler))
+            .field("runloop", &self.runloop)
+            .field("recursive_info", &self.recursive_info)
+            .finish()
+    }
 }
 
 // CFMutableArrayRef is a type alias to *mut libc::c_void, so FsEventWatcher is not Send/Sync

--- a/src/poll.rs
+++ b/src/poll.rs
@@ -41,6 +41,7 @@ pub struct PollWatcher {
 impl Debug for PollWatcher {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("PollWatcher")
+            .field("event_handler", &Arc::as_ptr(&self.watches))
             .field("watches", &self.watches)
             .field("open", &self.open)
             .field("delay", &self.delay)

--- a/src/windows.rs
+++ b/src/windows.rs
@@ -397,6 +397,7 @@ unsafe extern "system" fn handle_event(
 }
 
 /// Watcher implementation based on ReadDirectoryChanges
+#[derive(Debug)]
 pub struct ReadDirectoryChangesWatcher {
     tx: Sender<Action>,
     cmd_rx: Receiver<Result<PathBuf>>,


### PR DESCRIPTION
Additional Debug derives are required in order to implement Debug for
`FsEventWatcher` and `ReadDirectoryChangesWatcher`.

Also, print `PollWatcher` `.event_handler` field as a pointer.
