### PR TITLE
fixed documentation error

### DIFF
--- a/notify/src/lib.rs
+++ b/notify/src/lib.rs
@@ -349,7 +349,7 @@ pub trait Watcher {
 
     /// Configure the watcher at runtime.
     ///
-    /// See the [`Config`](config/enum.Config.html) enum for all configuration options.
+    /// See the [`Config`](config/struct.Config.html) struct for all configuration options.
     ///
     /// # Returns
     ///


### PR DESCRIPTION
the enum referred as Config does not exist, its a struct

<!-- By contributing, you agree to the terms of the license, available in the LICENSE.ARTISTIC file, and of the code of conduct, available in the CODE_OF_CONDUCT.md file. Furthermore, you agree to release under CC0, also available in the LICENSE file, until Notify has fully transitioned to Artistic 2.0. -->

<!-- After creating this pull request, the test suite will run.

It is expected that if any failures occur in the builds, you either:

- fix the errors,
- ask for help, or
- note that the failures are expected with a detailed explanation.

If you do not, a maintainer may prompt you and/or do it themselves, but do note that it will take longer for your contribution to be reviewed if the build does not pass.

Running `cargo fmt` and/or `cargo clippy` is NOT required but appreciated!

You can remove this text. -->
