### PR TITLE
purge events on stop

### DIFF
--- a/notify/src/fsevent.rs
+++ b/notify/src/fsevent.rs
@@ -455,6 +455,13 @@ impl FsEventWatcher {
 
                     cf::CFRunLoopRun();
                     fs::FSEventStreamStop(stream);
+                    // There are edge-cases, when many events are pending,
+                    // despite the stream being stopped, that the stream's
+                    // associated callback will be invoked. Purging events
+                    // is intended to prevent this.
+                    let event_id = fs::FSEventsGetCurrentEventId();
+                    let device = fs::FSEventStreamGetDeviceBeingWatched(stream);
+                    fs::FSEventsPurgeEventsForDeviceUpToEventId(device, event_id);
                     fs::FSEventStreamInvalidate(stream);
                     fs::FSEventStreamRelease(stream);
                 }


### PR DESCRIPTION
There are edge-cases, when many events are pending, despite the stream being stopped, that the stream's associated callback will be invoked. Purging events is intended to prevent this.

Discovered and head-banged on this one on my watcher for a while. Eventually fixed here: https://github.com/e-dant/watcher/commit/3a45a7f473a3019019127fa01954aaf08cfb2ca1