### PR TITLE
Use official windows-sys crate for WinAPI instead of deprecated winapi crate

### DIFF
--- a/notify/Cargo.toml
+++ b/notify/Cargo.toml
@@ -35,7 +35,7 @@ kqueue = { version = "1.0", optional = true }
 mio = { version = "0.8", features = ["os-ext"], optional = true }
 
 [target.'cfg(windows)'.dependencies]
-winapi = { version = "0.3.8", features = ["fileapi", "handleapi", "ioapiset", "minwinbase", "synchapi", "winbase", "winnt"] }
+windows-sys = { version = "0.42.0", features = ["Win32_System_Threading", "Win32_Foundation", "Win32_Storage_FileSystem", "Win32_Security", "Win32_System_WindowsProgramming", "Win32_System_IO"] }
 
 [target.'cfg(any(target_os="freebsd", target_os="openbsd", target_os = "netbsd", target_os = "dragonflybsd"))'.dependencies]
 kqueue = "^1.0.4" # fix for #344


### PR DESCRIPTION
`winapi` crate is kinda deprecated. `windows` and `windows-sys` can be used instead. They are maintained directly by Microsoft and are actively developed.
`windows-sys` is a trimmed down version of `windows`. It offers better compilation time, and it is released once per 6 months.

I removed winapi dependency and replaced in with windows-sys.