### PR TITLE
prepare 5.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,25 @@
 
 v4 commits split out to branch `v4_maintenance` starting with `4.0.16`
 
+## 5.0.0 (2022-08-28)
+
+For a list of changes when upgrading from v5 see [UPGRADING_V4_TO_V5.md](UPGRADING_V4_TO_V5.md).
+
+Differences to 5.0.0-pre.16:
+
+- FIX: update minimum walkdir version to 2.2.2 #[432]
+- CHANGE: add `need_rescan` function to `Event`, allowing easier detection when a rescan is required [#435]
+- FIX: debouncer-mini: change crossbeam feature to `crossbeam`, to allow passthrough with notify re-exports [#429]
+- DOCS: improve v5-to-v5 upgrade docs [#431]
+- DOCS: file back v4 changelog into main [#437]
+- DOCS: cleanups and link fixes
+
+[#431]: https://github.com/notify-rs/notify/pull/431
+[#432]: https://github.com/notify-rs/notify/pull/432
+[#437]: https://github.com/notify-rs/notify/pull/437
+[#435]: https://github.com/notify-rs/notify/pull/435
+[#429]: https://github.com/notify-rs/notify/pull/429
+
 ## 5.0.0-pre.16 (2022-08-12)
 
 - CHANGE: require config for watcher creation and unify config [#426]

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ Originally created by [Félix Saparelli] and awesome [contributors].
 [contributors]: https://github.com/notify-rs/notify/graphs/contributors
 [crate]: https://crates.io/crates/notify
 [docket]: https://iwillspeak.github.io/docket/
-[docs]: https://docs.rs/notify/5.0.0-pre.16/notify/
+[docs]: https://docs.rs/notify/5.0.0/notify/
 [fsnotify]: https://github.com/go-fsnotify/fsnotify
 [handlebars-iron]: https://github.com/sunng87/handlebars-iron
 [hotwatch]: https://github.com/francesca64/hotwatch

--- a/UPGRADING_V4_TO_V5.md
+++ b/UPGRADING_V4_TO_V5.md
@@ -2,15 +2,17 @@
 
 This guide documents changes between v4 and v5 for upgrading existing code.
 
+## (Precise) Events & Debouncing
+
 Notify v5 only contains precise events. Debouncing is done by a separate crate [notify-debouncer-mini](https://github.com/notify-rs/notify/tree/main/notify-debouncer-mini). If you relied on `RawEvent`, this got replaced by `Event`.
 
-The old `DebouncedEvent` is completely removed. notify-debouncer-mini only reports an `Any` like event (named `DebouncedEvent` too) as relying on specific kinds (Write/Create/Remove) is very plattform specific and [can't](https://github.com/notify-rs/notify/issues/261) [be](https://github.com/notify-rs/notify/issues/187) [guaranteed](https://github.com/notify-rs/notify/issues/272) to work, relying on a lot of assumptions. In most cases you should check anway what exactly the state of files is, or probably re-run your application code, not relying on which event happened.
+The old `DebouncedEvent` is completely removed. [notify-debouncer-mini] only reports an `Any` like event (named `DebouncedEvent` too), as relying on specific kinds (Write/Create/Remove) is very platform specific and [can't](https://github.com/notify-rs/notify/issues/261) [be](https://github.com/notify-rs/notify/issues/187) [guaranteed](https://github.com/notify-rs/notify/issues/272) to work, relying on a lot of assumptions. In most cases you should check anyway what exactly the state of files is, or probably re-run your application code, not relying on which event happened.
 
-If you've used the previously by default debounced API, please see [here](https://github.com/notify-rs/notify/blob/main/examples/debounced.rs) for an example using the new crate.
+If you've used the debounced API, which was the default in v4 without `raw_`, please see [here](https://github.com/notify-rs/notify/blob/main/examples/debounced.rs) for an example using the new crate.
 
-For precise events you can see [here](https://github.com/notify-rs/notify/blob/main/examples/monitor_raw.rs).
+For precise events you can look [here](https://github.com/notify-rs/notify/blob/main/examples/monitor_raw.rs).
 
-Watchers now accept the `EventHandler` trait for event handling, allowing for callbacks and foreign channels.
+Watchers now accept the `EventHandler` trait for event handling, allowing for callbacks and foreign channels among other things.
 
 ## Config
 
@@ -18,7 +20,7 @@ All watcher only expose the `Watcher` trait, which takes an `EventHandler` and a
 
 ## Features
 
-Notify v5 by default uses crossbeam-channel internally. You can disable this (required for tokio) as documented in the crate, this may be required for tokio users.
+Notify v5 by default uses `crossbeam-channel` internally. You can disable this (required for tokio) as documented in the crate, this may be required for tokio users.
 
 For macOS the kqueue backend can now be used alternatively by using the `macos_kqueue` feature.
 

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -5,7 +5,7 @@ publish = false
 edition = "2021"
 
 [dev-dependencies]
-notify = { version = "5.0.0-pre.16" }
+notify = { version = "5.0.0" }
 notify-debouncer-mini = { version = "0.1" }
 futures = "0.3"
 

--- a/examples/hot_reload_tide/Cargo.toml
+++ b/examples/hot_reload_tide/Cargo.toml
@@ -11,7 +11,7 @@ tide = "0.16.0"
 async-std = { version = "1.6.0", features = ["attributes"] }
 serde_json = "1.0"
 serde = "1.0.115"
-notify = { version = "5.0.0-pre.16", features = ["serde"], path = "../../notify" }
+notify = { version = "5.0.0", features = ["serde"], path = "../../notify" }
 
 # required to prevent mixing with workspace
 # hack to prevent cargo audit from catching this

--- a/notify-debouncer-mini/Cargo.toml
+++ b/notify-debouncer-mini/Cargo.toml
@@ -24,6 +24,6 @@ default = ["crossbeam"]
 crossbeam = ["crossbeam-channel","notify/crossbeam-channel"]
 
 [dependencies]
-notify = "5.0.0-pre.16"
+notify = "5.0.0"
 crossbeam-channel = { version = "0.5", optional = true }
 serde = { version = "1.0.89", features = ["derive"], optional = true }

--- a/notify/Cargo.toml
+++ b/notify/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "notify"
-version = "5.0.0-pre.16"
+version = "5.0.0"
 rust-version = "1.56"
 description = "Cross-platform filesystem notification library"
 documentation = "https://docs.rs/notify"

--- a/notify/src/lib.rs
+++ b/notify/src/lib.rs
@@ -4,7 +4,7 @@
 //!
 //! ```toml
 //! [dependencies]
-//! notify = "5.0.0-pre.16"
+//! notify = "5.0.0"
 //! ```
 //! 
 //! If you want debounced events, see [notify-debouncer-mini](https://github.com/notify-rs/notify/tree/main/notify-debouncer-mini)
@@ -23,7 +23,7 @@
 //! Events are serialisable via [serde](https://serde.rs) if the `serde` feature is enabled:
 //!
 //! ```toml
-//! notify = { version = "5.0.0-pre.16", features = ["serde"] }
+//! notify = { version = "5.0.0", features = ["serde"] }
 //! ```
 //! 
 //! ### Crossbeam-Channel & Tokio
@@ -34,7 +34,7 @@
 //! You can disable crossbeam-channel, letting notify fallback to std channels via
 //! 
 //! ```toml
-//! notify = { version = "5.0.0-pre.16", default-features = false, feature=["macos_kqueue"] }
+//! notify = { version = "5.0.0", default-features = false, feature=["macos_kqueue"] }
 //! // Alternatively macos_fsevent instead of macos_kqueue
 //! ```
 //! Note the `macos_kqueue` requirement here, otherwise no backend is available on macos.


### PR DESCRIPTION
This prepares the v5.0.0 release and changes the upgrade docs a tiny bit.

Closes #249 