### PR TITLE
Fixed the Event of watch dir Deletion

### DIFF
--- a/notify/src/inotify.rs
+++ b/notify/src/inotify.rs
@@ -37,6 +37,7 @@ struct EventLoop {
     inotify: Option<Inotify>,
     event_handler: Box<dyn EventHandler>,
     // PathBuf -> (WatchDescriptor, WatchMask, is_recursive, is_dir)
+    /// PathBuf -> (WatchDescriptor, WatchMask, is_recursive, is_dir)
     watches: HashMap<PathBuf, (WatchDescriptor, WatchMask, bool, bool)>,
     paths: HashMap<WatchDescriptor, PathBuf>,
     rename_event: Option<Event>,

--- a/notify/src/inotify.rs
+++ b/notify/src/inotify.rs
@@ -306,13 +306,16 @@ impl EventLoop {
                                             None => RemoveKind::Other,
                                         }
                                     }
-                                    None => RemoveKind::Other,
+                                    None => {
+                                        log::trace!("No patch for DELETE_SELF event, may be a bug?");
+                                        RemoveKind::Other
+                                    },
                                 };
                                 evs.push(
                                     Event::new(EventKind::Remove(remove_kind))
                                         .add_some_path(path.clone()),
                                 );
-                                remove_watch_by_event(&path, &self.watches, &mut remove_watches)
+                                remove_watch_by_event(&path, &self.watches, &mut remove_watches);
                             }
                             if event.mask.contains(EventMask::MODIFY) {
                                 evs.push(

--- a/notify/src/inotify.rs
+++ b/notify/src/inotify.rs
@@ -297,9 +297,9 @@ impl EventLoop {
                                 remove_watch_by_event(&path, &self.watches, &mut remove_watches);
                             }
                             if event.mask.contains(EventMask::DELETE_SELF) {
-                                let remove_kind = match path.clone() {
+                                let remove_kind = match &path {
                                     Some(watched_path) => {
-                                        let current_watch = self.watches.get(&watched_path);
+                                        let current_watch = self.watches.get(watched_path);
                                         match current_watch {
                                             Some(&(_, _, _, true)) => RemoveKind::Folder,
                                             Some(&(_, _, _, false)) => RemoveKind::File,

--- a/notify/src/inotify.rs
+++ b/notify/src/inotify.rs
@@ -298,19 +298,17 @@ impl EventLoop {
                                 remove_watch_by_event(&path, &self.watches, &mut remove_watches);
                             }
                             if event.mask.contains(EventMask::DELETE_SELF) {
-                                let remove_kind: RemoveKind;
-
-                                if path.is_none() {
-                                    remove_kind = RemoveKind::Other
-                                } else {
-                                    let watched_path = path.clone().unwrap();
-                                    let current_watch = self.watches.get(&watched_path);
-                                    remove_kind = match current_watch {
-                                        Some(&(_, _, _, true)) => RemoveKind::Folder,
-                                        Some(&(_, _, _, false)) => RemoveKind::File,
-                                        None => RemoveKind::Other,
+                                let remove_kind = match path.clone() {
+                                    Some(watched_path) => {
+                                        let current_watch = self.watches.get(&watched_path);
+                                        match current_watch {
+                                            Some(&(_, _, _, true)) => RemoveKind::Folder,
+                                            Some(&(_, _, _, false)) => RemoveKind::File,
+                                            None => RemoveKind::Other,
+                                        }
                                     }
-                                }
+                                    None => RemoveKind::Other,
+                                };
                                 evs.push(
                                     Event::new(EventKind::Remove(remove_kind))
                                         .add_some_path(path.clone()),

--- a/notify/src/inotify.rs
+++ b/notify/src/inotify.rs
@@ -27,6 +27,8 @@ const MESSAGE: mio::Token = mio::Token(1);
 // -  messages telling it what to do
 //
 // -  events telling it that something has happened on one of the watched files.
+//
+// - watches HashMap Value  tuple (WatchDescriptor, WatchMask, is_recursive, is_dir)
 struct EventLoop {
     running: bool,
     poll: mio::Poll,
@@ -35,7 +37,7 @@ struct EventLoop {
     event_loop_rx: Receiver<EventLoopMsg>,
     inotify: Option<Inotify>,
     event_handler: Box<dyn EventHandler>,
-    watches: HashMap<PathBuf, (WatchDescriptor, WatchMask, bool)>,
+    watches: HashMap<PathBuf, (WatchDescriptor, WatchMask, bool, bool)>,
     paths: HashMap<WatchDescriptor, PathBuf>,
     rename_event: Option<Event>,
 }
@@ -58,13 +60,13 @@ enum EventLoopMsg {
 fn add_watch_by_event(
     path: &Option<PathBuf>,
     event: &inotify_sys::Event<&OsStr>,
-    watches: &HashMap<PathBuf, (WatchDescriptor, WatchMask, bool)>,
+    watches: &HashMap<PathBuf, (WatchDescriptor, WatchMask, bool, bool)>,
     add_watches: &mut Vec<PathBuf>,
 ) {
     if let Some(ref path) = *path {
         if event.mask.contains(EventMask::ISDIR) {
             if let Some(parent_path) = path.parent() {
-                if let Some(&(_, _, is_recursive)) = watches.get(parent_path) {
+                if let Some(&(_, _, is_recursive, _)) = watches.get(parent_path) {
                     if is_recursive {
                         add_watches.push(path.to_owned());
                     }
@@ -77,7 +79,7 @@ fn add_watch_by_event(
 #[inline]
 fn remove_watch_by_event(
     path: &Option<PathBuf>,
-    watches: &HashMap<PathBuf, (WatchDescriptor, WatchMask, bool)>,
+    watches: &HashMap<PathBuf, (WatchDescriptor, WatchMask, bool, bool)>,
     remove_watches: &mut Vec<PathBuf>,
 ) {
     if let Some(ref path) = *path {
@@ -281,9 +283,7 @@ impl EventLoop {
                                 );
                                 add_watch_by_event(&path, &event, &self.watches, &mut add_watches);
                             }
-                            if event.mask.contains(EventMask::DELETE_SELF)
-                                || event.mask.contains(EventMask::DELETE)
-                            {
+                            if event.mask.contains(EventMask::DELETE) {
                                 evs.push(
                                     Event::new(EventKind::Remove(
                                         if event.mask.contains(EventMask::ISDIR) {
@@ -295,6 +295,28 @@ impl EventLoop {
                                     .add_some_path(path.clone()),
                                 );
                                 remove_watch_by_event(&path, &self.watches, &mut remove_watches);
+                            }
+                            if event.mask.contains(EventMask::DELETE_SELF) {
+                                evs.push(
+                                    Event::new(EventKind::Remove(match path.clone() {
+                                        Some(path) => {
+                                            let current_watch = self.watches.get(&path);
+                                            match current_watch {
+                                                Some(&(_, _, _, is_dir)) => {
+                                                    if is_dir {
+                                                        RemoveKind::Folder
+                                                    } else {
+                                                        RemoveKind::File
+                                                    }
+                                                }
+                                                None => RemoveKind::Other,
+                                            }
+                                        }
+                                        None => RemoveKind::Other,
+                                    }))
+                                    .add_some_path(path.clone()),
+                                );
+                                remove_watch_by_event(&path, &self.watches, &mut remove_watches)
                             }
                             if event.mask.contains(EventMask::MODIFY) {
                                 evs.push(
@@ -401,7 +423,7 @@ impl EventLoop {
             watchmask.insert(WatchMask::MOVE_SELF);
         }
 
-        if let Some(&(_, old_watchmask, _)) = self.watches.get(&path) {
+        if let Some(&(_, old_watchmask, _, _)) = self.watches.get(&path) {
             watchmask.insert(old_watchmask);
             watchmask.insert(WatchMask::MASK_ADD);
         }
@@ -421,8 +443,9 @@ impl EventLoop {
                 }
                 Ok(w) => {
                     watchmask.remove(WatchMask::MASK_ADD);
+                    let is_dir = metadata(&path).map_err(Error::io)?.is_dir();
                     self.watches
-                        .insert(path.clone(), (w.clone(), watchmask, is_recursive));
+                        .insert(path.clone(), (w.clone(), watchmask, is_recursive, is_dir));
                     self.paths.insert(w, path);
                     Ok(())
                 }
@@ -435,7 +458,7 @@ impl EventLoop {
     fn remove_watch(&mut self, path: PathBuf, remove_recursive: bool) -> Result<()> {
         match self.watches.remove(&path) {
             None => return Err(Error::watch_not_found().add_path(path)),
-            Some((w, _, is_recursive)) => {
+            Some((w, _, is_recursive, _)) => {
                 if let Some(ref mut inotify) = self.inotify {
                     log::trace!("removing inotify watch: {}", path.display());
 

--- a/notify/src/inotify.rs
+++ b/notify/src/inotify.rs
@@ -27,8 +27,7 @@ const MESSAGE: mio::Token = mio::Token(1);
 // -  messages telling it what to do
 //
 // -  events telling it that something has happened on one of the watched files.
-//
-// - watches HashMap Value  tuple (WatchDescriptor, WatchMask, is_recursive, is_dir)
+
 struct EventLoop {
     running: bool,
     poll: mio::Poll,
@@ -37,6 +36,7 @@ struct EventLoop {
     event_loop_rx: Receiver<EventLoopMsg>,
     inotify: Option<Inotify>,
     event_handler: Box<dyn EventHandler>,
+    // PathBuf -> (WatchDescriptor, WatchMask, is_recursive, is_dir)
     watches: HashMap<PathBuf, (WatchDescriptor, WatchMask, bool, bool)>,
     paths: HashMap<WatchDescriptor, PathBuf>,
     rename_event: Option<Event>,

--- a/notify/src/inotify.rs
+++ b/notify/src/inotify.rs
@@ -36,7 +36,6 @@ struct EventLoop {
     event_loop_rx: Receiver<EventLoopMsg>,
     inotify: Option<Inotify>,
     event_handler: Box<dyn EventHandler>,
-    // PathBuf -> (WatchDescriptor, WatchMask, is_recursive, is_dir)
     /// PathBuf -> (WatchDescriptor, WatchMask, is_recursive, is_dir)
     watches: HashMap<PathBuf, (WatchDescriptor, WatchMask, bool, bool)>,
     paths: HashMap<WatchDescriptor, PathBuf>,


### PR DESCRIPTION
Resolves #493
Deleting watched dir only returns Delete self and Ignore event. Unlike deleting other folders, it doesn't return events to check whether it is dir or not. 

I stored whether path is dir or not in watches. Taking metadata after delete event triggers is not possible. 