### PR TITLE
update minimum walkdir version to 2.2.2

### DIFF
--- a/notify/Cargo.toml
+++ b/notify/Cargo.toml
@@ -23,7 +23,7 @@ crossbeam-channel = { version = "0.5.0", optional = true }
 filetime = "0.2.6"
 libc = "0.2.4"
 serde = { version = "1.0.89", features = ["derive"], optional = true }
-walkdir = "2.0.1"
+walkdir = "2.2.2"
 
 [target.'cfg(target_os="linux")'.dependencies]
 inotify = { version = "0.9", default-features = false }


### PR DESCRIPTION
While trying out `notify 5.0.0-pre.16`, I got some issues as it declare a dependency on `walkdir 2.0.1`, but uses a [function added in `2.2.2`](https://docs.rs/walkdir/2.2.2/walkdir/struct.DirEntry.html#method.into_path). This patch aims to fix that little issue.

I've tested the RC for my (arguably simple) use case, and on Linux it seems to work fine. I'll test on MacOS and Windows in the following days, and report if I got any issue.