### PR TITLE
Update windows.rs

### DIFF
--- a/notify/src/windows.rs
+++ b/notify/src/windows.rs
@@ -278,7 +278,7 @@ fn start_read(rd: &ReadData, event_handler: Arc<Mutex<dyn EventHandler>>, handle
     };
 
     unsafe {
-        let mut overlapped: Box<OVERLAPPED> = Box::new(mem::zeroed());
+        let mut overlapped: Box<OVERLAPPED> = std::mem::ManuallyDrop::new(Box::new(mem::zeroed()));
         // When using callback based async requests, we are allowed to use the hEvent member
         // for our own purposes
 
@@ -305,9 +305,6 @@ fn start_read(rd: &ReadData, event_handler: Arc<Mutex<dyn EventHandler>>, handle
             let request: Box<ReadDirectoryRequest> = mem::transmute(request_p);
 
             ReleaseSemaphore(request.data.complete_sem, 1, ptr::null_mut());
-        } else {
-            // read ok. forget overlapped to let the completion routine handle memory
-            mem::forget(overlapped);
         }
     }
 }


### PR DESCRIPTION
Hi,
I found a memory-safety/soundness issue in this crate while scanning Rust code for potential vulnerabilities. This PR contains a fix for the issue.

# Issue Description
https://github.com/notify-rs/notify/blob/5f40b83c04b04893a42f91b55e4ceeef3777d47c/notify/src/windows.rs#L281-L310

If a panic!() occurs between the `Box::new()` function and `std::mem::forget`, a double free vulnerability emerges.

# Fix
In Rust, `std::mem::forget` does not actually free the memory, instead it simply allows the memory to leak. This can lead to double free when the data object goes out of scope and its destructor is called automatically. The modification here uses `std::mem::ManuallyDrop` to wrap data. This ensures that data will not be automatically dropped when it goes out of scope, thus avoiding a double free scenario. With `ManuallyDrop`, we explicitly state that the data variable should not be dropped, thus avoiding any potential double free issues.