### PR TITLE
Name all threads

### DIFF
--- a/src/fsevent.rs
+++ b/src/fsevent.rs
@@ -457,7 +457,7 @@ impl FsEventWatcher {
                     fs::FSEventStreamInvalidate(stream);
                     fs::FSEventStreamRelease(stream);
                 }
-            });
+            })?;
         // block until runloop has been sent
         self.runloop = Some((rl_rx.recv().unwrap().0, thread_handle));
 

--- a/src/fsevent.rs
+++ b/src/fsevent.rs
@@ -432,7 +432,7 @@ impl FsEventWatcher {
         // channel to pass runloop around
         let (rl_tx, rl_rx) = unbounded();
 
-        let thread_handle = thread::spawn(move || {
+        let thread_handle = thread::Builder::new().name("notify-rs fsevents".to_string()).spawn(move || {
             let stream = stream.0;
 
             unsafe {

--- a/src/fsevent.rs
+++ b/src/fsevent.rs
@@ -433,7 +433,7 @@ impl FsEventWatcher {
         let (rl_tx, rl_rx) = unbounded();
 
         let thread_handle = thread::Builder::new()
-            .name("notify-rs fsevents".to_string())
+            .name("notify-rs fsevents loop".to_string())
             .spawn(move || {
                 let stream = stream.0;
 

--- a/src/inotify.rs
+++ b/src/inotify.rs
@@ -128,7 +128,9 @@ impl EventLoop {
 
     // Run the event loop.
     pub fn run(self) {
-        thread::Builder::new().name("notify-rs inotify".to_string()).spawn(|| self.event_loop_thread());
+        thread::Builder::new()
+            .name("notify-rs inotify".to_string())
+            .spawn(|| self.event_loop_thread());
     }
 
     fn event_loop_thread(mut self) {
@@ -418,14 +420,16 @@ impl EventLoop {
                             let event_loop_tx = self.event_loop_tx.clone();
                             let waker = self.event_loop_waker.clone();
                             let cookie = rename_event.tracker().unwrap(); // unwrap is safe because rename_event is always set with some cookie
-                            thread::Builder::new().name("notify-rs inotify rename".to_string()).spawn(move || {
-                                thread::sleep(Duration::from_millis(10)); // wait up to 10 ms for a subsequent event
+                            thread::Builder::new()
+                                .name("notify-rs inotify rename".to_string())
+                                .spawn(move || {
+                                    thread::sleep(Duration::from_millis(10)); // wait up to 10 ms for a subsequent event
 
-                                // An error here means the other end of the channel was closed, a thing that can
-                                // happen normally.
-                                let _ = event_loop_tx.send(EventLoopMsg::RenameTimeout(cookie));
-                                let _ = waker.wake();
-                            });
+                                    // An error here means the other end of the channel was closed, a thing that can
+                                    // happen normally.
+                                    let _ = event_loop_tx.send(EventLoopMsg::RenameTimeout(cookie));
+                                    let _ = waker.wake();
+                                });
                         }
                     }
                     Err(e) => {

--- a/src/inotify.rs
+++ b/src/inotify.rs
@@ -129,7 +129,7 @@ impl EventLoop {
     // Run the event loop.
     pub fn run(self) {
         let _ = thread::Builder::new()
-            .name("notify-rs inotify".to_string())
+            .name("notify-rs inotify loop".to_string())
             .spawn(|| self.event_loop_thread());
     }
 

--- a/src/inotify.rs
+++ b/src/inotify.rs
@@ -128,7 +128,7 @@ impl EventLoop {
 
     // Run the event loop.
     pub fn run(self) {
-        thread::spawn(|| self.event_loop_thread());
+        thread::Builder::new().name("notify-rs inotify".to_string()).spawn(|| self.event_loop_thread());
     }
 
     fn event_loop_thread(mut self) {
@@ -418,7 +418,7 @@ impl EventLoop {
                             let event_loop_tx = self.event_loop_tx.clone();
                             let waker = self.event_loop_waker.clone();
                             let cookie = rename_event.tracker().unwrap(); // unwrap is safe because rename_event is always set with some cookie
-                            thread::spawn(move || {
+                            thread::Builder::new().name("notify-rs inotify rename".to_string()).spawn(move || {
                                 thread::sleep(Duration::from_millis(10)); // wait up to 10 ms for a subsequent event
 
                                 // An error here means the other end of the channel was closed, a thing that can

--- a/src/inotify.rs
+++ b/src/inotify.rs
@@ -128,7 +128,7 @@ impl EventLoop {
 
     // Run the event loop.
     pub fn run(self) {
-        thread::Builder::new()
+        let _ = thread::Builder::new()
             .name("notify-rs inotify".to_string())
             .spawn(|| self.event_loop_thread());
     }
@@ -420,7 +420,7 @@ impl EventLoop {
                             let event_loop_tx = self.event_loop_tx.clone();
                             let waker = self.event_loop_waker.clone();
                             let cookie = rename_event.tracker().unwrap(); // unwrap is safe because rename_event is always set with some cookie
-                            thread::Builder::new()
+                            let _ = thread::Builder::new()
                                 .name("notify-rs inotify rename".to_string())
                                 .spawn(move || {
                                     thread::sleep(Duration::from_millis(10)); // wait up to 10 ms for a subsequent event

--- a/src/kqueue.rs
+++ b/src/kqueue.rs
@@ -76,7 +76,7 @@ impl EventLoop {
 
     // Run the event loop.
     pub fn run(self) {
-        thread::Builder::new()
+        let _ = thread::Builder::new()
             .name("notify-rs kqueue".to_string())
             .spawn(|| self.event_loop_thread());
     }

--- a/src/kqueue.rs
+++ b/src/kqueue.rs
@@ -76,7 +76,7 @@ impl EventLoop {
 
     // Run the event loop.
     pub fn run(self) {
-        thread::spawn(|| self.event_loop_thread());
+        thread::Builder::new().name("notify-rs kqueue".to_string()).spawn(|| self.event_loop_thread());
     }
 
     fn event_loop_thread(mut self) {

--- a/src/kqueue.rs
+++ b/src/kqueue.rs
@@ -77,7 +77,7 @@ impl EventLoop {
     // Run the event loop.
     pub fn run(self) {
         let _ = thread::Builder::new()
-            .name("notify-rs kqueue".to_string())
+            .name("notify-rs kqueue loop".to_string())
             .spawn(|| self.event_loop_thread());
     }
 

--- a/src/kqueue.rs
+++ b/src/kqueue.rs
@@ -76,7 +76,9 @@ impl EventLoop {
 
     // Run the event loop.
     pub fn run(self) {
-        thread::Builder::new().name("notify-rs kqueue".to_string()).spawn(|| self.event_loop_thread());
+        thread::Builder::new()
+            .name("notify-rs kqueue".to_string())
+            .spawn(|| self.event_loop_thread());
     }
 
     fn event_loop_thread(mut self) {

--- a/src/poll.rs
+++ b/src/poll.rs
@@ -76,7 +76,7 @@ impl PollWatcher {
         let event_handler = self.event_handler.clone();
         let event_handler = move |res| emit_event(&event_handler, res);
 
-        thread::spawn(move || {
+        thread::Builder::new().name("notify-rs poll".to_string()).spawn(move || {
             // In order of priority:
             // TODO: handle metadata events
             // TODO: handle renames

--- a/src/poll.rs
+++ b/src/poll.rs
@@ -76,7 +76,7 @@ impl PollWatcher {
         let event_handler = self.event_handler.clone();
         let event_handler = move |res| emit_event(&event_handler, res);
 
-        thread::Builder::new()
+        let _ = thread::Builder::new()
             .name("notify-rs poll".to_string())
             .spawn(move || {
                 // In order of priority:

--- a/src/poll.rs
+++ b/src/poll.rs
@@ -77,7 +77,7 @@ impl PollWatcher {
         let event_handler = move |res| emit_event(&event_handler, res);
 
         let _ = thread::Builder::new()
-            .name("notify-rs poll".to_string())
+            .name("notify-rs poll loop".to_string())
             .spawn(move || {
                 // In order of priority:
                 // TODO: handle metadata events

--- a/src/windows.rs
+++ b/src/windows.rs
@@ -85,7 +85,7 @@ impl ReadDirectoryChangesServer {
         // it is, in fact, ok to send the semaphore across threads
         let sem_temp = wakeup_sem as u64;
         let _ = thread::Builder::new()
-            .name("notify-rs windows".to_string())
+            .name("notify-rs windows loop".to_string())
             .spawn(move || {
                 let wakeup_sem = sem_temp as HANDLE;
                 let server = ReadDirectoryChangesServer {

--- a/src/windows.rs
+++ b/src/windows.rs
@@ -84,7 +84,7 @@ impl ReadDirectoryChangesServer {
         let (action_tx, action_rx) = unbounded();
         // it is, in fact, ok to send the semaphore across threads
         let sem_temp = wakeup_sem as u64;
-        thread::spawn(move || {
+        thread::Builder::new().name("notify-rs windows".to_string()).spawn(move || {
             let wakeup_sem = sem_temp as HANDLE;
             let server = ReadDirectoryChangesServer {
                 rx: action_rx,

--- a/src/windows.rs
+++ b/src/windows.rs
@@ -84,18 +84,20 @@ impl ReadDirectoryChangesServer {
         let (action_tx, action_rx) = unbounded();
         // it is, in fact, ok to send the semaphore across threads
         let sem_temp = wakeup_sem as u64;
-        thread::Builder::new().name("notify-rs windows".to_string()).spawn(move || {
-            let wakeup_sem = sem_temp as HANDLE;
-            let server = ReadDirectoryChangesServer {
-                rx: action_rx,
-                event_handler,
-                meta_tx,
-                cmd_tx,
-                watches: HashMap::new(),
-                wakeup_sem,
-            };
-            server.run();
-        });
+        thread::Builder::new()
+            .name("notify-rs windows".to_string())
+            .spawn(move || {
+                let wakeup_sem = sem_temp as HANDLE;
+                let server = ReadDirectoryChangesServer {
+                    rx: action_rx,
+                    event_handler,
+                    meta_tx,
+                    cmd_tx,
+                    watches: HashMap::new(),
+                    wakeup_sem,
+                };
+                server.run();
+            });
         action_tx
     }
 

--- a/src/windows.rs
+++ b/src/windows.rs
@@ -84,7 +84,7 @@ impl ReadDirectoryChangesServer {
         let (action_tx, action_rx) = unbounded();
         // it is, in fact, ok to send the semaphore across threads
         let sem_temp = wakeup_sem as u64;
-        thread::Builder::new()
+        let _ = thread::Builder::new()
             .name("notify-rs windows".to_string())
             .spawn(move || {
                 let wakeup_sem = sem_temp as HANDLE;

--- a/tests/race-with-remove-dir.rs
+++ b/tests/race-with-remove-dir.rs
@@ -10,7 +10,7 @@ fn test_race_with_remove_dir() {
 
     {
         let tmpdir = tmpdir.path().to_path_buf();
-        thread::Builder::new()
+        let _ = thread::Builder::new()
             .name("notify-rs test-race-with-remove-dir".to_string())
             .spawn(move || {
                 let mut watcher = notify::recommended_watcher(move |result| {

--- a/tests/race-with-remove-dir.rs
+++ b/tests/race-with-remove-dir.rs
@@ -10,7 +10,7 @@ fn test_race_with_remove_dir() {
 
     {
         let tmpdir = tmpdir.path().to_path_buf();
-        thread::spawn(move || {
+        thread::Builder::new().name("notify-rs test-race-with-remove-dir".to_string()).spawn(move || {
             let mut watcher = notify::recommended_watcher(move |result| {
                 eprintln!("received event: {:?}", result);
             })

--- a/tests/race-with-remove-dir.rs
+++ b/tests/race-with-remove-dir.rs
@@ -10,14 +10,16 @@ fn test_race_with_remove_dir() {
 
     {
         let tmpdir = tmpdir.path().to_path_buf();
-        thread::Builder::new().name("notify-rs test-race-with-remove-dir".to_string()).spawn(move || {
-            let mut watcher = notify::recommended_watcher(move |result| {
-                eprintln!("received event: {:?}", result);
-            })
-            .unwrap();
+        thread::Builder::new()
+            .name("notify-rs test-race-with-remove-dir".to_string())
+            .spawn(move || {
+                let mut watcher = notify::recommended_watcher(move |result| {
+                    eprintln!("received event: {:?}", result);
+                })
+                .unwrap();
 
-            watcher.watch(&tmpdir, RecursiveMode::NonRecursive).unwrap();
-        });
+                watcher.watch(&tmpdir, RecursiveMode::NonRecursive).unwrap();
+            });
     }
 
     let subdir = tmpdir.path().join("146d921d.tmp");


### PR DESCRIPTION
It's a small change to give a name to all threads notify creates, this way it's easy to pinpoint where they come from in a debugger and profiler.

Edit: cargo fmt is a separate commit so it's a bit easier to see the changes.
Edit 2: `cargo build --workspace --all-targets` doesn't seem to build cleanly, and `cargo clippy --workspace --all-targets` also doesn't seem to be clean on main?
Edit 3: in our own codebase we've added this to clippy.toml which could be interesting to add here as well.

```
disallowed-methods = [
    # We require all of our threads to be named, use std::thread::Builder instead
    # to provide a name for the thread.
    "std::thread::spawn",
]
```