### PR TITLE
bump `filetime` dependency

### DIFF
--- a/notify/Cargo.toml
+++ b/notify/Cargo.toml
@@ -19,7 +19,7 @@ edition = "2021"
 
 [dependencies]
 crossbeam-channel = { version = "0.5.0", optional = true }
-filetime = "0.2.6"
+filetime = "0.2.22"
 libc = "0.2.4"
 log = "0.4.17"
 serde = { version = "1.0.89", features = ["derive"], optional = true }


### PR DESCRIPTION
this allows code using `notify` to not pull in an outdated version of `filetime` (`<0.2.22`) relying on outdated `redox_syscall` see https://github.com/alexcrichton/filetime/issues/98