### PR TITLE
Fix build on FreeBSD

### DIFF
--- a/src/kqueue.rs
+++ b/src/kqueue.rs
@@ -263,6 +263,10 @@ impl EventLoop {
                             remove_watches.push(path.clone());
                             Ok(Event::new(EventKind::Remove(RemoveKind::Any)).add_path(path))
                         }
+
+                        // On different BSD variants, different extra events may be present
+                        #[allow(unreachable_patterns)]
+                        _ => Ok(Event::new(EventKind::Other)),
                     };
                     self.event_handler.handle_event(event);
                 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -111,6 +111,9 @@ pub use crate::fsevent::FsEventWatcher;
 pub use crate::inotify::INotifyWatcher;
 #[cfg(any(
     target_os = "freebsd",
+    target_os = "openbsd",
+    target_os = "netbsd",
+    target_os = "dragonflybsd",
     all(target_os = "macos", feature = "macos_kqueue")
 ))]
 pub use crate::kqueue::KqueueWatcher;
@@ -269,6 +272,9 @@ pub type RecommendedWatcher = ReadDirectoryChangesWatcher;
 /// The recommended `Watcher` implementation for the current platform
 #[cfg(any(
     target_os = "freebsd",
+    target_os = "openbsd",
+    target_os = "netbsd",
+    target_os = "dragonflybsd",
     all(target_os = "macos", feature = "macos_kqueue")
 ))]
 pub type RecommendedWatcher = KqueueWatcher;
@@ -277,7 +283,10 @@ pub type RecommendedWatcher = KqueueWatcher;
     target_os = "linux",
     target_os = "macos",
     target_os = "windows",
-    target_os = "freebsd"
+    target_os = "freebsd",
+    target_os = "openbsd",
+    target_os = "netbsd",
+    target_os = "dragonflybsd"
 )))]
 pub type RecommendedWatcher = PollWatcher;
 


### PR DESCRIPTION
Was failing due to non-exhaustive match which occurs because the kqueue crate has extra platform-specific enum variants.

While here, I noticed that the other BSDs had `mod kqueue` enabled but not the `pub use` re-export nor the `RecommendedWatcher`. Fixed that too.