### PR TITLE
Replace `windows-sys` with manual bindings

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches:
       # test branches
-      - 'try-**'
+      - "try-**"
 
       # main branches
       - main
@@ -55,7 +55,7 @@ jobs:
 
       - name: check build without crossbeam/default features
         if: matrix.version == 'stable'
-        run: cargo check -p notify --no-default-features --features=macos_fsevent
+        run: cargo check -p notify --no-default-features --features=macos_fsevent,windows-sys
 
       - name: check build without windows-sys and with internal bindings
         if: matrix.os == 'windows-latest'

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -56,6 +56,10 @@ jobs:
       - name: check build without crossbeam/default features
         if: matrix.version == 'stable'
         run: cargo check -p notify --no-default-features --features=macos_fsevent
+
+      - name: check build without windows-sys and with internal bindings
+        if: matrix.os == 'windows-latest'
+        run: cargo check -p notify --no-default-features --features=slim_windows
         # -p notify required for feature selection!
 
       - name: check build without crossbeam/default features on macos with kqueue

--- a/notify/Cargo.toml
+++ b/notify/Cargo.toml
@@ -34,9 +34,6 @@ fsevent-sys = { version = "4", optional = true }
 kqueue = { version = "1.0", optional = true }
 mio = { version = "0.8", features = ["os-ext"], optional = true }
 
-[target.'cfg(windows)'.dependencies]
-windows-sys = { version = "0.45.0", features = ["Win32_System_Threading", "Win32_Foundation", "Win32_Storage_FileSystem", "Win32_Security", "Win32_System_WindowsProgramming", "Win32_System_IO"] }
-
 [target.'cfg(any(target_os="freebsd", target_os="openbsd", target_os = "netbsd", target_os = "dragonflybsd"))'.dependencies]
 kqueue = "^1.0.4" # fix for #344
 mio = { version = "0.8", features = ["os-ext"] }

--- a/notify/Cargo.toml
+++ b/notify/Cargo.toml
@@ -12,7 +12,7 @@ keywords = ["events", "filesystem", "notify", "watch"]
 categories = ["filesystem"]
 authors = [
   "Félix Saparelli <me@passcod.name>",
-  "Daniel Faust <hessijames@gmail.com>"
+  "Daniel Faust <hessijames@gmail.com>",
 ]
 
 edition = "2021"
@@ -34,6 +34,18 @@ fsevent-sys = { version = "4", optional = true }
 kqueue = { version = "1.0", optional = true }
 mio = { version = "0.8", features = ["os-ext"], optional = true }
 
+[target.'cfg(windows)'.dependencies.windows-sys]
+version = "0.45.0"
+optional = true
+features = [
+  "Win32_Foundation",
+  "Win32_Security",
+  "Win32_Storage_FileSystem",
+  "Win32_System_IO",
+  "Win32_System_Threading",
+  "Win32_System_WindowsProgramming",
+]
+
 [target.'cfg(any(target_os="freebsd", target_os="openbsd", target_os = "netbsd", target_os = "dragonflybsd"))'.dependencies]
 kqueue = "^1.0.4" # fix for #344
 mio = { version = "0.8", features = ["os-ext"] }
@@ -44,8 +56,9 @@ tempfile = "3.2.0"
 nix = "0.23.1"
 
 [features]
-default = ["macos_fsevent","crossbeam-channel"]
+default = ["macos_fsevent", "crossbeam-channel", "windows-sys"]
 timing_tests = []
 manual_tests = []
 macos_kqueue = ["kqueue", "mio"]
 macos_fsevent = ["fsevent-sys"]
+slim_windows = []

--- a/notify/src/windows.rs
+++ b/notify/src/windows.rs
@@ -20,6 +20,11 @@ use std::slice;
 use std::sync::{Arc, Mutex};
 use std::thread;
 
