### PR TITLE
Manage file ID cache paths in debouncer-full

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,26 @@
 # Changelog
 
-v5 maintenance branch is on `v5_maintenance` after `5.2.0`  
+v5 maintenance branch is on `v5_maintenance` after `5.2.0`
+
 v4 commits split out to branch `v4_maintenance` starting with `4.0.16`
+
+## debouncer-full 0.4.0
+
+- CHANGE: Manage root folder paths for the file ID cache automatically. **breaking**
+
+  ```rust
+  debouncer.watcher().watch(path, RecursiveMode::Recursive)?;
+  debouncer.cache().add_root(path, RecursiveMode::Recursive);
+  ```
+
+  becomes:
+
+  ```rust
+  debouncer.watch(path, RecursiveMode::Recursive)?;
+  ```
+
+- CHANGE: Add `RecommendedCache`, which automatically enables the file ID cache on Windows and MacOS
+  and disables it on Linux, where it is not needed.
 
 ## debouncer-full 0.3.1 (2023-08-21)
 

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 [dev-dependencies]
 notify = { version = "6.1.1", path = "../notify" }
 notify-debouncer-mini = { version = "0.4.1", path = "../notify-debouncer-mini" }
-notify-debouncer-full = { version = "0.3.1", path = "../notify-debouncer-full" }
+notify-debouncer-full = { version = "0.4.0", path = "../notify-debouncer-full" }
 futures = "0.3"
 tempfile = "3.5.0"
 log = "0.4.17"

--- a/examples/debouncer_full.rs
+++ b/examples/debouncer_full.rs
@@ -1,6 +1,6 @@
 use std::{fs, thread, time::Duration};
 
-use notify::{RecursiveMode, Watcher};
+use notify::RecursiveMode;
 use notify_debouncer_full::new_debouncer;
 use tempfile::tempdir;
 
@@ -31,13 +31,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     // no specific tickrate, max debounce time 2 seconds
     let mut debouncer = new_debouncer(Duration::from_secs(2), None, tx)?;
 
-    debouncer
-        .watcher()
-        .watch(dir.path(), RecursiveMode::Recursive)?;
-
-    debouncer
-        .cache()
-        .add_root(dir.path(), RecursiveMode::Recursive);
+    debouncer.watch(dir.path(), RecursiveMode::Recursive)?;
 
     // print all events and errors
     for result in rx {

--- a/examples/monitor_debounced.rs
+++ b/examples/monitor_debounced.rs
@@ -1,4 +1,4 @@
-use notify::{RecursiveMode, Watcher};
+use notify::RecursiveMode;
 use notify_debouncer_full::new_debouncer;
 use std::{path::Path, time::Duration};
 
@@ -26,17 +26,7 @@ fn watch<P: AsRef<Path>>(path: P) -> notify::Result<()> {
 
     // Add a path to be watched. All files and directories at that path and
     // below will be monitored for changes.
-    debouncer
-        .watcher()
-        .watch(path.as_ref(), RecursiveMode::Recursive)?;
-
-    // Initialize the file id cache for the same path. This will allow the debouncer to stitch together move events,
-    // even if the underlying watch implementation doesn't support it.
-    // Without the cache and with some watch implementations,
-    // you may receive `move from` and `move to` events instead of one `move both` event.
-    debouncer
-        .cache()
-        .add_root(path.as_ref(), RecursiveMode::Recursive);
+    debouncer.watch(path.as_ref(), RecursiveMode::Recursive)?;
 
     // print all events and errors
     for result in rx {

--- a/notify-debouncer-full/Cargo.toml
+++ b/notify-debouncer-full/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "notify-debouncer-full"
-version = "0.3.1"
+version = "0.4.0"
 edition = "2021"
 rust-version = "1.63"
 description = "notify event debouncer optimized for ease of use"

--- a/notify-debouncer-full/Cargo.toml
+++ b/notify-debouncer-full/Cargo.toml
@@ -30,7 +30,6 @@ notify = { version = "6.1.1", path = "../notify", default-features = false }
 crossbeam-channel = { version = "0.5", optional = true }
 file-id = { version = "0.2.1", path = "../file-id" }
 walkdir = "2.2.2"
-parking_lot = "0.12.1"
 log = "0.4.17"
 
 [dev-dependencies]

--- a/notify-debouncer-full/src/testing.rs
+++ b/notify-debouncer-full/src/testing.rs
@@ -268,6 +268,7 @@ impl schema::State {
 
         DebounceDataInner {
             queues,
+            roots: Vec::new(),
             cache,
             rename_event,
             rescan_event,
@@ -290,27 +291,21 @@ impl TestCache {
 }
 
 impl FileIdCache for TestCache {
-    fn add_root(&mut self, _path: impl Into<PathBuf>, _recursive_mode: RecursiveMode) {}
-
-    fn remove_root(&mut self, _path: impl AsRef<Path>) {}
-
     fn cached_file_id(&self, path: &Path) -> Option<&FileId> {
         self.paths.get(path)
     }
 
-    fn add_path(&mut self, path: &Path) {
-        for (p, file_id) in &self.file_system {
-            if p.starts_with(path) {
-                self.paths.insert(p.clone(), file_id.clone());
+    fn add_path(&mut self, path: &Path, recursive_mode: RecursiveMode) {
+        for (file_path, file_id) in &self.file_system {
+            if file_path == path
+                || (file_path.starts_with(path) && recursive_mode == RecursiveMode::Recursive)
+            {
+                self.paths.insert(file_path.clone(), file_id.clone());
             }
         }
     }
 
     fn remove_path(&mut self, path: &Path) {
         self.paths.remove(path);
-    }
-
-    fn rescan(&mut self) {
-        self.add_path(Path::new("/"))
     }
 }

--- a/notify-debouncer-full/src/testing.rs
+++ b/notify-debouncer-full/src/testing.rs
@@ -11,7 +11,7 @@ use notify::{
         AccessKind, AccessMode, CreateKind, DataChange, Flag, MetadataKind, ModifyKind, RemoveKind,
         RenameMode,
     },
-    Error, ErrorKind, Event, EventKind,
+    Error, ErrorKind, Event, EventKind, RecursiveMode,
 };
 
 use crate::{DebounceDataInner, DebouncedEvent, FileIdCache, Queue};
@@ -290,6 +290,10 @@ impl TestCache {
 }
 
 impl FileIdCache for TestCache {
+    fn add_root(&mut self, _path: impl Into<PathBuf>, _recursive_mode: RecursiveMode) {}
+
+    fn remove_root(&mut self, _path: impl AsRef<Path>) {}
+
     fn cached_file_id(&self, path: &Path) -> Option<&FileId> {
         self.paths.get(path)
     }
@@ -307,6 +311,6 @@ impl FileIdCache for TestCache {
     }
 
     fn rescan(&mut self) {
-        self.add_path(&Path::new("/"))
+        self.add_path(Path::new("/"))
     }
 }


### PR DESCRIPTION
- CHANGE: Manage root folder paths for the file ID cache automatically. **breaking**

  This simplifies the usage of the `debouncer-full`. By default it will now maintain the file id cache on its own.
  It should make it impossible to misuse the feature.

- CHANGE: Add `RecommendedCache`, which automatically enables the file ID cache on Windows and MacOS
  and disables it on Linux, where it is not needed.

  inotify emits rename cookies, so the file id cache can be disabled on Linux.