### PR TITLE
debouncer: correctly document crossbeam feature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 v4 commits split out to branch `v4_maintenance` starting with `4.0.16`
 
+## debouncer-mini 0.2.1 (2022-09-05)
+
+- DOCS: correctly document the `crossbeam` feature [#440]
+
+[#440]: https://github.com/notify-rs/notify/pull/440
+
 ## debouncer-mini 0.2.0 (2022-08-30)
 
 Upgrade notify dependency to 5.0.0

--- a/notify-debouncer-mini/Cargo.toml
+++ b/notify-debouncer-mini/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "notify-debouncer-mini"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2021"
 rust-version = "1.56"
 description = "notify mini debouncer for events"

--- a/notify-debouncer-mini/src/lib.rs
+++ b/notify-debouncer-mini/src/lib.rs
@@ -42,10 +42,11 @@
 //!
 //! # Features
 //!
-//! The following feature can be turned on or off.
+//! The following crate features can be turned on or off in your cargo dependency config:
 //!
-//! - `crossbeam-channel` enabled by default, adds DebounceEventHandler support for crossbeam channels.
-//! - `serde` enabled serde support for events.
+//! - `crossbeam` enabled by default, adds [`DebounceEventHandler`](DebounceEventHandler) support for crossbeam channels.
+//!   Also enables crossbeam-channel in the re-exported notify. You may want to disable this when using the tokio async runtime.
+//! - `serde` enables serde support for events.
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 use std::{


### PR DESCRIPTION
Marks 0.2.1 to fixup feature name in docs