### PR TITLE
Backport changes necessary for mio 0.8

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,9 +30,9 @@ filetime = "0.2.5"
 walkdir = "^2.0.1"
 
 [target.'cfg(target_os="linux")'.dependencies]
+crossbeam-channel = "0.5.0"
 inotify = { version = "^0.7", default-features = false }
-mio = "^0.6.15"
-mio-extras = "^2.0.5"
+mio = { version = "0.8", features = ["os-ext"] }
 
 [target.'cfg(target_os="macos")'.dependencies]
 fsevent = "0.4"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -90,6 +90,8 @@
 
 #![deny(missing_docs)]
 
+#[cfg(target_os = "linux")]
+extern crate crossbeam_channel;
 #[macro_use]
 extern crate bitflags;
 extern crate filetime;
@@ -98,8 +100,6 @@ extern crate fsevent_sys;
 extern crate libc;
 #[cfg(target_os = "linux")]
 extern crate mio;
-#[cfg(target_os = "linux")]
-extern crate mio_extras;
 #[cfg(target_os = "windows")]
 extern crate winapi;
 
@@ -524,7 +524,7 @@ impl From<io::Error> for Error {
         #[cfg(target_os = "linux")]
         {
             if err.raw_os_error() == Some(28) {
-                return Error::Generic(String::from("Can't watch (more) files, limit on the total number of inotify watches reached"))
+                return Error::Generic(String::from("Can't watch (more) files, limit on the total number of inotify watches reached"));
             }
         }
         Error::Io(err)


### PR DESCRIPTION
This PR backports necessary changes for mio 0.8 support to notify 4.0 branch.

This is because mio 0.6 depends on miow 0.2.2 which has an open security issue: https://rustsec.org/advisories/RUSTSEC-2020-0080.html and thus it's triggering warnings for packages using notify 4.x.

Since 5.0 is still in pre-release, and seemingly has been in the status for a long time, it might be better backporting mio 0.8 to 4.x branch and release a new version.