### PR TITLE
prepare notify 6.1.0, debouncer-mini, 0.4.0 debouncer-full 0.3.0, fil…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,13 +3,60 @@
 v5 maintenance branch is on `v5_maintenance` after `5.2.0`  
 v4 commits split out to branch `v4_maintenance` starting with `4.0.16`
 
-## file-id 0.2.0
+## debouncer-full 0.3.0 (2023-08-18)
 
+- CHANGE: opt-out of the serde binary experiment by restricting it to < 1.0.171 [#528]
+- CHANGE: license changed to dual-license of MIT OR Apache-2.0 [#520]
+- CHANGE: upgrade to file-id 0.2.0 for high resolution file IDs [#494]
+- FEATURE: derive debug for the debouncer struct [#510]
+
+## debouncer-mini 0.4.0 (2023-08-18)
+
+- CHANGE: opt-out of the serde binary experiment by restricting it to < 1.0.171 [#528]
+- CHANGE: license changed to dual-license of MIT OR Apache-2.0 [#520]
+- CHANGE: replace active polling with passive loop, removing empty ticks [#467]
+- FEATURE: derive debug for the debouncer struct [#510]
+
+[#467]: https://github.com/notify-rs/notify/pull/467
+[#510]: https://github.com/notify-rs/notify/pull/510
+
+## notify 6.1.0 (2023-08-18)
+
+- CHANGE: opt-out of the serde binary experiment by restricting it to < 1.0.171 [#528]
+- CHANGE: license changed to only CC0-1.0 [#520]
+- CHANGE: use logging [#499]
+- CHANGE: upgrade windows-sys to 0.48 [#479]
+- CHANGE: bump filetime to 0.2.22 [#521]
+- FEATURE: support manual polling of PollWatcher and disabling automatic polling [#524]
+- FEATURE: support listening to the initial pollwatcher file scan [#507]
+- FIX: fix moved folders not being watched on linux [#498]
+- FIX: fixup potential future double free on windows [#517]
+- FIX: require bitflags only on macos and upgrade the crate [#505]
+- DOCS: add more known issues, typos and cleanup examples [#523] [#502] [#522]
+
+[#524]: https://github.com/notify-rs/notify/pull/524
+[#523]: https://github.com/notify-rs/notify/pull/523
+[#502]: https://github.com/notify-rs/notify/pull/502
+[#522]: https://github.com/notify-rs/notify/pull/522
+[#479]: https://github.com/notify-rs/notify/pull/479
+[#521]: https://github.com/notify-rs/notify/pull/521
+[#517]: https://github.com/notify-rs/notify/pull/517
+[#507]: https://github.com/notify-rs/notify/pull/507
+[#499]: https://github.com/notify-rs/notify/pull/499
+[#505]: https://github.com/notify-rs/notify/pull/505
+[#498]: https://github.com/notify-rs/notify/pull/498
+
+## file-id 0.2.0 (2023-08-18)
+
+- CHANGE: opt-out of the serde binary experiment by restricting it to < 1.0.171 [#528]
+- CHANGE: license changed to dual-license of MIT OR Apache-2.0 [#520]
 - CHANGE: switch from winapi to windows-sys [#494]
 - CHANGE: turn FileId struct into an enum [#494]
 - FEATURE: support for high resolution file ids on Windows using GetFileInformationByHandleEx [#494]
 
 [#494]: https://github.com/notify-rs/notify/pull/494
+[#520]: https://github.com/notify-rs/notify/pull/520
+[#528]: https://github.com/notify-rs/notify/pull/528
 
 ## notify 6.0.1 (2023-06-16)
 

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -5,9 +5,9 @@ publish = false
 edition = "2021"
 
 [dev-dependencies]
-notify = { version = "6.0.1", path = "../notify" }
+notify = { version = "6.1.0", path = "../notify" }
 notify-debouncer-mini = { version = "0.4.0", path = "../notify-debouncer-mini" }
-notify-debouncer-full = { version = "0.2.0", path = "../notify-debouncer-full" }
+notify-debouncer-full = { version = "0.3.0", path = "../notify-debouncer-full" }
 futures = "0.3"
 tempfile = "3.5.0"
 log = "0.4.17"

--- a/examples/hot_reload_tide/Cargo.toml
+++ b/examples/hot_reload_tide/Cargo.toml
@@ -11,7 +11,7 @@ tide = "0.16.0"
 async-std = { version = "1.6.0", features = ["attributes"] }
 serde_json = "1.0"
 serde = "1.0.115, < 1.0.172"
-notify = { version = "6.0.1", features = ["serde"], path = "../../notify" }
+notify = { version = "6.1.0", features = ["serde"], path = "../../notify" }
 
 # required to prevent mixing with workspace
 # hack to prevent cargo audit from catching this

--- a/file-id/Cargo.toml
+++ b/file-id/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "file-id"
-version = "0.1.0"
+version = "0.2.0"
 rust-version = "1.60"
 description = "Utility for reading inode numbers (Linux, MacOS) and file IDs (Windows)"
 documentation = "https://docs.rs/notify"

--- a/notify-debouncer-full/Cargo.toml
+++ b/notify-debouncer-full/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "notify-debouncer-full"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2021"
 rust-version = "1.60"
 description = "notify event debouncer optimized for ease of use"
@@ -24,9 +24,9 @@ default = ["crossbeam"]
 crossbeam = ["crossbeam-channel","notify/crossbeam-channel"]
 
 [dependencies]
-notify = { version = "6.0.1", path = "../notify" }
+notify = { version = "6.1.0", path = "../notify" }
 crossbeam-channel = { version = "0.5", optional = true }
-file-id = { version = "0.1.0", path = "../file-id" }
+file-id = { version = "0.2.0", path = "../file-id" }
 walkdir = "2.2.2"
 parking_lot = "0.12.1"
 log = "0.4.17"

--- a/notify-debouncer-full/src/lib.rs
+++ b/notify-debouncer-full/src/lib.rs
@@ -12,7 +12,7 @@
 //!
 //! ```toml
 //! [dependencies]
-//! notify-debouncer-full = "0.2.0"
+//! notify-debouncer-full = "0.3.0"
 //! ```
 //!
 //! In case you want to select specific features of notify,
@@ -20,7 +20,7 @@
 //! Otherwise you can just use the re-export of notify from debouncer-full.
 //!
 //! ```toml
-//! notify-debouncer-full = "0.2.0"
+//! notify-debouncer-full = "0.3.0"
 //! notify = { version = "..", features = [".."] }
 //! ```
 //!  

--- a/notify-debouncer-mini/Cargo.toml
+++ b/notify-debouncer-mini/Cargo.toml
@@ -24,7 +24,7 @@ default = ["crossbeam"]
 crossbeam = ["crossbeam-channel","notify/crossbeam-channel"]
 
 [dependencies]
-notify = { version = "6.0.1", path = "../notify" }
+notify = { version = "6.1.0", path = "../notify" }
 crossbeam-channel = { version = "0.5", optional = true }
 serde = { version = "1.0.89, < 1.0.172", features = ["derive"], optional = true }
 log = "0.4.17"

--- a/notify/Cargo.toml
+++ b/notify/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "notify"
-version = "6.0.1"
+version = "6.1.0"
 rust-version = "1.60"
 description = "Cross-platform filesystem notification library"
 documentation = "https://docs.rs/notify"

--- a/notify/src/lib.rs
+++ b/notify/src/lib.rs
@@ -4,7 +4,7 @@
 //!
 //! ```toml
 //! [dependencies]
-//! notify = "6.0.1"
+//! notify = "6.1.0"
 //! ```
 //!
 //! If you want debounced events (or don't need them in-order), see [notify-debouncer-mini](https://docs.rs/notify-debouncer-mini/latest/notify_debouncer_mini/)
@@ -24,7 +24,7 @@
 //! Events are serializable via [serde](https://serde.rs) if the `serde` feature is enabled:
 //!
 //! ```toml
-//! notify = { version = "6.0.1", features = ["serde"] }
+//! notify = { version = "6.1.0", features = ["serde"] }
 //! ```
 //!
 //! ### Crossbeam-Channel & Tokio
@@ -35,7 +35,7 @@
 //! You can disable crossbeam-channel, letting notify fallback to std channels via
 //!
 //! ```toml
-//! notify = { version = "6.0.1", default-features = false, features = ["macos_kqueue"] }
+//! notify = { version = "6.1.0", default-features = false, features = ["macos_kqueue"] }
 //! // Alternatively macos_fsevent instead of macos_kqueue
 //! ```
 //! Note the `macos_kqueue` requirement here, otherwise no native backend is available on macos.


### PR DESCRIPTION
…e-id 0.2.0

<!-- By contributing, you agree to the terms of the license, available in the LICENSE.ARTISTIC file, and of the code of conduct, available in the CODE_OF_CONDUCT.md file. Furthermore, you agree to release under CC0, also available in the LICENSE file, until Notify has fully transitioned to Artistic 2.0. -->

<!-- After creating this pull request, the test suite will run.

It is expected that if any failures occur in the builds, you either:

- fix the errors,
- ask for help, or
- note that the failures are expected with a detailed explanation.

If you do not, a maintainer may prompt you and/or do it themselves, but do note that it will take longer for your contribution to be reviewed if the build does not pass.

Running `cargo fmt` and/or `cargo clippy` is NOT required but appreciated!

You can remove this text. -->
