### PR TITLE
Harden CI for examples

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -25,7 +25,7 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: setup toolchain
         # `--no-self-update` is needed due to a permission issue on the GHA env.
@@ -65,7 +65,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: setup toolchain
         # `--no-self-update` is needed due to a permission issue on the GHA env.
@@ -83,7 +83,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: install cargo-audit
         run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -42,9 +42,13 @@ jobs:
         if: matrix.version != 'stable' && matrix.os != 'macos-latest'
         run: cargo check --features=serde --examples
 
-      - name: check build hot reload tide
+      - name: check build example
         if: matrix.version != 'stable'
-        run: cargo check -p hot_reload_tide
+        run: cargo check -p watcher_kind
+
+      - name: test hot_reload_tide
+        if: matrix.version != 'stable'
+        run: cargo test -p hot_reload_tide
 
       - name: test
         if: matrix.version == 'stable'

--- a/examples/hot_reload_tide/tests/messages_test.rs
+++ b/examples/hot_reload_tide/tests/messages_test.rs
@@ -1,4 +1,4 @@
-use announcer::messages::*;
+use hot_reload_tide::messages::{Config, load_config};
 
 #[test]
 fn load_config_from_file() {


### PR DESCRIPTION
The current CI doesn't check the build of watcher_kind and test hot_reload_tide, let's do it.