### PR TITLE
fix moved directory not being watched

### DIFF
--- a/notify/src/inotify.rs
+++ b/notify/src/inotify.rs
@@ -254,14 +254,8 @@ impl EventLoop {
                                         .add_some_path(rename_event.paths.first().cloned())
                                         .add_some_path(path.clone()),
                                     );
-                                } else {
-                                    add_watch_by_event(
-                                        &path,
-                                        &event,
-                                        &self.watches,
-                                        &mut add_watches,
-                                    );
                                 }
+                                add_watch_by_event(&path, &event, &self.watches, &mut add_watches);
                             }
                             if event.mask.contains(EventMask::MOVE_SELF) {
                                 evs.push(


### PR DESCRIPTION
Fixes https://github.com/notify-rs/notify/issues/491

The bug was introduced in https://github.com/notify-rs/notify/commit/65d6d91ca1e97eeb548e41f8694513b280d49d0a#diff-9663de7aadbfa93d9f87e8c0dc5c94855e59fff314c091caa5478b666e404983R258-R264, which calls `add_watch_by_event` only if the trackers matched. 

Prior to https://github.com/notify-rs/notify/commit/65d6d91ca1e97eeb548e41f8694513b280d49d0a, `add_watch_by_event` was called so long as the `event.mask.contains(EventMask::MOVED_TO)` regardless of whether the trackers matched
https://github.com/notify-rs/notify/blob/29376adabb8477698465a3e454ffe6805824fce4/notify/src/inotify.rs#L252-L303