### PR TITLE
prepare notify 6.0.1 and debouncer-full 0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ v4 commits split out to branch `v4_maintenance` starting with `4.0.16`
 
 - CHANGE: emit events as `DebouncedEvent`s, each containing the original notify event and the time at which it occurred [#488]
 
+[#488]: https://github.com/notify-rs/notify/pull/488
+
 ## notify 6.0.0 (2023-05-17)
 
 - CHANGE: files and directories moved into a watch folder on Linux will now be reported as `rename to` events instead of `create` events [#480]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,13 @@
 v5 maintenance branch is on `v5_maintenance` after `5.2.0`  
 v4 commits split out to branch `v4_maintenance` starting with `4.0.16`
 
-## debouncer-full 0.2.0
+## notify 6.0.1 (2023-06-16)
+
+- DOCS: fix swapped debouncer-full / -mini links in the readme/crates.io [4be6bde]
+
+[4be6bde]: https://github.com/notify-rs/notify/commit/4be6bdef4fa7b260a3a56a11212ac074f8e39b39
+
+## debouncer-full 0.2.0 (2023-06-16)
 
 - CHANGE: emit events as `DebouncedEvent`s, each containing the original notify event and the time at which it occurred [#488]
 

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ Originally created by [Félix Saparelli] and awesome [contributors].
 [contributors]: https://github.com/notify-rs/notify/graphs/contributors
 [crate]: https://crates.io/crates/notify
 [docket]: https://iwillspeak.github.io/docket/
-[docs]: https://docs.rs/notify/6.0.0/notify/
+[docs]: https://docs.rs/notify/6.0.1/notify/
 [fsnotify]: https://github.com/go-fsnotify/fsnotify
 [handlebars-iron]: https://github.com/sunng87/handlebars-iron
 [hotwatch]: https://github.com/francesca64/hotwatch

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -5,7 +5,7 @@ publish = false
 edition = "2021"
 
 [dev-dependencies]
-notify = { version = "6.0.0", path = "../notify" }
+notify = { version = "6.0.1", path = "../notify" }
 notify-debouncer-mini = { version = "0.3.0", path = "../notify-debouncer-mini" }
 notify-debouncer-full = { version = "0.2.0", path = "../notify-debouncer-full" }
 futures = "0.3"

--- a/examples/async_monitor.rs
+++ b/examples/async_monitor.rs
@@ -2,7 +2,7 @@ use futures::{
     channel::mpsc::{channel, Receiver},
     SinkExt, StreamExt,
 };
-use notify::{Event, RecommendedWatcher, RecursiveMode, Watcher, Config};
+use notify::{Config, Event, RecommendedWatcher, RecursiveMode, Watcher};
 use std::path::Path;
 
 /// Async, futures channel based event watching
@@ -24,11 +24,14 @@ fn async_watcher() -> notify::Result<(RecommendedWatcher, Receiver<notify::Resul
 
     // Automatically select the best implementation for your platform.
     // You can also access each implementation directly e.g. INotifyWatcher.
-    let watcher = RecommendedWatcher::new(move |res| {
-        futures::executor::block_on(async {
-            tx.send(res).await.unwrap();
-        })
-    }, Config::default())?;
+    let watcher = RecommendedWatcher::new(
+        move |res| {
+            futures::executor::block_on(async {
+                tx.send(res).await.unwrap();
+            })
+        },
+        Config::default(),
+    )?;
 
     Ok((watcher, rx))
 }

--- a/examples/debouncer_mini_custom.rs
+++ b/examples/debouncer_mini_custom.rs
@@ -1,6 +1,6 @@
 use std::{path::Path, time::Duration};
 
-use notify::{RecursiveMode, Config};
+use notify::{Config, RecursiveMode};
 use notify_debouncer_mini::new_debouncer_opt;
 
 /// Debouncer with custom backend and waiting for exit
@@ -18,7 +18,13 @@ fn main() {
     // setup debouncer
     let (tx, rx) = std::sync::mpsc::channel();
     // select backend via fish operator, here PollWatcher backend
-    let mut debouncer = new_debouncer_opt::<_,notify::PollWatcher>(Duration::from_secs(2), None, tx, Config::default()).unwrap();
+    let mut debouncer = new_debouncer_opt::<_, notify::PollWatcher>(
+        Duration::from_secs(2),
+        None,
+        tx,
+        Config::default(),
+    )
+    .unwrap();
 
     debouncer
         .watcher()

--- a/examples/hot_reload_tide/Cargo.toml
+++ b/examples/hot_reload_tide/Cargo.toml
@@ -11,7 +11,7 @@ tide = "0.16.0"
 async-std = { version = "1.6.0", features = ["attributes"] }
 serde_json = "1.0"
 serde = "1.0.115"
-notify = { version = "6.0.0", features = ["serde"], path = "../../notify" }
+notify = { version = "6.0.1", features = ["serde"], path = "../../notify" }
 
 # required to prevent mixing with workspace
 # hack to prevent cargo audit from catching this

--- a/examples/monitor_raw.rs
+++ b/examples/monitor_raw.rs
@@ -1,4 +1,4 @@
-use notify::{RecommendedWatcher, RecursiveMode, Watcher, Config};
+use notify::{Config, RecommendedWatcher, RecursiveMode, Watcher};
 use std::path::Path;
 
 fn main() {

--- a/examples/poll_sysfs.rs
+++ b/examples/poll_sysfs.rs
@@ -3,7 +3,7 @@
 /// This example can't be demonstrated under windows, it might be relevant for network shares
 #[cfg(not(target_os = "windows"))]
 fn not_windows_main() -> notify::Result<()> {
-    use notify::{PollWatcher, RecursiveMode, Watcher, Config};
+    use notify::{Config, PollWatcher, RecursiveMode, Watcher};
     use std::path::Path;
     use std::time::Duration;
 
@@ -27,7 +27,7 @@ fn not_windows_main() -> notify::Result<()> {
     println!("watching {:?}...", paths);
     // configure pollwatcher backend
     let config = Config::default()
-        .with_compare_contents(true) // crucial part for pseudo filesystems 
+        .with_compare_contents(true) // crucial part for pseudo filesystems
         .with_poll_interval(Duration::from_secs(2));
     let (tx, rx) = std::sync::mpsc::channel();
     // create pollwatcher backend

--- a/examples/watcher_kind.rs
+++ b/examples/watcher_kind.rs
@@ -1,5 +1,5 @@
-use std::{path::Path, time::Duration};
 use notify::*;
+use std::{path::Path, time::Duration};
 
 // example of detecting the recommended watcher kind
 fn main() {
@@ -8,9 +8,8 @@ fn main() {
     // That way the pollwatcher specific stuff is still configured, if it should be used.
     let mut watcher: Box<dyn Watcher> = if RecommendedWatcher::kind() == WatcherKind::PollWatcher {
         // custom config for PollWatcher kind
-        // you 
-        let config = Config::default()
-            .with_poll_interval(Duration::from_secs(1));
+        // you
+        let config = Config::default().with_poll_interval(Duration::from_secs(1));
         Box::new(PollWatcher::new(tx, config).unwrap())
     } else {
         // use default config for everything else

--- a/file-id/src/lib.rs
+++ b/file-id/src/lib.rs
@@ -14,7 +14,7 @@
 //!
 //! println!("{file_id:?}");
 //! ```
-use std::{fs, io, path::Path};
+use std::{io, path::Path};
 
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
@@ -39,6 +39,7 @@ impl FileId {
 /// Get the `FileId` for the file at `path`
 #[cfg(target_family = "unix")]
 pub fn get_file_id(path: impl AsRef<Path>) -> io::Result<FileId> {
+    use std::fs;
     use std::os::unix::fs::MetadataExt;
 
     let metadata = fs::metadata(path.as_ref())?;

--- a/notify-debouncer-full/Cargo.toml
+++ b/notify-debouncer-full/Cargo.toml
@@ -24,7 +24,7 @@ default = ["crossbeam"]
 crossbeam = ["crossbeam-channel","notify/crossbeam-channel"]
 
 [dependencies]
-notify = { version = "6.0.0", path = "../notify" }
+notify = { version = "6.0.1", path = "../notify" }
 crossbeam-channel = { version = "0.5", optional = true }
 file-id = { version = "0.1.0", path = "../file-id" }
 walkdir = "2.2.2"

--- a/notify-debouncer-mini/Cargo.toml
+++ b/notify-debouncer-mini/Cargo.toml
@@ -24,6 +24,6 @@ default = ["crossbeam"]
 crossbeam = ["crossbeam-channel","notify/crossbeam-channel"]
 
 [dependencies]
-notify = { version = "6.0.0", path = "../notify" }
+notify = { version = "6.0.1", path = "../notify" }
 crossbeam-channel = { version = "0.5", optional = true }
 serde = { version = "1.0.89", features = ["derive"], optional = true }

--- a/notify/Cargo.toml
+++ b/notify/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "notify"
-version = "6.0.0"
+version = "6.0.1"
 rust-version = "1.60"
 description = "Cross-platform filesystem notification library"
 documentation = "https://docs.rs/notify"

--- a/notify/src/config.rs
+++ b/notify/src/config.rs
@@ -22,10 +22,10 @@ impl RecursiveMode {
 }
 
 /// Watcher Backend configuration
-/// 
+///
 /// This contains multiple settings that may relate to only one specific backend,
 /// such as to correctly configure each backend regardless of what is selected during runtime.
-/// 
+///
 /// ```rust
 /// # use std::time::Duration;
 /// # use notify::Config;
@@ -33,7 +33,7 @@ impl RecursiveMode {
 ///     .with_poll_interval(Duration::from_secs(2))
 ///     .with_compare_contents(true);
 /// ```
-/// 
+///
 /// Some options can be changed during runtime, others have to be set when creating the watcher backend.
 #[derive(Copy, Clone, PartialEq, Eq, Debug, Hash)]
 pub struct Config {
@@ -46,10 +46,10 @@ pub struct Config {
 
 impl Config {
     /// For [crate::PollWatcher]
-    /// 
+    ///
     /// Interval between each rescan attempt. This can be extremely expensive for large
     /// file trees so it is recommended to measure and tune accordingly.
-    /// 
+    ///
     /// The default poll frequency is 30 seconds.
     pub fn with_poll_interval(mut self, dur: Duration) -> Self {
         self.poll_interval = dur;
@@ -62,14 +62,14 @@ impl Config {
     }
 
     /// For [crate::PollWatcher]
-    /// 
+    ///
     /// Optional feature that will evaluate the contents of changed files to determine if
     /// they have indeed changed using a fast hashing algorithm.  This is especially important
     /// for pseudo filesystems like those on Linux under /sys and /proc which are not obligated
     /// to respect any other filesystem norms such as modification timestamps, file sizes, etc.
     /// By enabling this feature, performance will be significantly impacted as all files will
     /// need to be read and hashed at each `poll_interval`.
-    /// 
+    ///
     /// This can't be changed during runtime. Off by default.
     pub fn with_compare_contents(mut self, compare_contents: bool) -> Self {
         self.compare_contents = compare_contents;
@@ -84,9 +84,9 @@ impl Config {
 
 impl Default for Config {
     fn default() -> Self {
-        Self { 
+        Self {
             poll_interval: Duration::from_secs(30),
-            compare_contents: false
+            compare_contents: false,
         }
     }
 }

--- a/notify/src/lib.rs
+++ b/notify/src/lib.rs
@@ -4,7 +4,7 @@
 //!
 //! ```toml
 //! [dependencies]
-//! notify = "6.0.0"
+//! notify = "6.0.1"
 //! ```
 //!
 //! If you want debounced events, see [notify-debouncer-mini](https://github.com/notify-rs/notify/tree/main/notify-debouncer-mini)
@@ -24,7 +24,7 @@
 //! Events are serialisable via [serde](https://serde.rs) if the `serde` feature is enabled:
 //!
 //! ```toml
-//! notify = { version = "6.0.0", features = ["serde"] }
+//! notify = { version = "6.0.1", features = ["serde"] }
 //! ```
 //!
 //! ### Crossbeam-Channel & Tokio
@@ -35,7 +35,7 @@
 //! You can disable crossbeam-channel, letting notify fallback to std channels via
 //!
 //! ```toml
-//! notify = { version = "6.0.0", default-features = false, features = ["macos_kqueue"] }
+//! notify = { version = "6.0.1", default-features = false, features = ["macos_kqueue"] }
 //! // Alternatively macos_fsevent instead of macos_kqueue
 //! ```
 //! Note the `macos_kqueue` requirement here, otherwise no backend is available on macos.

--- a/notify/src/lib.rs
+++ b/notify/src/lib.rs
@@ -6,14 +6,14 @@
 //! [dependencies]
 //! notify = "6.0.0"
 //! ```
-//! 
+//!
 //! If you want debounced events, see [notify-debouncer-mini](https://github.com/notify-rs/notify/tree/main/notify-debouncer-mini)
 //! or [notify-debouncer-full](https://github.com/notify-rs/notify/tree/main/notify-debouncer-full).
-//! 
+//!
 //! ## Features
-//! 
+//!
 //! List of compilation features, see below for details
-//! 
+//!
 //! - `serde` for serialization of events
 //! - `macos_fsevent` enabled by default, for fsevent backend on macos
 //! - `macos_kqueue` for kqueue backend on macos
@@ -26,66 +26,66 @@
 //! ```toml
 //! notify = { version = "6.0.0", features = ["serde"] }
 //! ```
-//! 
+//!
 //! ### Crossbeam-Channel & Tokio
-//! 
+//!
 //! By default crossbeam-channel is used internally by notify.
 //! This can [cause issues](https://github.com/notify-rs/notify/issues/380) when used inside tokio.
-//! 
+//!
 //! You can disable crossbeam-channel, letting notify fallback to std channels via
-//! 
+//!
 //! ```toml
 //! notify = { version = "6.0.0", default-features = false, features = ["macos_kqueue"] }
 //! // Alternatively macos_fsevent instead of macos_kqueue
 //! ```
 //! Note the `macos_kqueue` requirement here, otherwise no backend is available on macos.
-//! 
+//!
 //! # Known Problems
-//! 
+//!
 //! ### Docker with Linux on MacOS M1
-//! 
+//!
 //! Docker on macos M1 [throws](https://github.com/notify-rs/notify/issues/423) `Function not implemented (os error 38)`.
 //! You have to manually use the [PollWatcher], as the native backend isn't available inside the emulation.
-//! 
+//!
 //! ### MacOS, FSEvents and unowned files
-//! 
+//!
 //! Due to the inner security model of FSEvents (see [FileSystemEventSecurity](https://developer.apple.com/library/mac/documentation/Darwin/Conceptual/FSEvents_ProgGuide/FileSystemEventSecurity/FileSystemEventSecurity.html)),
 //! some events cannot be observed easily when trying to follow files that do not
 //! belong to you. In this case, reverting to the pollwatcher can fix the issue,
 //! with a slight performance cost.
-//! 
+//!
 //! ### Editor Behaviour
-//! 
+//!
 //! If you rely on precise events (Write/Delete/Create..), you will notice that the actual events
 //! can differ a lot between file editors. Some truncate the file on save, some create a new one and replace the old one.
 //! See also [this](https://github.com/notify-rs/notify/issues/247) and [this](https://github.com/notify-rs/notify/issues/113#issuecomment-281836995) issues for example.
 //!
 //! ### Parent folder deletion
-//! 
+//!
 //! If you want to receive an event for a deletion of folder `b` for the path `/a/b/..`, you will have to watch its parent `/a`.
 //! See [here](https://github.com/notify-rs/notify/issues/403) for more details.
-//! 
+//!
 //! ### Pseudo Filesystems like /proc,/sys
-//! 
+//!
 //! Some filesystems like `/proc` and `/sys` on *nix do not emit change events or use correct file change dates.
 //! To circumvent that problem you can use the [PollWatcher] with the `compare_contents` option.
-//! 
+//!
 //! ### Linux: Bad File Descriptor / No space left on device
-//! 
+//!
 //! This may be the case of running into the max-files watched limits of your user or system.
 //! (Files also includes folders.) Note that for recursive watched folders each file and folder inside counts towards the limit.
-//! 
+//!
 //! You may increase this limit in linux via
 //! ```sh
 //! sudo sysctl fs.inotify.max_user_instances=8192 # example number
 //! sudo sysctl fs.inotify.max_user_watches=524288 # example number
 //! sudo sysctl -p
 //! ```
-//! 
+//!
 //! Note that the [PollWatcher] is not restricted by this limitation, so it may be an alternative if your users can't increase the limit.
-//! 
+//!
 //! # Examples
-//! 
+//!
 //! For more examples visit the [examples folder](https://github.com/notify-rs/notify/tree/main/examples) in the repository.
 //!
 //! ```rust,no_exec

--- a/notify/src/poll.rs
+++ b/notify/src/poll.rs
@@ -3,7 +3,7 @@
 //! Checks the `watch`ed paths periodically to detect changes. This implementation only uses
 //! Rust stdlib APIs and should work on all of the platforms it supports.
 
-use crate::{EventHandler, RecursiveMode, Watcher, Config};
+use crate::{Config, EventHandler, RecursiveMode, Watcher};
 use std::{
     collections::HashMap,
     path::{Path, PathBuf},
@@ -393,10 +393,10 @@ mod data {
 }
 
 /// Polling based `Watcher` implementation.
-/// 
+///
 /// By default scans through all files and checks for changed entries based on their change date.
 /// Can also be changed to perform file content change checks.
-/// 
+///
 /// See [Config] for more details.
 #[derive(Debug)]
 pub struct PollWatcher {
@@ -408,10 +408,7 @@ pub struct PollWatcher {
 
 impl PollWatcher {
     /// Create a new [PollWatcher], configured as needed.
-    pub fn new<F: EventHandler>(
-        event_handler: F,
-        config: Config,
-    ) -> crate::Result<PollWatcher> {
+    pub fn new<F: EventHandler>(event_handler: F, config: Config) -> crate::Result<PollWatcher> {
         let data_builder = DataBuilder::new(event_handler, config.compare_contents());
 
         let poll_watcher = PollWatcher {

--- a/release_checklist.md
+++ b/release_checklist.md
@@ -8,3 +8,4 @@ Specifically the notify version.
 - update notify/cargo.toml examples/Cargo.toml examples/hot_reload_tide/Cargo.toml
   - bump version number on the root Cargo.toml and examples
 - maybe update notify-debouncer-mini/Cargo.toml
+- maybe update notify-debouncer-full/Cargo.toml


### PR DESCRIPTION
<!-- By contributing, you agree to the terms of the license, available in the LICENSE.ARTISTIC file, and of the code of conduct, available in the CODE_OF_CONDUCT.md file. Furthermore, you agree to release under CC0, also available in the LICENSE file, until Notify has fully transitioned to Artistic 2.0. -->

<!-- After creating this pull request, the test suite will run.

It is expected that if any failures occur in the builds, you either:

- fix the errors,
- ask for help, or
- note that the failures are expected with a detailed explanation.

If you do not, a maintainer may prompt you and/or do it themselves, but do note that it will take longer for your contribution to be reviewed if the build does not pass.

Running `cargo fmt` and/or `cargo clippy` is NOT required but appreciated!

You can remove this text. -->
