### PR TITLE
Updated windows-sys crate to version 0.48.

### DIFF
--- a/notify/Cargo.toml
+++ b/notify/Cargo.toml
@@ -36,7 +36,7 @@ kqueue = { version = "1.0", optional = true }
 mio = { version = "0.8", features = ["os-ext"], optional = true }
 
 [target.'cfg(windows)'.dependencies]
-windows-sys = { version = "0.45.0", features = ["Win32_System_Threading", "Win32_Foundation", "Win32_Storage_FileSystem", "Win32_Security", "Win32_System_WindowsProgramming", "Win32_System_IO"] }
+windows-sys = { version = "0.48.0", features = ["Win32_System_Threading", "Win32_Foundation", "Win32_Storage_FileSystem", "Win32_Security", "Win32_System_WindowsProgramming", "Win32_System_IO"] }
 
 [target.'cfg(any(target_os="freebsd", target_os="openbsd", target_os = "netbsd", target_os = "dragonflybsd"))'.dependencies]
 kqueue = "^1.0.4" # fix for #344

--- a/notify/src/windows.rs
+++ b/notify/src/windows.rs
@@ -34,7 +34,7 @@ use windows_sys::Win32::Storage::FileSystem::{
 use windows_sys::Win32::System::Threading::{
     CreateSemaphoreW, ReleaseSemaphore, WaitForSingleObjectEx,
 };
-use windows_sys::Win32::System::WindowsProgramming::INFINITE;
+use windows_sys::Win32::System::Threading::INFINITE;
 use windows_sys::Win32::System::IO::{CancelIo, OVERLAPPED};
 
 const BUF_SIZE: u32 = 16384;


### PR DESCRIPTION
This PR is a small update to update the version of the `windows-sys` dependency crate to version 0.48.
