### PR TITLE
Prevent installing `crossbeam-channel` with `default-features="false"`

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -63,14 +63,24 @@ jobs:
         run: cargo check -p notify --no-default-features --features=macos_kqueue
         # -p notify required for feature selection!
 
-      - name: check notify debouncer mini features
+      - name: check notify debouncer mini without crossbeam/default features
         if: matrix.version == 'stable'
-        run: cargo check -p notify-debouncer-mini --no-default-features
+        run: cargo check -p notify-debouncer-mini --no-default-features --features=macos_fsevent
         # -p required for feature selection to actually work!
 
-      - name: check notify debouncer full features
+      - name: check notify debouncer mini without crossbeam/default features on macos with kqueue
+        if: matrix.version == 'stable' && matrix.os == 'macos-latest'
+        run: cargo check -p notify-debouncer-mini --no-default-features --features=macos_kqueue
+        # -p required for feature selection to actually work!
+
+      - name: check notify debouncer full without crossbeam/default features
         if: matrix.version == 'stable'
-        run: cargo check -p notify-debouncer-full --no-default-features
+        run: cargo check -p notify-debouncer-full --no-default-features --features=macos_fsevent
+        # -p required for feature selection to actually work!
+
+      - name: check notify debouncer full without crossbeam/default features on macos with kqueue
+        if: matrix.version == 'stable' && matrix.os == 'macos-latest'
+        run: cargo check -p notify-debouncer-full --no-default-features --features=macos_kqueue
         # -p required for feature selection to actually work!
 
       - name: check build examples

--- a/notify-debouncer-full/Cargo.toml
+++ b/notify-debouncer-full/Cargo.toml
@@ -19,12 +19,14 @@ name = "notify_debouncer_full"
 path = "src/lib.rs"
 
 [features]
-default = ["crossbeam"]
+default = ["crossbeam","macos_fsevent"]
 # can't use dep:crossbeam-channel and feature name crossbeam-channel below rust 1.60
 crossbeam = ["crossbeam-channel","notify/crossbeam-channel"]
+macos_fsevent = ["notify/macos_fsevent"]
+macos_kqueue = ["notify/macos_kqueue"]
 
 [dependencies]
-notify = { version = "6.1.1", path = "../notify" }
+notify = { version = "6.1.1", path = "../notify", default-features = false }
 crossbeam-channel = { version = "0.5", optional = true }
 file-id = { version = "0.2.1", path = "../file-id" }
 walkdir = "2.2.2"

--- a/notify-debouncer-full/README.md
+++ b/notify-debouncer-full/README.md
@@ -17,13 +17,24 @@ A debouncer for [notify] that is optimized for ease of use.
 - `crossbeam` enabled by default, for crossbeam channel support.
 
   This may create problems used in tokio environments. See [#380](https://github.com/notify-rs/notify/issues/380).  
-  Use someting like the following to disable it.
+  Use something like the following to disable it.
   
   ```toml
   notify-debouncer-full = { version = "*", default-features = false }
   ```
   
   This also passes through to notify as `crossbeam-channel` feature.
+
+  On MacOS, when disabling default features, enable either the `macos_fsevent` feature
+  or, on latest MacOS, the `macos_kqueue` feature to be passed through to notify.
+
+  ```toml
+  # Using FSEvents
+  notify-debouncer-full = { version = "*", default-features = false, features = ["macos_fsevent"] }
+
+  # Using Kernel Queues
+  notify-debouncer-full = { version = "*", default-features = false, features = ["macos_kqueue"] }
+  ```
 
 [docs]: https://docs.rs/notify-debouncer-full
 [notify]: https://crates.io/crates/notify

--- a/notify-debouncer-mini/Cargo.toml
+++ b/notify-debouncer-mini/Cargo.toml
@@ -19,12 +19,14 @@ name = "notify_debouncer_mini"
 path = "src/lib.rs"
 
 [features]
-default = ["crossbeam"]
+default = ["crossbeam","macos_fsevent"]
 # can't use dep:crossbeam-channel and feature name crossbeam-channel below rust 1.60
 crossbeam = ["crossbeam-channel","notify/crossbeam-channel"]
+macos_fsevent = ["notify/macos_fsevent"]
+macos_kqueue = ["notify/macos_kqueue"]
 
 [dependencies]
-notify = { version = "6.1.1", path = "../notify" }
+notify = { version = "6.1.1", path = "../notify", default-features = false }
 crossbeam-channel = { version = "0.5", optional = true }
 serde = { version = "1.0.89", features = ["derive"], optional = true }
 log = "0.4.17"

--- a/notify-debouncer-mini/README.md
+++ b/notify-debouncer-mini/README.md
@@ -6,13 +6,27 @@ Tiny debouncer for [notify]. Filters incoming events and emits only one event pe
 
 ## Features
 
-- `crossbeam` enabled by default, for crossbeam channel support.  
-This may create problems used in tokio environments. See [#380](https://github.com/notify-rs/notify/issues/380).  
-Use something like the following to disable it.
-```toml
-notify-debouncer-mini = { version = "*", default-features = false }
-```
-This also passes through to notify as `crossbeam-channel` feature.
+- `crossbeam` enabled by default, for crossbeam channel support.
+
+  This may create problems used in tokio environments. See [#380](https://github.com/notify-rs/notify/issues/380).
+  Use something like the following to disable it.
+
+  ```toml
+  notify-debouncer-mini = { version = "*", default-features = false }
+  ```
+
+  This also passes through to notify as `crossbeam-channel` feature.
+
+  On MacOS, when disabling default features, enable either the `macos_fsevent` feature
+  or, on latest MacOS, the `macos_kqueue` feature to be passed through to notify.
+
+  ```toml
+  # Using FSEvents
+  notify-debouncer-mini = { version = "*", default-features = false, features = ["macos_fsevent"] }
+
+  # Using Kernel Queues
+  notify-debouncer-mini = { version = "*", default-features = false, features = ["macos_kqueue"] }
+  ```
 - `serde` for serde support of event types, off by default
 
 [docs]: https://docs.rs/notify-debouncer-mini


### PR DESCRIPTION
Debouncers used to install `crossbeam-channel`,
due to keeping `notify`'s default features enabled
even if their own default features were disabled.

With this change, `crossbeam-channel` will
no longer be installed if `notify-debouncer-*`
as well as `notify` are installed with
`default-features = false`

Fixes #549

<!-- By contributing, you agree to the terms of the license, available in the LICENSE.ARTISTIC file, and of the code of conduct, available in the CODE_OF_CONDUCT.md file. Furthermore, you agree to release under CC0, also available in the LICENSE file, until Notify has fully transitioned to Artistic 2.0. -->

<!-- After creating this pull request, the test suite will run.

It is expected that if any failures occur in the builds, you either:

- fix the errors,
- ask for help, or
- note that the failures are expected with a detailed explanation.

If you do not, a maintainer may prompt you and/or do it themselves, but do note that it will take longer for your contribution to be reviewed if the build does not pass.

Running `cargo fmt` and/or `cargo clippy` is NOT required but appreciated!

You can remove this text. -->
