### PR TITLE
v7.0 Replace deprecated poll_interval signature

### DIFF
--- a/notify/src/config.rs
+++ b/notify/src/config.rs
@@ -60,18 +60,8 @@ impl Config {
     }
 
     /// Returns current setting
-    #[deprecated(
-        since = "6.1.0",
-        note = "use poll_interval_v2 to account for disabled automatic polling"
-    )]
-    pub fn poll_interval(&self) -> Duration {
-        // TODO: v7.0 break signature to option
-        self.poll_interval.unwrap_or_default()
-    }
-
-    /// Returns current setting
-    pub fn poll_interval_v2(&self) -> Option<Duration> {
-        // TODO: v7.0 break signature to option
+    pub fn poll_interval(&self) -> Option<Duration> {
+        // Changed Signature to Option
         self.poll_interval
     }
 

--- a/notify/src/poll.rs
+++ b/notify/src/poll.rs
@@ -18,7 +18,7 @@ use std::{
 /// Event send for registered handler on initial directory scans
 pub type ScanEvent = crate::Result<PathBuf>;
 
-/// Handler trait for receivers of ScanEvent.  
+/// Handler trait for receivers of ScanEvent.
 /// Very much the same as [EventHandler], but including the Result.
 ///
 /// See the full example for more information.
@@ -476,7 +476,7 @@ pub struct PollWatcher {
     watches: Arc<Mutex<HashMap<PathBuf, WatchData>>>,
     data_builder: Arc<Mutex<DataBuilder>>,
     want_to_stop: Arc<AtomicBool>,
-    /// channel to the poll loop  
+    /// channel to the poll loop
     /// currently used only for manual polling
     message_channel: Sender<()>,
     delay: Option<Duration>,
@@ -522,7 +522,7 @@ impl PollWatcher {
             watches: Default::default(),
             data_builder: Arc::new(Mutex::new(data_builder)),
             want_to_stop: Arc::new(AtomicBool::new(false)),
-            delay: config.poll_interval_v2(),
+            delay: config.poll_interval(),
             message_channel: tx,
         };
 


### PR DESCRIPTION
 Issue: Breaking Changes v7 #525 
Addresses: Config: Replace deprecated poll_interval signature with poll_interval_v2