### PR TITLE
Fix a lint warning in examples

### DIFF
--- a/examples/debounced.rs
+++ b/examples/debounced.rs
@@ -27,9 +27,11 @@ fn main() {
         .unwrap();
 
     // print all events, non returning
-    for events in rx {
-        for e in events {
-            println!("{:?}", e);
+    for inner in rx {
+        if let Ok(events) = inner {
+            for event in events {
+                println!("{:?}", event);
+            }
         }
     }
 }

--- a/examples/debounced_full_custom.rs
+++ b/examples/debounced_full_custom.rs
@@ -25,9 +25,11 @@ fn main() {
         .watch(Path::new("."), RecursiveMode::Recursive)
         .unwrap();
     // print all events, non returning
-    for events in rx {
-        for e in events {
-            println!("{:?}", e);
+    for inner in rx {
+        if let Ok(events) = inner {
+            for event in events {
+                println!("{:?}", event);
+            }
         }
     }
 }


### PR DESCRIPTION
Currently, some examples have the following warning when running.

```
warning: for loop over a `Result`. This is more readably written as an `if let` statement
  --> examples/debounced_full_custom.rs:29:18
   |
29 |         for e in events {
   |                  ^^^^^^
   |
   = note: `#[warn(for_loops_over_fallibles)]` on by default
help: to check pattern in a loop use `while let`
   |
29 |         while let Ok(e) = events {
   |         ~~~~~~~~~~~~~ ~~~
help: consider using `if let` to clear intent
   |
29 |         if let Ok(e) = events {
   |         ~~~~~~~~~~ ~~~
```

This fixed those files as per the linter's suggestion.

<!-- By contributing, you agree to the terms of the license, available in the LICENSE.ARTISTIC file, and of the code of conduct, available in the CODE_OF_CONDUCT.md file. Furthermore, you agree to release under CC0, also available in the LICENSE file, until Notify has fully transitioned to Artistic 2.0. -->

<!-- After creating this pull request, the test suite will run.

It is expected that if any failures occur in the builds, you either:

- fix the errors,
- ask for help, or
- note that the failures are expected with a detailed explanation.

If you do not, a maintainer may prompt you and/or do it themselves, but do note that it will take longer for your contribution to be reviewed if the build does not pass.

Running `cargo fmt` and/or `cargo clippy` is NOT required but appreciated!

You can remove this text. -->
