### PR TITLE
fixup optional crossbeam feature selection in debouncer-mini

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -63,6 +63,11 @@ jobs:
         run: cargo check -p notify --no-default-features --features=macos_kqueue
         # -p notify required for feature selection!
 
+      - name: check notify debouncer mini features
+        if: matrix.version == 'stable'
+        run: cargo check -p notify-debouncer-mini --no-default-features
+        # -p required for feature selection to actually work!
+
       - name: check build examples
         if: matrix.version == 'stable'
         run: cargo check --package examples --examples

--- a/notify-debouncer-mini/Cargo.toml
+++ b/notify-debouncer-mini/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "notify-debouncer-mini"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2021"
 rust-version = "1.56"
 description = "notify mini debouncer for events"
@@ -19,7 +19,9 @@ name = "notify_debouncer_mini"
 path = "src/lib.rs"
 
 [features]
-default = ["crossbeam-channel"]
+default = ["crossbeam"]
+# can't use dep:crossbeam-channel and feature name crossbeam-channel below rust 1.60
+crossbeam = ["crossbeam-channel","notify/crossbeam-channel"]
 
 [dependencies]
 notify = "5.0.0-pre.16"

--- a/notify-debouncer-mini/README.md
+++ b/notify-debouncer-mini/README.md
@@ -2,16 +2,19 @@
 
 [![» Docs](https://flat.badgen.net/badge/api/docs.rs/df3600)][docs]
 
-Tiny debouncer for [notify](https://crates.io/crates/notify). Filters incoming events and emits only one event per timeframe per file.
+Tiny debouncer for [notify]. Filters incoming events and emits only one event per timeframe per file.
 
 ## Features
 
 - `crossbeam` enabled by default, for crossbeam channel support.  
 This may create problems used in tokio environments. See [#380](https://github.com/notify-rs/notify/issues/380).  
+<<<<<<< HEAD
 Use someting like the following to disable it.
 ```toml
 notify-debouncer-mini = { version = "*", default-features = false }
 ```
+This also passes through to notify as `crossbeam-channel` feature.
 - `serde` for serde support of event types, off by default
 
 [docs]: https://docs.rs/notify-debouncer-mini
+[notify]: https://crates.io/crates/notify

--- a/notify-debouncer-mini/src/lib.rs
+++ b/notify-debouncer-mini/src/lib.rs
@@ -6,6 +6,13 @@
 //! [dependencies]
 //! notify-debouncer-mini = "0.1"
 //! ```
+//! In case you want to select specific features of notify,
+//! specify notify as dependency explicitely in your dependencies.
+//! Otherwise you can just use the re-export of notify from debouncer-mini.
+//! ```toml
+//! notify-debouncer-mini = "0.1"
+//! notify = { version = "..", features = [".."] }
+//! ```
 //!  
 //! # Examples
 //!
@@ -174,10 +181,8 @@ impl DebounceDataInner {
         // TODO: perfect fit for drain_filter https://github.com/rust-lang/rust/issues/59618
         for (k, v) in self.d.drain() {
             if v.update.elapsed() >= self.timeout {
-                println!("normal timeout");
                 events_expired.push(DebouncedEvent::new(k, DebouncedEventKind::Any));
             } else if v.insert.elapsed() >= self.timeout {
-                println!("continuous");
                 data_back.insert(k.clone(), v);
                 events_expired.push(DebouncedEvent::new(k, DebouncedEventKind::AnyContinuous));
             } else {
@@ -205,7 +210,6 @@ impl DebounceDataInner {
         for path in e.paths.into_iter() {
             if let Some(v) = self.d.get_mut(&path) {
                 v.update = Instant::now();
-                println!("Exists");
             } else {
                 self.d.insert(path, EventData::new_any());
             }


### PR DESCRIPTION
Actually pass through the optional crossbeam dep from debouncer-mini to notify.

Also verify this in CI. (Requires a manual -p call to work.)

Also closes #433 