### PR TITLE
ci: do not fail fast for `cargo audit`

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -77,6 +77,8 @@ jobs:
 
   audit:
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
 
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
Output of `cargo audit` can be very noisy, so don't cancel all other test cases if in the event of a failure. Maintainers can decide if the `cargo audit` failure merits an actual failure.

Based on test failures in #397.