### PR TITLE
Add `DebouncedEvent` to debouncer-full

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 v5 maintenance branch is on `v5_maintenance` after `5.2.0`  
 v4 commits split out to branch `v4_maintenance` starting with `4.0.16`
 
+## debouncer-full 0.2.0
+
+- CHANGE: emit events as `DebouncedEvent`s, each containing the original notify event and the time at which it occurred [#488]
+
 ## notify 6.0.0 (2023-05-17)
 
 - CHANGE: files and directories moved into a watch folder on Linux will now be reported as `rename to` events instead of `create` events [#480]

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 [dev-dependencies]
 notify = { version = "6.0.0", path = "../notify" }
 notify-debouncer-mini = { version = "0.3.0", path = "../notify-debouncer-mini" }
-notify-debouncer-full = { version = "0.1.0", path = "../notify-debouncer-full" }
+notify-debouncer-full = { version = "0.2.0", path = "../notify-debouncer-full" }
 futures = "0.3"
 tempfile = "3.5.0"
 

--- a/notify-debouncer-full/Cargo.toml
+++ b/notify-debouncer-full/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "notify-debouncer-full"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 rust-version = "1.60"
 description = "notify event debouncer optimized for ease of use"
@@ -26,7 +26,6 @@ crossbeam = ["crossbeam-channel","notify/crossbeam-channel"]
 [dependencies]
 notify = { version = "6.0.0", path = "../notify" }
 crossbeam-channel = { version = "0.5", optional = true }
-serde = { version = "1.0.89", features = ["derive"], optional = true }
 file-id = { version = "0.1.0", path = "../file-id" }
 walkdir = "2.2.2"
 parking_lot = "0.12.1"

--- a/notify-debouncer-full/README.md
+++ b/notify-debouncer-full/README.md
@@ -6,6 +6,7 @@ A debouncer for [notify] that is optimized for ease of use.
 
 * Only emits a single `Rename` event if the rename `From` and `To` events can be matched
 * Merges multiple `Rename` events
+* Takes `Rename` events into account and updates paths for events that occurred before the rename event, but which haven't been emitted, yet
 * Optionally keeps track of the file system IDs all files and stiches rename events together (FSevents, Windows)
 * Emits only one `Remove` event when deleting a directory (inotify)
 * Doesn't emit duplicate create events
@@ -23,8 +24,6 @@ A debouncer for [notify] that is optimized for ease of use.
   ```
   
   This also passes through to notify as `crossbeam-channel` feature.
-
-- `serde` for serde support of event types, off by default
 
 [docs]: https://docs.rs/notify-debouncer-full
 [notify]: https://crates.io/crates/notify

--- a/notify-debouncer-full/src/debounced_event.rs
+++ b/notify-debouncer-full/src/debounced_event.rs
@@ -1,0 +1,57 @@
+use std::ops::{Deref, DerefMut};
+
+#[cfg(test)]
+use mock_instant::Instant;
+
+#[cfg(not(test))]
+use std::time::Instant;
+
+use notify::Event;
+
+/// A debounced event is emitted after a short delay.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DebouncedEvent {
+    /// The original event.
+    pub event: Event,
+
+    /// The time at which the event occurred.
+    pub time: Instant,
+}
+
+impl DebouncedEvent {
+    pub fn new(event: Event, time: Instant) -> Self {
+        Self { event, time }
+    }
+}
+
+impl Deref for DebouncedEvent {
+    type Target = Event;
+
+    fn deref(&self) -> &Self::Target {
+        &self.event
+    }
+}
+
+impl DerefMut for DebouncedEvent {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.event
+    }
+}
+
+impl Default for DebouncedEvent {
+    fn default() -> Self {
+        Self {
+            event: Default::default(),
+            time: Instant::now(),
+        }
+    }
+}
+
+impl From<Event> for DebouncedEvent {
+    fn from(event: Event) -> Self {
+        Self {
+            event,
+            time: Instant::now(),
+        }
+    }
+}

--- a/notify-debouncer-full/test_cases/add_rename_from_and_to_event_after_rename.hjson
+++ b/notify-debouncer-full/test_cases/add_rename_from_and_to_event_after_rename.hjson
@@ -3,20 +3,20 @@
         queues: {
             /watch/temp: {
                 events: [
-                    { kind: "rename-both", paths: ["/watch/source", "/watch/temp"], tracker: 1, ts: 1 }
+                    { kind: "rename-both", paths: ["/watch/source", "/watch/temp"], tracker: 1, time: 1 }
                 ]
             }
         }
     }
     events: [
-        { kind: "rename-from", paths: ["/watch/temp"], tracker: 2, ts: 2 }
-        { kind: "rename-to", paths: ["/watch/target"], tracker: 2, ts: 3 }
+        { kind: "rename-from", paths: ["/watch/temp"], tracker: 2, time: 2 }
+        { kind: "rename-to", paths: ["/watch/target"], tracker: 2, time: 3 }
     ]
     expected: {
         queues: {
             /watch/target: {
                 events: [
-                    { kind: "rename-both", paths: ["/watch/source", "/watch/target"], tracker: 2, ts: 1 }
+                    { kind: "rename-both", paths: ["/watch/source", "/watch/target"], tracker: 2, time: 1 }
                 ]
             }
         }

--- a/notify-debouncer-full/test_cases/emit_close_events_only_once.hjson
+++ b/notify-debouncer-full/test_cases/emit_close_events_only_once.hjson
@@ -1,27 +1,27 @@
 {
     state: {}
     events: [
-        { kind: "modify-data-any", paths: ["/watch/file"], ts: 1 }
-        { kind: "access-close-write", paths: ["/watch/file"], ts: 2 }
-        { kind: "modify-data-any", paths: ["/watch/file"], ts: 3 }
-        { kind: "access-close-write", paths: ["/watch/file"], ts: 4 }
+        { kind: "modify-data-any", paths: ["/watch/file"], time: 1 }
+        { kind: "access-close-write", paths: ["/watch/file"], time: 2 }
+        { kind: "modify-data-any", paths: ["/watch/file"], time: 3 }
+        { kind: "access-close-write", paths: ["/watch/file"], time: 4 }
     ]
     expected: {
         queues: {
             /watch/file: {
                 events: [
-                    { kind: "modify-data-any", paths: ["*"], ts: 1 }
-                    { kind: "access-close-write", paths: ["*"], ts: 2 }
-                    { kind: "modify-data-any", paths: ["*"], ts: 3 }
-                    { kind: "access-close-write", paths: ["*"], ts: 4 }
+                    { kind: "modify-data-any", paths: ["*"], time: 1 }
+                    { kind: "access-close-write", paths: ["*"], time: 2 }
+                    { kind: "modify-data-any", paths: ["*"], time: 3 }
+                    { kind: "access-close-write", paths: ["*"], time: 4 }
                 ]
             }
         }
         events: {
             short: []
             long: [
-                { kind: "modify-data-any", paths: ["/watch/file"], ts: 3 }
-                { kind: "access-close-write", paths: ["/watch/file"], ts: 4 }
+                { kind: "modify-data-any", paths: ["/watch/file"], time: 3 }
+                { kind: "access-close-write", paths: ["/watch/file"], time: 4 }
             ]
         }
     }

--- a/notify-debouncer-full/test_cases/emit_continuous_modify_content_events.hjson
+++ b/notify-debouncer-full/test_cases/emit_continuous_modify_content_events.hjson
@@ -3,17 +3,17 @@
         timeout: 5
     }
     events: [
-        { kind: "modify-data-content", paths: ["/watch/file"], ts: 1 }
-        { kind: "modify-data-content", paths: ["/watch/file"], ts: 2 }
-        { kind: "modify-data-content", paths: ["/watch/file"], ts: 3 }
+        { kind: "modify-data-content", paths: ["/watch/file"], time: 1 }
+        { kind: "modify-data-content", paths: ["/watch/file"], time: 2 }
+        { kind: "modify-data-content", paths: ["/watch/file"], time: 3 }
     ]
     expected: {
         queues: {
             /watch/file: {
                 events: [
-                    { kind: "modify-data-content", paths: ["*"], ts: 1 }
-                    { kind: "modify-data-content", paths: ["*"], ts: 2 }
-                    { kind: "modify-data-content", paths: ["*"], ts: 3 }
+                    { kind: "modify-data-content", paths: ["*"], time: 1 }
+                    { kind: "modify-data-content", paths: ["*"], time: 2 }
+                    { kind: "modify-data-content", paths: ["*"], time: 3 }
                 ]
             }
         }
@@ -24,25 +24,25 @@
             4: []
             5: []
             6: [
-                { kind: "modify-data-content", paths: ["/watch/file"] }
+                { kind: "modify-data-content", paths: ["/watch/file"], time: 1 }
             ]
             7: [
-                { kind: "modify-data-content", paths: ["/watch/file"] }
+                { kind: "modify-data-content", paths: ["/watch/file"], time: 2 }
             ]
             8: [
-                { kind: "modify-data-content", paths: ["/watch/file"] }
+                { kind: "modify-data-content", paths: ["/watch/file"], time: 3 }
             ]
             9: [
-                { kind: "modify-data-content", paths: ["/watch/file"] }
+                { kind: "modify-data-content", paths: ["/watch/file"], time: 3 }
             ]
             10: [
-                { kind: "modify-data-content", paths: ["/watch/file"] }
+                { kind: "modify-data-content", paths: ["/watch/file"], time: 3 }
             ]
             100: [
-                { kind: "modify-data-content", paths: ["/watch/file"] }
+                { kind: "modify-data-content", paths: ["/watch/file"], time: 3 }
             ]
             1000: [
-                { kind: "modify-data-content", paths: ["/watch/file"] }
+                { kind: "modify-data-content", paths: ["/watch/file"], time: 3 }
             ]
         }
     }

--- a/notify-debouncer-full/test_cases/emit_events_in_chronological_order.hjson
+++ b/notify-debouncer-full/test_cases/emit_events_in_chronological_order.hjson
@@ -3,42 +3,42 @@
         timeout: 5
     }
     events: [
-        { kind: "modify-data-content", paths: ["/watch/file-a"], ts: 1 }
-        { kind: "modify-data-content", paths: ["/watch/file-b"], ts: 3 }
-        { kind: "modify-data-content", paths: ["/watch/file-c"], ts: 4 }
-        { kind: "modify-metadata-write-time", paths: ["/watch/file-b"], ts: 7 }
-        { kind: "modify-metadata-write-time", paths: ["/watch/file-c"], ts: 8 }
-        { kind: "modify-metadata-write-time", paths: ["/watch/file-a"], ts: 9 }
+        { kind: "modify-data-content", paths: ["/watch/file-a"], time: 1 }
+        { kind: "modify-data-content", paths: ["/watch/file-b"], time: 3 }
+        { kind: "modify-data-content", paths: ["/watch/file-c"], time: 4 }
+        { kind: "modify-metadata-write-time", paths: ["/watch/file-b"], time: 7 }
+        { kind: "modify-metadata-write-time", paths: ["/watch/file-c"], time: 8 }
+        { kind: "modify-metadata-write-time", paths: ["/watch/file-a"], time: 9 }
     ]
     expected: {
         queues: {
             /watch/file-a: {
                 events: [
-                    { kind: "modify-data-content", paths: ["*"], ts: 1 }
-                    { kind: "modify-metadata-write-time", paths: ["*"], ts: 9 }
+                    { kind: "modify-data-content", paths: ["*"], time: 1 }
+                    { kind: "modify-metadata-write-time", paths: ["*"], time: 9 }
                 ]
             }
             /watch/file-b: {
                 events: [
-                    { kind: "modify-data-content", paths: ["*"], ts: 3 }
-                    { kind: "modify-metadata-write-time", paths: ["*"], ts: 7 }
+                    { kind: "modify-data-content", paths: ["*"], time: 3 }
+                    { kind: "modify-metadata-write-time", paths: ["*"], time: 7 }
                 ]
             }
             /watch/file-c: {
                 events: [
-                    { kind: "modify-data-content", paths: ["*"], ts: 4 }
-                    { kind: "modify-metadata-write-time", paths: ["*"], ts: 8 }
+                    { kind: "modify-data-content", paths: ["*"], time: 4 }
+                    { kind: "modify-metadata-write-time", paths: ["*"], time: 8 }
                 ]
             }
         }
         events: {
             long: [
-                { kind: "modify-data-content", paths: ["/watch/file-a"] }
-                { kind: "modify-data-content", paths: ["/watch/file-b"] }
-                { kind: "modify-data-content", paths: ["/watch/file-c"] }
-                { kind: "modify-metadata-write-time", paths: ["/watch/file-b"] }
-                { kind: "modify-metadata-write-time", paths: ["/watch/file-c"] }
-                { kind: "modify-metadata-write-time", paths: ["/watch/file-a"] }
+                { kind: "modify-data-content", paths: ["/watch/file-a"], time: 1 }
+                { kind: "modify-data-content", paths: ["/watch/file-b"], time: 3 }
+                { kind: "modify-data-content", paths: ["/watch/file-c"], time: 4 }
+                { kind: "modify-metadata-write-time", paths: ["/watch/file-b"], time: 7 }
+                { kind: "modify-metadata-write-time", paths: ["/watch/file-c"], time: 8 }
+                { kind: "modify-metadata-write-time", paths: ["/watch/file-a"], time: 9 }
             ]
         }
     }

--- a/notify-debouncer-full/test_cases/emit_events_with_a_prepended_rename_event.hjson
+++ b/notify-debouncer-full/test_cases/emit_events_with_a_prepended_rename_event.hjson
@@ -3,33 +3,33 @@
         timeout: 5
     }
     events: [
-        { kind: "modify-data-content", paths: ["/watch/source"], ts: 1 }
-        { kind: "modify-data-content", paths: ["/watch/source"], ts: 4 }
-        { kind: "rename-from", paths: ["/watch/source"], tracker: 1, ts: 7 }
-        { kind: "rename-to", paths: ["/watch/target"], tracker: 1, ts: 8 }
-        { kind: "modify-metadata-write-time", paths: ["/watch/target"], ts: 9 }
+        { kind: "modify-data-content", paths: ["/watch/source"], time: 1 }
+        { kind: "modify-data-content", paths: ["/watch/source"], time: 4 }
+        { kind: "rename-from", paths: ["/watch/source"], tracker: 1, time: 7 }
+        { kind: "rename-to", paths: ["/watch/target"], tracker: 1, time: 8 }
+        { kind: "modify-metadata-write-time", paths: ["/watch/target"], time: 9 }
     ]
     expected: {
         queues: {
             /watch/target: {
                 events: [
-                    { kind: "rename-both", paths: ["/watch/source", "/watch/target"], tracker: 1, ts: 7 }
-                    { kind: "modify-data-content", paths: ["*"], ts: 1 }
-                    { kind: "modify-data-content", paths: ["*"], ts: 4 }
-                    { kind: "modify-metadata-write-time", paths: ["*"], ts: 9 }
+                    { kind: "rename-both", paths: ["/watch/source", "/watch/target"], tracker: 1, time: 7 }
+                    { kind: "modify-data-content", paths: ["*"], time: 1 }
+                    { kind: "modify-data-content", paths: ["*"], time: 4 }
+                    { kind: "modify-metadata-write-time", paths: ["*"], time: 9 }
                 ]
             }
         }
         events: {
             11: []
             12: [
-                { kind: "rename-both", paths: ["/watch/source", "/watch/target"], tracker: 1, ts: 7 }
-                { kind: "modify-data-content", paths: ["/watch/target"], ts: 1 }
+                { kind: "rename-both", paths: ["/watch/source", "/watch/target"], tracker: 1, time: 7 }
+                { kind: "modify-data-content", paths: ["/watch/target"], time: 4 }
             ]
             14: [
-                { kind: "rename-both", paths: ["/watch/source", "/watch/target"], tracker: 1, ts: 7 }
-                { kind: "modify-data-content", paths: ["/watch/target"], ts: 1 }
-                { kind: "modify-metadata-write-time", paths: ["/watch/target"], ts: 9 }
+                { kind: "rename-both", paths: ["/watch/source", "/watch/target"], tracker: 1, time: 7 }
+                { kind: "modify-data-content", paths: ["/watch/target"], time: 4 }
+                { kind: "modify-metadata-write-time", paths: ["/watch/target"], time: 9 }
             ]
         }
     }

--- a/notify-debouncer-full/test_cases/emit_modify_event_after_close_event.hjson
+++ b/notify-debouncer-full/test_cases/emit_modify_event_after_close_event.hjson
@@ -1,29 +1,29 @@
 {
     state: {}
     events: [
-        { kind: "modify-data-any", paths: ["/watch/file"], ts: 1 }
-        { kind: "access-close-write", paths: ["/watch/file"], ts: 2 }
-        { kind: "modify-data-any", paths: ["/watch/file"], ts: 3 }
-        { kind: "access-close-write", paths: ["/watch/file"], ts: 4 }
-        { kind: "modify-data-any", paths: ["/watch/file"], ts: 5 }
+        { kind: "modify-data-any", paths: ["/watch/file"], time: 1 }
+        { kind: "access-close-write", paths: ["/watch/file"], time: 2 }
+        { kind: "modify-data-any", paths: ["/watch/file"], time: 3 }
+        { kind: "access-close-write", paths: ["/watch/file"], time: 4 }
+        { kind: "modify-data-any", paths: ["/watch/file"], time: 5 }
     ]
     expected: {
         queues: {
             /watch/file: {
                 events: [
-                    { kind: "modify-data-any", paths: ["*"], ts: 1 }
-                    { kind: "access-close-write", paths: ["*"], ts: 2 }
-                    { kind: "modify-data-any", paths: ["*"], ts: 3 }
-                    { kind: "access-close-write", paths: ["*"], ts: 4 }
-                    { kind: "modify-data-any", paths: ["*"], ts: 5 }
+                    { kind: "modify-data-any", paths: ["*"], time: 1 }
+                    { kind: "access-close-write", paths: ["*"], time: 2 }
+                    { kind: "modify-data-any", paths: ["*"], time: 3 }
+                    { kind: "access-close-write", paths: ["*"], time: 4 }
+                    { kind: "modify-data-any", paths: ["*"], time: 5 }
                 ]
             }
         }
         events: {
             short: []
             long: [
-                { kind: "access-close-write", paths: ["/watch/file"], ts: 4 }
-                { kind: "modify-data-any", paths: ["/watch/file"], ts: 5 }
+                { kind: "access-close-write", paths: ["/watch/file"], time: 4 }
+                { kind: "modify-data-any", paths: ["/watch/file"], time: 5 }
             ]
         }
     }

--- a/notify-debouncer-full/test_cases/emit_needs_rescan_event.hjson
+++ b/notify-debouncer-full/test_cases/emit_needs_rescan_event.hjson
@@ -3,12 +3,12 @@
         queues: {
             /watch/file-a: {
                 events: [
-                    { kind: "create-any", paths: ["*"], ts: 1 }
+                    { kind: "create-any", paths: ["*"], time: 1 }
                 ]
             }
             /watch/file-b: {
                 events: [
-                    { kind: "create-any", paths: ["*"], ts: 2 }
+                    { kind: "create-any", paths: ["*"], time: 2 }
                 ]
             }
         }
@@ -23,22 +23,22 @@
         }
     }
     events: [
-        { kind: "other", flags: ["rescan"], ts: 3 }
+        { kind: "other", flags: ["rescan"], time: 3 }
     ]
     expected: {
         queues: {
             /watch/file-a: {
                 events: [
-                    { kind: "create-any", paths: ["*"], ts: 1 }
+                    { kind: "create-any", paths: ["*"], time: 1 }
                 ]
             }
             /watch/file-b: {
                 events: [
-                    { kind: "create-any", paths: ["*"], ts: 2 }
+                    { kind: "create-any", paths: ["*"], time: 2 }
                 ]
             }
         }
-        rescan_event: { kind: "other", flags: ["rescan"], ts: 3 }
+        rescan_event: { kind: "other", flags: ["rescan"], time: 3 }
         cache: {
             /watch/file-a: 1
             /watch/file-b: 2
@@ -47,9 +47,9 @@
         events: {
             short: []
             long: [
-                { kind: "create-any", paths: ["/watch/file-a"], ts: 1 }
-                { kind: "create-any", paths: ["/watch/file-b"], ts: 2 }
-                { kind: "other", flags: ["rescan"], ts: 3 }
+                { kind: "create-any", paths: ["/watch/file-a"], time: 1 }
+                { kind: "create-any", paths: ["/watch/file-b"], time: 2 }
+                { kind: "other", flags: ["rescan"], time: 3 }
             ]
         }
     }


### PR DESCRIPTION
Emit events in the debouncer-full as `DebouncedEvent`s, each containing the original notify event and the time at which it occurred.

Having access to the time at which the event occurred is useful when handling situations in which the application writes to the file system and has to ignore the resulting events within a certain time frame.