### PR TITLE
make crossbeam-channels optional

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -37,21 +37,31 @@ jobs:
           rustup toolchain install ${{ matrix.version }} --no-self-update
           rustup override set ${{ matrix.version }}
 
-      - name: check build
+      - name: check build serde,macos_kqueue for examples
         if: matrix.version != '1.56.0' && matrix.os == 'macos-latest'
-        run: cargo check --features=serde,macos_kqueue --examples
+        run: cargo check -p notify --features=serde,macos_kqueue --examples
 
-      - name: check build
+      - name: check build serde,macos_kqueue
         if: matrix.version == '1.56.0' && matrix.os == 'macos-latest'
-        run: cargo check --features=serde,macos_kqueue
+        run: cargo check -p notify --features=serde,macos_kqueue
 
-      - name: check build
+      - name: check build serde for examples
         if: matrix.version != '1.56.0' && matrix.os != 'macos-latest'
-        run: cargo check --features=serde --examples
+        run: cargo check -p notify --features=serde --examples
 
-      - name: check build
+      - name: check build serde
         if: matrix.version == '1.56.0' && matrix.os != 'macos-latest'
         run: cargo check --features=serde
+
+      - name: check build without crossbeam/default features
+        if: matrix.version == 'stable'
+        run: cargo check -p notify --no-default-features --features=macos_fsevent
+        # -p notify required for feature selection!
+
+      - name: check build without crossbeam/default features on macos with kqueue
+        if: matrix.version == 'stable' && matrix.os == 'macos-latest'
+        run: cargo check -p notify --no-default-features --features=macos_kqueue
+        # -p notify required for feature selection!
 
       - name: check build examples
         if: matrix.version == 'stable'
@@ -89,6 +99,9 @@ jobs:
         run: |
           rustc --version && cargo --version
           cargo build --target ${{ matrix.target }}
+
+      - name: check build without crossbeam/default features
+        run: cargo build -p notify --no-default-features --target ${{ matrix.target }}
 
   audit:
     runs-on: ubuntu-latest

--- a/notify/Cargo.toml
+++ b/notify/Cargo.toml
@@ -19,7 +19,7 @@ edition = "2021"
 
 [dependencies]
 bitflags = "1.0.4"
-crossbeam-channel = "0.5.0"
+crossbeam-channel = { version = "0.5.0", optional = true }
 filetime = "0.2.6"
 libc = "0.2.4"
 serde = { version = "1.0.89", features = ["derive"], optional = true }
@@ -47,7 +47,7 @@ tempfile = "3.2.0"
 nix = "0.23.1"
 
 [features]
-default = ["macos_fsevent"]
+default = ["macos_fsevent","crossbeam-channel"]
 timing_tests = []
 manual_tests = []
 macos_kqueue = ["kqueue", "mio"]

--- a/notify/src/error.rs
+++ b/notify/src/error.rs
@@ -131,14 +131,27 @@ impl From<io::Error> for Error {
     }
 }
 
+#[cfg(feature = "crossbeam-channel")]
 impl<T> From<crossbeam_channel::SendError<T>> for Error {
     fn from(err: crossbeam_channel::SendError<T>) -> Self {
         Error::generic(&format!("internal channel disconnect: {:?}", err))
     }
 }
-
+#[cfg(not(feature = "crossbeam-channel"))]
+impl<T> From<std::sync::mpsc::SendError<T>> for Error {
+    fn from(err: std::sync::mpsc::SendError<T>) -> Self {
+        Error::generic(&format!("internal channel disconnect: {:?}", err))
+    }
+}
+#[cfg(feature = "crossbeam-channel")]
 impl From<crossbeam_channel::RecvError> for Error {
     fn from(err: crossbeam_channel::RecvError) -> Self {
+        Error::generic(&format!("internal channel disconnect: {:?}", err))
+    }
+}
+#[cfg(not(feature = "crossbeam-channel"))]
+impl From<std::sync::mpsc::RecvError> for Error {
+    fn from(err: std::sync::mpsc::RecvError) -> Self {
         Error::generic(&format!("internal channel disconnect: {:?}", err))
     }
 }