+/// We do our own minimal bindings to the win32 API here with only the things we
+/// need. This means we can avoid a dependency on the `windows-sys` crate and its
+/// version churn, and the `winapi` due to its maintenance status.
+///
+/// These APIs will never change, though they may be supplanted in the future.
 #[allow(non_camel_case_types, non_snake_case)]
 mod bindings {
     pub const INFINITE: u32 = 4294967295;

--- a/notify/src/windows.rs
+++ b/notify/src/windows.rs
@@ -19,23 +19,133 @@ use std::ptr;
 use std::slice;
 use std::sync::{Arc, Mutex};
 use std::thread;
-use windows_sys::Win32::Foundation::{
-    CloseHandle, ERROR_OPERATION_ABORTED, HANDLE, INVALID_HANDLE_VALUE, WAIT_OBJECT_0,
-};
-use windows_sys::Win32::Storage::FileSystem::{
-    CreateFileW, ReadDirectoryChangesW, FILE_ACTION_ADDED, FILE_ACTION_MODIFIED,
-    FILE_ACTION_REMOVED, FILE_ACTION_RENAMED_NEW_NAME, FILE_ACTION_RENAMED_OLD_NAME,
-    FILE_FLAG_BACKUP_SEMANTICS, FILE_FLAG_OVERLAPPED, FILE_LIST_DIRECTORY,
-    FILE_NOTIFY_CHANGE_ATTRIBUTES, FILE_NOTIFY_CHANGE_CREATION, FILE_NOTIFY_CHANGE_DIR_NAME,
-    FILE_NOTIFY_CHANGE_FILE_NAME, FILE_NOTIFY_CHANGE_LAST_WRITE, FILE_NOTIFY_CHANGE_SECURITY,
-    FILE_NOTIFY_CHANGE_SIZE, FILE_NOTIFY_INFORMATION, FILE_SHARE_DELETE, FILE_SHARE_READ,
-    FILE_SHARE_WRITE, OPEN_EXISTING,
-};
-use windows_sys::Win32::System::Threading::{
-    CreateSemaphoreW, ReleaseSemaphore, WaitForSingleObjectEx,
-};
-use windows_sys::Win32::System::WindowsProgramming::INFINITE;
-use windows_sys::Win32::System::IO::{CancelIo, OVERLAPPED};
+
+#[allow(non_camel_case_types, non_snake_case)]
+mod bindings {
+    pub const INFINITE: u32 = 4294967295;
+    pub const INVALID_HANDLE_VALUE: isize = -1;
+    pub type HANDLE = isize;
+
+    pub type FILE_ACCESS_FLAGS = u32;
+    pub const FILE_LIST_DIRECTORY: FILE_ACCESS_FLAGS = 1;
+
+    pub type FILE_SHARE_MODE = u32;
+    pub const FILE_SHARE_DELETE: FILE_SHARE_MODE = 4;
+    pub const FILE_SHARE_READ: FILE_SHARE_MODE = 1;
+    pub const FILE_SHARE_WRITE: FILE_SHARE_MODE = 2;
+
+    pub type BOOL = i32;
+
+    #[repr(C)]
+    pub struct SECURITY_ATTRIBUTES {
+        pub nLength: u32,
+        pub lpSecurityDescriptor: *mut std::ffi::c_void,
+        pub bInheritHandle: BOOL,
+    }
+
+    pub type FILE_CREATION_DISPOSITION = u32;
+    pub const OPEN_EXISTING: FILE_CREATION_DISPOSITION = 3;
+
+    pub type FILE_FLAGS_AND_ATTRIBUTES = u32;
+    pub const FILE_FLAG_OVERLAPPED: FILE_FLAGS_AND_ATTRIBUTES = 1073741824;
+    pub const FILE_FLAG_BACKUP_SEMANTICS: FILE_FLAGS_AND_ATTRIBUTES = 33554432;
+
+    pub type FILE_NOTIFY_CHANGE = u32;
+    pub const FILE_NOTIFY_CHANGE_FILE_NAME: FILE_NOTIFY_CHANGE = 1;
+    pub const FILE_NOTIFY_CHANGE_DIR_NAME: FILE_NOTIFY_CHANGE = 2;
+    pub const FILE_NOTIFY_CHANGE_ATTRIBUTES: FILE_NOTIFY_CHANGE = 4;
+    pub const FILE_NOTIFY_CHANGE_SIZE: FILE_NOTIFY_CHANGE = 8;
+    pub const FILE_NOTIFY_CHANGE_LAST_WRITE: FILE_NOTIFY_CHANGE = 16;
+    pub const FILE_NOTIFY_CHANGE_CREATION: FILE_NOTIFY_CHANGE = 64;
+    pub const FILE_NOTIFY_CHANGE_SECURITY: FILE_NOTIFY_CHANGE = 256;
+
+    #[repr(C)]
+    pub struct OVERLAPPED_0_0 {
+        pub Offset: u32,
+        pub OffsetHigh: u32,
+    }
+    #[repr(C)]
+    pub union OVERLAPPED_0 {
+        pub Anonymous: std::mem::ManuallyDrop<OVERLAPPED_0_0>,
+        pub Pointer: *mut std::ffi::c_void,
+    }
+    #[repr(C)]
+    pub struct OVERLAPPED {
+        pub Internal: usize,
+        pub InternalHigh: usize,
+        pub Anonymous: OVERLAPPED_0,
+        pub hEvent: HANDLE,
+    }
+    pub type LPOVERLAPPED_COMPLETION_ROUTINE = Option<
+        unsafe extern "system" fn(
+            dwErrorCode: u32,
+            dwNumberOfBytesTransfered: u32,
+            lpOverlapped: *mut OVERLAPPED,
+        ),
+    >;
+
+    pub type FILE_ACTION = u32;
+    pub const FILE_ACTION_ADDED: FILE_ACTION = 1;
+    pub const FILE_ACTION_REMOVED: FILE_ACTION = 2;
+    pub const FILE_ACTION_MODIFIED: FILE_ACTION = 3;
+    pub const FILE_ACTION_RENAMED_OLD_NAME: FILE_ACTION = 4;
+    pub const FILE_ACTION_RENAMED_NEW_NAME: FILE_ACTION = 5;
+
+    #[repr(C)]
+    pub struct FILE_NOTIFY_INFORMATION {
+        pub NextEntryOffset: u32,
+        pub Action: FILE_ACTION,
+        pub FileNameLength: u32,
+        pub FileName: [u16; 1],
+    }
+
+    pub type WIN32_ERROR = u32;
+    pub const WAIT_OBJECT_0: WIN32_ERROR = 0;
+    pub const ERROR_OPERATION_ABORTED: WIN32_ERROR = 995;
+
+    #[link(name = "kernel32")]
+    extern "system" {
+        pub fn CreateFileW(
+            lpFileName: *const u16,
+            dwDesiredAccess: FILE_ACCESS_FLAGS,
+            dwShareMode: FILE_SHARE_MODE,
+            lpSecurityAttributes: *const SECURITY_ATTRIBUTES,
+            dwCreationDisposition: FILE_CREATION_DISPOSITION,
+            dwFlagsAndAttributes: FILE_FLAGS_AND_ATTRIBUTES,
+            hTemplateFile: HANDLE,
+        ) -> HANDLE;
+        pub fn ReadDirectoryChangesW(
+            hDirectory: HANDLE,
+            lpBuffer: *mut std::ffi::c_void,
+            nBufferLength: u32,
+            bWatchSubtree: BOOL,
+            dwNotifyFilter: FILE_NOTIFY_CHANGE,
+            lpBytesReturned: *mut u32,
+            lpOverlapped: *mut OVERLAPPED,
+            lpCompletionRoutine: LPOVERLAPPED_COMPLETION_ROUTINE,
+        ) -> BOOL;
+        pub fn CloseHandle(hObject: HANDLE) -> BOOL;
+        pub fn CancelIo(hFile: HANDLE) -> BOOL;
+        pub fn CreateSemaphoreW(
+            lpSemaphoreAttributes: *const SECURITY_ATTRIBUTES,
+            lInitialCount: i32,
+            lMaximumCount: i32,
+            lpName: *const u16,
+        ) -> HANDLE;
+        pub fn ReleaseSemaphore(
+            hSemaphore: HANDLE,
+            lReleaseCount: i32,
+            lpPreviousCount: *mut i32,
+        ) -> BOOL;
+        pub fn WaitForSingleObjectEx(
+            hHandle: HANDLE,
+            dwMilliseconds: u32,
+            bAlertable: BOOL,
+        ) -> WIN32_ERROR;
+    }
+}
+
+use bindings::*;
 
 const BUF_SIZE: u32 = 16384;
 

--- a/notify/src/windows.rs
+++ b/notify/src/windows.rs
@@ -20,7 +20,10 @@ use std::slice;
 use std::sync::{Arc, Mutex};
 use std::thread;
 
-#[cfg(all(feature = "windows-sys", not(feature = "slim_windows")))]
+#[cfg(all(not(feature = "windows-sys"), not(feature = "slim_windows")))]
+compile_error!("You must enable either the `windows-sys` or slim_windows` features");
+
+#[cfg(not(feature = "slim_windows"))]
 mod sys {
     pub use windows_sys::Win32::Foundation::{
         CloseHandle, ERROR_OPERATION_ABORTED, HANDLE, INVALID_HANDLE_VALUE, WAIT_OBJECT_0,
@@ -40,12 +43,12 @@ mod sys {
     pub use windows_sys::Win32::System::WindowsProgramming::INFINITE;
     pub use windows_sys::Win32::System::IO::{CancelIo, OVERLAPPED};
 }
-#[cfg(all(feature = "windows-sys", not(feature = "slim_windows")))]
+#[cfg(not(feature = "slim_windows"))]
 use sys::*;
 
-#[cfg(any(not(feature = "windows-sys"), feature = "slim_windows"))]
+#[cfg(feature = "slim_windows")]
 mod bindings;
-#[cfg(any(not(feature = "windows-sys"), feature = "slim_windows"))]
+#[cfg(feature = "slim_windows")]
 use bindings::*;
 
 const BUF_SIZE: u32 = 16384;

--- a/notify/src/windows.rs
+++ b/notify/src/windows.rs
@@ -20,136 +20,32 @@ use std::slice;
 use std::sync::{Arc, Mutex};
 use std::thread;
 
-/// We do our own minimal bindings to the win32 API here with only the things we
-/// need. This means we can avoid a dependency on the `windows-sys` crate and its
-/// version churn, and the `winapi` due to its maintenance status.
-///
-/// These APIs will never change, though they may be supplanted in the future.
-#[allow(non_camel_case_types, non_snake_case)]
-mod bindings {
-    pub const INFINITE: u32 = 4294967295;
-    pub const INVALID_HANDLE_VALUE: isize = -1;
-    pub type HANDLE = isize;
-
-    pub type FILE_ACCESS_FLAGS = u32;
-    pub const FILE_LIST_DIRECTORY: FILE_ACCESS_FLAGS = 1;
-
-    pub type FILE_SHARE_MODE = u32;
-    pub const FILE_SHARE_DELETE: FILE_SHARE_MODE = 4;
-    pub const FILE_SHARE_READ: FILE_SHARE_MODE = 1;
-    pub const FILE_SHARE_WRITE: FILE_SHARE_MODE = 2;
-
-    pub type BOOL = i32;
-
-    #[repr(C)]
-    pub struct SECURITY_ATTRIBUTES {
-        pub nLength: u32,
-        pub lpSecurityDescriptor: *mut std::ffi::c_void,
-        pub bInheritHandle: BOOL,
-    }
-
-    pub type FILE_CREATION_DISPOSITION = u32;
-    pub const OPEN_EXISTING: FILE_CREATION_DISPOSITION = 3;
-
-    pub type FILE_FLAGS_AND_ATTRIBUTES = u32;
-    pub const FILE_FLAG_OVERLAPPED: FILE_FLAGS_AND_ATTRIBUTES = 1073741824;
-    pub const FILE_FLAG_BACKUP_SEMANTICS: FILE_FLAGS_AND_ATTRIBUTES = 33554432;
-
-    pub type FILE_NOTIFY_CHANGE = u32;
-    pub const FILE_NOTIFY_CHANGE_FILE_NAME: FILE_NOTIFY_CHANGE = 1;
-    pub const FILE_NOTIFY_CHANGE_DIR_NAME: FILE_NOTIFY_CHANGE = 2;
-    pub const FILE_NOTIFY_CHANGE_ATTRIBUTES: FILE_NOTIFY_CHANGE = 4;
-    pub const FILE_NOTIFY_CHANGE_SIZE: FILE_NOTIFY_CHANGE = 8;
-    pub const FILE_NOTIFY_CHANGE_LAST_WRITE: FILE_NOTIFY_CHANGE = 16;
-    pub const FILE_NOTIFY_CHANGE_CREATION: FILE_NOTIFY_CHANGE = 64;
-    pub const FILE_NOTIFY_CHANGE_SECURITY: FILE_NOTIFY_CHANGE = 256;
-
-    #[repr(C)]
-    pub struct OVERLAPPED_0_0 {
-        pub Offset: u32,
-        pub OffsetHigh: u32,
-    }
-    #[repr(C)]
-    pub union OVERLAPPED_0 {
-        pub Anonymous: std::mem::ManuallyDrop<OVERLAPPED_0_0>,
-        pub Pointer: *mut std::ffi::c_void,
-    }
-    #[repr(C)]
-    pub struct OVERLAPPED {
-        pub Internal: usize,
-        pub InternalHigh: usize,
-        pub Anonymous: OVERLAPPED_0,
-        pub hEvent: HANDLE,
-    }
-    pub type LPOVERLAPPED_COMPLETION_ROUTINE = Option<
-        unsafe extern "system" fn(
-            dwErrorCode: u32,
-            dwNumberOfBytesTransfered: u32,
-            lpOverlapped: *mut OVERLAPPED,
-        ),
-    >;
-
-    pub type FILE_ACTION = u32;
-    pub const FILE_ACTION_ADDED: FILE_ACTION = 1;
-    pub const FILE_ACTION_REMOVED: FILE_ACTION = 2;
-    pub const FILE_ACTION_MODIFIED: FILE_ACTION = 3;
-    pub const FILE_ACTION_RENAMED_OLD_NAME: FILE_ACTION = 4;
-    pub const FILE_ACTION_RENAMED_NEW_NAME: FILE_ACTION = 5;
-
-    #[repr(C)]
-    pub struct FILE_NOTIFY_INFORMATION {
-        pub NextEntryOffset: u32,
-        pub Action: FILE_ACTION,
-        pub FileNameLength: u32,
-        pub FileName: [u16; 1],
-    }
-
-    pub type WIN32_ERROR = u32;
-    pub const WAIT_OBJECT_0: WIN32_ERROR = 0;
-    pub const ERROR_OPERATION_ABORTED: WIN32_ERROR = 995;
-
-    #[link(name = "kernel32")]
-    extern "system" {
-        pub fn CreateFileW(
-            lpFileName: *const u16,
-            dwDesiredAccess: FILE_ACCESS_FLAGS,
-            dwShareMode: FILE_SHARE_MODE,
-            lpSecurityAttributes: *const SECURITY_ATTRIBUTES,
-            dwCreationDisposition: FILE_CREATION_DISPOSITION,
-            dwFlagsAndAttributes: FILE_FLAGS_AND_ATTRIBUTES,
-            hTemplateFile: HANDLE,
-        ) -> HANDLE;
-        pub fn ReadDirectoryChangesW(
-            hDirectory: HANDLE,
-            lpBuffer: *mut std::ffi::c_void,
-            nBufferLength: u32,
-            bWatchSubtree: BOOL,
-            dwNotifyFilter: FILE_NOTIFY_CHANGE,
-            lpBytesReturned: *mut u32,
-            lpOverlapped: *mut OVERLAPPED,
-            lpCompletionRoutine: LPOVERLAPPED_COMPLETION_ROUTINE,
-        ) -> BOOL;
-        pub fn CloseHandle(hObject: HANDLE) -> BOOL;
-        pub fn CancelIo(hFile: HANDLE) -> BOOL;
-        pub fn CreateSemaphoreW(
-            lpSemaphoreAttributes: *const SECURITY_ATTRIBUTES,
-            lInitialCount: i32,
-            lMaximumCount: i32,
-            lpName: *const u16,
-        ) -> HANDLE;
-        pub fn ReleaseSemaphore(
-            hSemaphore: HANDLE,
-            lReleaseCount: i32,
-            lpPreviousCount: *mut i32,
-        ) -> BOOL;
-        pub fn WaitForSingleObjectEx(
-            hHandle: HANDLE,
-            dwMilliseconds: u32,
-            bAlertable: BOOL,
-        ) -> WIN32_ERROR;
-    }
+#[cfg(all(feature = "windows-sys", not(feature = "slim_windows")))]
+mod sys {
+    pub use windows_sys::Win32::Foundation::{
+        CloseHandle, ERROR_OPERATION_ABORTED, HANDLE, INVALID_HANDLE_VALUE, WAIT_OBJECT_0,
+    };
+    pub use windows_sys::Win32::Storage::FileSystem::{
+        CreateFileW, ReadDirectoryChangesW, FILE_ACTION_ADDED, FILE_ACTION_MODIFIED,
+        FILE_ACTION_REMOVED, FILE_ACTION_RENAMED_NEW_NAME, FILE_ACTION_RENAMED_OLD_NAME,
+        FILE_FLAG_BACKUP_SEMANTICS, FILE_FLAG_OVERLAPPED, FILE_LIST_DIRECTORY,
+        FILE_NOTIFY_CHANGE_ATTRIBUTES, FILE_NOTIFY_CHANGE_CREATION, FILE_NOTIFY_CHANGE_DIR_NAME,
+        FILE_NOTIFY_CHANGE_FILE_NAME, FILE_NOTIFY_CHANGE_LAST_WRITE, FILE_NOTIFY_CHANGE_SECURITY,
+        FILE_NOTIFY_CHANGE_SIZE, FILE_NOTIFY_INFORMATION, FILE_SHARE_DELETE, FILE_SHARE_READ,
+        FILE_SHARE_WRITE, OPEN_EXISTING,
+    };
+    pub use windows_sys::Win32::System::Threading::{
+        CreateSemaphoreW, ReleaseSemaphore, WaitForSingleObjectEx,
+    };
+    pub use windows_sys::Win32::System::WindowsProgramming::INFINITE;
+    pub use windows_sys::Win32::System::IO::{CancelIo, OVERLAPPED};
 }
+#[cfg(all(feature = "windows-sys", not(feature = "slim_windows")))]
+use sys::*;
 
+#[cfg(any(not(feature = "windows-sys"), feature = "slim_windows"))]
+mod bindings;
+#[cfg(any(not(feature = "windows-sys"), feature = "slim_windows"))]
 use bindings::*;
 
 const BUF_SIZE: u32 = 16384;

--- a/notify/src/windows/bindings.rs
+++ b/notify/src/windows/bindings.rs
@@ -1,0 +1,129 @@
+#![allow(non_camel_case_types, non_snake_case)]
+
+//! We do our own minimal bindings to the win32 API here with only the things we
+//! need. This means we can avoid a dependency on the `windows-sys` crate and its
+//! version churn, and the `winapi` due to its maintenance status.
+//!
+//! These APIs will never change, though they may be supplanted in the future.
+
+pub const INFINITE: u32 = 4294967295;
+pub const INVALID_HANDLE_VALUE: isize = -1;
+pub type HANDLE = isize;
+
+pub type FILE_ACCESS_FLAGS = u32;
+pub const FILE_LIST_DIRECTORY: FILE_ACCESS_FLAGS = 1;
+
+pub type FILE_SHARE_MODE = u32;
+pub const FILE_SHARE_DELETE: FILE_SHARE_MODE = 4;
+pub const FILE_SHARE_READ: FILE_SHARE_MODE = 1;
+pub const FILE_SHARE_WRITE: FILE_SHARE_MODE = 2;
+
+pub type BOOL = i32;
+
+#[repr(C)]
+pub struct SECURITY_ATTRIBUTES {
+    pub nLength: u32,
+    pub lpSecurityDescriptor: *mut std::ffi::c_void,
+    pub bInheritHandle: BOOL,
+}
+
+pub type FILE_CREATION_DISPOSITION = u32;
+pub const OPEN_EXISTING: FILE_CREATION_DISPOSITION = 3;
+
+pub type FILE_FLAGS_AND_ATTRIBUTES = u32;
+pub const FILE_FLAG_OVERLAPPED: FILE_FLAGS_AND_ATTRIBUTES = 1073741824;
+pub const FILE_FLAG_BACKUP_SEMANTICS: FILE_FLAGS_AND_ATTRIBUTES = 33554432;
+
+pub type FILE_NOTIFY_CHANGE = u32;
+pub const FILE_NOTIFY_CHANGE_FILE_NAME: FILE_NOTIFY_CHANGE = 1;
+pub const FILE_NOTIFY_CHANGE_DIR_NAME: FILE_NOTIFY_CHANGE = 2;
+pub const FILE_NOTIFY_CHANGE_ATTRIBUTES: FILE_NOTIFY_CHANGE = 4;
+pub const FILE_NOTIFY_CHANGE_SIZE: FILE_NOTIFY_CHANGE = 8;
+pub const FILE_NOTIFY_CHANGE_LAST_WRITE: FILE_NOTIFY_CHANGE = 16;
+pub const FILE_NOTIFY_CHANGE_CREATION: FILE_NOTIFY_CHANGE = 64;
+pub const FILE_NOTIFY_CHANGE_SECURITY: FILE_NOTIFY_CHANGE = 256;
+
+#[repr(C)]
+pub struct OVERLAPPED_0_0 {
+    pub Offset: u32,
+    pub OffsetHigh: u32,
+}
+#[repr(C)]
+pub union OVERLAPPED_0 {
+    pub Anonymous: std::mem::ManuallyDrop<OVERLAPPED_0_0>,
+    pub Pointer: *mut std::ffi::c_void,
+}
+#[repr(C)]
+pub struct OVERLAPPED {
+    pub Internal: usize,
+    pub InternalHigh: usize,
+    pub Anonymous: OVERLAPPED_0,
+    pub hEvent: HANDLE,
+}
+pub type LPOVERLAPPED_COMPLETION_ROUTINE = Option<
+    unsafe extern "system" fn(
+        dwErrorCode: u32,
+        dwNumberOfBytesTransfered: u32,
+        lpOverlapped: *mut OVERLAPPED,
+    ),
+>;
+
+pub type FILE_ACTION = u32;
+pub const FILE_ACTION_ADDED: FILE_ACTION = 1;
+pub const FILE_ACTION_REMOVED: FILE_ACTION = 2;
+pub const FILE_ACTION_MODIFIED: FILE_ACTION = 3;
+pub const FILE_ACTION_RENAMED_OLD_NAME: FILE_ACTION = 4;
+pub const FILE_ACTION_RENAMED_NEW_NAME: FILE_ACTION = 5;
+
+#[repr(C)]
+pub struct FILE_NOTIFY_INFORMATION {
+    pub NextEntryOffset: u32,
+    pub Action: FILE_ACTION,
+    pub FileNameLength: u32,
+    pub FileName: [u16; 1],
+}
+
+pub type WIN32_ERROR = u32;
+pub const WAIT_OBJECT_0: WIN32_ERROR = 0;
+pub const ERROR_OPERATION_ABORTED: WIN32_ERROR = 995;
+
+#[link(name = "kernel32")]
+extern "system" {
+    pub fn CreateFileW(
+        lpFileName: *const u16,
+        dwDesiredAccess: FILE_ACCESS_FLAGS,
+        dwShareMode: FILE_SHARE_MODE,
+        lpSecurityAttributes: *const SECURITY_ATTRIBUTES,
+        dwCreationDisposition: FILE_CREATION_DISPOSITION,
+        dwFlagsAndAttributes: FILE_FLAGS_AND_ATTRIBUTES,
+        hTemplateFile: HANDLE,
+    ) -> HANDLE;
+    pub fn ReadDirectoryChangesW(
+        hDirectory: HANDLE,
+        lpBuffer: *mut std::ffi::c_void,
+        nBufferLength: u32,
+        bWatchSubtree: BOOL,
+        dwNotifyFilter: FILE_NOTIFY_CHANGE,
+        lpBytesReturned: *mut u32,
+        lpOverlapped: *mut OVERLAPPED,
+        lpCompletionRoutine: LPOVERLAPPED_COMPLETION_ROUTINE,
+    ) -> BOOL;
+    pub fn CloseHandle(hObject: HANDLE) -> BOOL;
+    pub fn CancelIo(hFile: HANDLE) -> BOOL;
+    pub fn CreateSemaphoreW(
+        lpSemaphoreAttributes: *const SECURITY_ATTRIBUTES,
+        lInitialCount: i32,
+        lMaximumCount: i32,
+        lpName: *const u16,
+    ) -> HANDLE;
+    pub fn ReleaseSemaphore(
+        hSemaphore: HANDLE,
+        lReleaseCount: i32,
+        lpPreviousCount: *mut i32,
+    ) -> BOOL;
+    pub fn WaitForSingleObjectEx(
+        hHandle: HANDLE,
+        dwMilliseconds: u32,
+        bAlertable: BOOL,
+    ) -> WIN32_ERROR;
+}


### PR DESCRIPTION
This replaces the dependency on `windows-sys` with manual bindings to the win32 functionality used by this crate.

The rationale for this change is that these bindings will **never meaningfully change** so it doesn't make sense to use an external dependency, especially in light of https://github.com/microsoft/windows-rs/issues/1720, which is why the currently published version of this crate actually ends up pulling in 2 version of windows-sys since the published version depends on 0.42, but the mio dependency uses 0.45. And as shown in #472, the minor version changes in windows-sys are noise, and only meaningful in the negative impact.