### PR TITLE
[notify-debouncer-full] mark as compatible with rstest 0.18.x

### DIFF
--- a/notify-debouncer-full/Cargo.toml
+++ b/notify-debouncer-full/Cargo.toml
@@ -36,7 +36,7 @@ log = "0.4.17"
 [dev-dependencies]
 pretty_assertions = "1.3.0"
 mock_instant = "0.3.0"
-rstest = "0.17.0"
+rstest = "0.18"
 serde = { version = "1.0.89", features = ["derive"] }
 deser-hjson = "1.1.1"
 rand = "0.8.5"


### PR DESCRIPTION
We are packaging this in Fedora, and tests pass using rstest 0.18.x that is in our repositories

See https://bugzilla.redhat.com/show_bug.cgi?id=2257209