--- a/notify/src/fsevent.rs
+++ b/notify/src/fsevent.rs
@@ -15,8 +15,7 @@
 #![allow(non_upper_case_globals, dead_code)]
 
 use crate::event::*;
-use crate::{Config, Error, EventHandler, RecursiveMode, Result, Watcher};
-use crossbeam_channel::{unbounded, Sender};
+use crate::{Config, Error, EventHandler, RecursiveMode, Result, Watcher, unbounded, Sender};
 use fsevent_sys as fs;
 use fsevent_sys::core_foundation as cf;
 use std::collections::HashMap;

--- a/notify/src/kqueue.rs
+++ b/notify/src/kqueue.rs
@@ -6,7 +6,7 @@
 
 use super::event::*;
 use super::{Error, EventHandler, RecursiveMode, Result, Watcher};
-use crossbeam_channel::{unbounded, Sender};
+use crate::{unbounded, Sender, Receiver};
 use kqueue::{EventData, EventFilter, FilterFlag, Ident};
 use std::collections::HashMap;
 use std::env;
@@ -29,8 +29,8 @@ struct EventLoop {
     running: bool,
     poll: mio::Poll,
     event_loop_waker: Arc<mio::Waker>,
-    event_loop_tx: crossbeam_channel::Sender<EventLoopMsg>,
-    event_loop_rx: crossbeam_channel::Receiver<EventLoopMsg>,
+    event_loop_tx: Sender<EventLoopMsg>,
+    event_loop_rx: Receiver<EventLoopMsg>,
     kqueue: kqueue::Watcher,
     event_handler: Box<dyn EventHandler>,
     watches: HashMap<PathBuf, bool>,
@@ -39,7 +39,7 @@ struct EventLoop {
 /// Watcher implementation based on inotify
 #[derive(Debug)]
 pub struct KqueueWatcher {
-    channel: crossbeam_channel::Sender<EventLoopMsg>,
+    channel: Sender<EventLoopMsg>,
     waker: Arc<mio::Waker>,
 }
 
@@ -51,7 +51,7 @@ enum EventLoopMsg {
 
 impl EventLoop {
     pub fn new(kqueue: kqueue::Watcher, event_handler: Box<dyn EventHandler>) -> Result<Self> {
-        let (event_loop_tx, event_loop_rx) = crossbeam_channel::unbounded::<EventLoopMsg>();
+        let (event_loop_tx, event_loop_rx) = unbounded::<EventLoopMsg>();
         let poll = mio::Poll::new()?;
 
         let event_loop_waker = Arc::new(mio::Waker::new(poll.registry(), MESSAGE)?);

--- a/notify/src/windows.rs
+++ b/notify/src/windows.rs
@@ -17,7 +17,7 @@ use winapi::um::winnt::{self, FILE_NOTIFY_INFORMATION, HANDLE};
 
 use crate::{event::*, WatcherKind};
 use crate::{Config, Error, EventHandler, RecursiveMode, Result, Watcher};
-use crossbeam_channel::{bounded, unbounded, Receiver, Sender};
+use crate::{unbounded, bounded, Sender, Receiver, BoundSender};
 use std::collections::HashMap;
 use std::env;
 use std::ffi::OsString;
@@ -51,7 +51,7 @@ enum Action {
     Watch(PathBuf, RecursiveMode),
     Unwatch(PathBuf),
     Stop,
-    Configure(Config, Sender<Result<bool>>),
+    Configure(Config, BoundSender<Result<bool>>),
 }
 
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
@@ -228,7 +228,7 @@ impl ReadDirectoryChangesServer {
         }
     }
 
-    fn configure_raw_mode(&mut self, _config: Config, tx: Sender<Result<bool>>) {
+    fn configure_raw_mode(&mut self, _config: Config, tx: BoundSender<Result<bool>>) {
         tx.send(Ok(false))
             .expect("configuration channel disconnect");
     }


### PR DESCRIPTION
Allows disabling crossbeam-channel by disabling default features.

This fixes #380