### PR TITLE
kqueue: Only make a single syscall to add all the watches

### DIFF
--- a/notify/src/fsevent.rs
+++ b/notify/src/fsevent.rs
@@ -585,7 +585,7 @@ fn test_fsevent_watcher_drop() {
     let (tx, rx) = std::sync::mpsc::channel();
 
     {
-        let mut watcher = FsEventWatcher::new(tx).unwrap();
+        let mut watcher = FsEventWatcher::new(tx, Default::default()).unwrap();
         watcher.watch(dir.path(), RecursiveMode::Recursive).unwrap();
         thread::sleep(Duration::from_millis(2000));
         println!("is running -> {}", watcher.is_running());

--- a/notify/src/kqueue.rs
+++ b/notify/src/kqueue.rs
@@ -5,7 +5,7 @@
 //! pieces of kernel code termed filters.
 
 use super::event::*;
-use super::{Error, EventHandler, RecursiveMode, Result, Watcher, Config};
+use super::{Config, Error, EventHandler, RecursiveMode, Result, Watcher};
 use crate::{unbounded, Receiver, Sender};
 use kqueue::{EventData, EventFilter, FilterFlag, Ident};
 use std::collections::HashMap;

--- a/notify/src/kqueue.rs
+++ b/notify/src/kqueue.rs
@@ -302,6 +302,9 @@ impl EventLoop {
         Ok(())
     }
 
+    /// Adds a single watch to the kqueue.
+    ///
+    /// The caller of this function must call `self.kqueue.watch()` afterwards to register the new watch.
     fn add_single_watch(&mut self, path: PathBuf, is_recursive: bool) -> Result<()> {
         let event_filter = EventFilter::EVFILT_VNODE;
         let filter_flags = FilterFlag::NOTE_DELETE


### PR DESCRIPTION
Hey!

We use notify v4 in [`turbopack`](https://github.com/vercel/turbo) and we've recently tried updating to v5 to use the `kqueue` implementation, as we found it to be much faster than FSEvents at detecting updates.

However, we also noticed a very large drop in performance when watching large directories. After a bit of investigating, it turns out that `notify` makes a `kevent` syscall for each file it watches. Watching a folder with 15k files ends up taking about 11.5s.

This PR changes this behavior to ensure we only make a single `kevent` call when adding multiple files at the same time. This improves the above case to take 900ms.

I've also filed [an issue with `kqueue`](https://gitlab.com/rust-kqueue/rust-kqueue/-/issues/12) to fix another performance problem, which makes watching n files O(n²). This would further improve to 400ms.

Finally, while profiling the above issue, I noticed that during the 12s of watching, only 2 cores of my computer were working. I have a prototype version that uses multiple threads to open files, which might be faster when watching large directories, but it would also require changes to `kqueue`, so I'm filing it away for now.