### PR TITLE
MSRV 1.72

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       matrix:
         version:
-          - 1.63.0 # MSRV
+          - 1.72.1 # MSRV
           - stable
           - nightly
         os:
@@ -38,19 +38,19 @@ jobs:
           rustup override set ${{ matrix.version }}
 
       - name: check build serde,macos_kqueue for examples
-        if: matrix.version != '1.63.0' && matrix.os == 'macos-latest'
+        if: matrix.version != '1.72.1' && matrix.os == 'macos-latest'
         run: cargo check -p notify --features=serde,macos_kqueue --examples
 
       - name: check build serde,macos_kqueue
-        if: matrix.version == '1.63.0' && matrix.os == 'macos-latest'
+        if: matrix.version == '1.72.1' && matrix.os == 'macos-latest'
         run: cargo check -p notify --features=serde,macos_kqueue
 
       - name: check build serde for examples
-        if: matrix.version != '1.63.0' && matrix.os != 'macos-latest'
+        if: matrix.version != '1.72.1' && matrix.os != 'macos-latest'
         run: cargo check -p notify --features=serde --examples
 
       - name: check build serde
-        if: matrix.version == '1.63.0' && matrix.os != 'macos-latest'
+        if: matrix.version == '1.72.1' && matrix.os != 'macos-latest'
         run: cargo check --features=serde
 
       - name: check build without crossbeam/default features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,11 +6,12 @@ v4 commits split out to branch `v4_maintenance` starting with `4.0.16`
 
 ## notify 7.0.0
 
-- CHANGE: Raise MSRV to 1.72
+- CHANGE: raise MSRV to 1.72
+- CHANGE: remove internal use of crossbeam-channels
 
 ## debouncer-full 0.4.0
 
-- CHANGE: Manage root folder paths for the file ID cache automatically. **breaking**
+- CHANGE: manage root folder paths for the file ID cache automatically **breaking**
 
   ```rust
   debouncer.watcher().watch(path, RecursiveMode::Recursive)?;
@@ -23,8 +24,8 @@ v4 commits split out to branch `v4_maintenance` starting with `4.0.16`
   debouncer.watch(path, RecursiveMode::Recursive)?;
   ```
 
-- CHANGE: Add `RecommendedCache`, which automatically enables the file ID cache on Windows and MacOS
-  and disables it on Linux, where it is not needed.
+- CHANGE: add `RecommendedCache`, which automatically enables the file ID cache on Windows and MacOS
+  and disables it on Linux, where it is not needed
 
 ## debouncer-full 0.3.1 (2023-08-21)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ v4 commits split out to branch `v4_maintenance` starting with `4.0.16`
 
 ## notify 7.0.0
 
-- CHANGE: Raise MSRV to 1.65
+- CHANGE: Raise MSRV to 1.72
 
 ## debouncer-full 0.4.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ v5 maintenance branch is on `v5_maintenance` after `5.2.0`
 
 v4 commits split out to branch `v4_maintenance` starting with `4.0.16`
 
+## notify 7.0.0
+
+- CHANGE: Raise MSRV to 1.65
+
 ## debouncer-full 0.4.0
 
 - CHANGE: Manage root folder paths for the file ID cache automatically. **breaking**

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ exclude = [
 ]
 
 [workspace.package]
-rust-version = "1.65"
+rust-version = "1.72"
 homepage = "https://github.com/notify-rs/notify"
 repository = "https://github.com/notify-rs/notify.git"
 edition = "2021"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,30 +20,30 @@ edition = "2021"
 
 [workspace.dependencies]
 bitflags = "2.3.0"
-crossbeam-channel = "0.5"
-deser-hjson = "1.1.1"
-env_logger = "0.10.0"
+crossbeam-channel = "0.5.0"
+deser-hjson = "2.2.4"
+env_logger = "0.11.2"
 file-id = { path = "file-id" }
 filetime = "0.2.22"
-fsevent-sys = "4"
-futures = "0.3"
-inotify = { version = "0.10", default-features = false }
+fsevent-sys = "4.0.0"
+futures = "0.3.30"
+inotify = { version = "0.10.2", default-features = false }
 insta = "1.34.0"
-kqueue = "1.0"
+kqueue = "1.0.8"
 libc = "0.2.4"
 log = "0.4.17"
-mio = { version = "0.8", features = ["os-ext"] }
+mio = { version = "0.8.10", features = ["os-ext"] }
 mock_instant = "0.3.0"
-nix = "0.23.1"
+nix = "0.27.0"
 notify = { path = "notify" }
 notify-debouncer-full = { path = "notify-debouncer-full" }
 notify-debouncer-mini = { path = "notify-debouncer-mini" }
 notify-types = { path = "notify-types" }
 pretty_assertions = "1.3.0"
 rand = "0.8.5"
-rstest = "0.17.0"
+rstest = "0.18.2"
 serde = { version = "1.0.89", features = ["derive"] }
 serde_json = "1.0.39"
-tempfile = "3.2.0"
-walkdir = "2.2.2"
-windows-sys = "0.48.0"
+tempfile = "3.10.0"
+walkdir = "2.4.0"
+windows-sys = "0.52.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,8 +6,8 @@ members = [
   "notify-debouncer-mini",
   "notify-debouncer-full",
   "file-id",
-  # internal
-  "examples"
-  #"examples/hot_reload_tide" until https://github.com/rustsec/rustsec/issues/501 is resolved
+  "examples",
 ]
-exclude = ["examples/hot_reload_tide"]
+exclude = [
+  "examples/hot_reload_tide", # excluded until https://github.com/rustsec/rustsec/issues/501 is resolved
+]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,3 +11,39 @@ members = [
 exclude = [
   "examples/hot_reload_tide", # excluded until https://github.com/rustsec/rustsec/issues/501 is resolved
 ]
+
+[workspace.package]
+rust-version = "1.65"
+homepage = "https://github.com/notify-rs/notify"
+repository = "https://github.com/notify-rs/notify.git"
+edition = "2021"
+
+[workspace.dependencies]
+bitflags = "2.3.0"
+crossbeam-channel = "0.5"
+deser-hjson = "1.1.1"
+env_logger = "0.10.0"
+file-id = { path = "file-id" }
+filetime = "0.2.22"
+fsevent-sys = "4"
+futures = "0.3"
+inotify = { version = "0.10", default-features = false }
+insta = "1.34.0"
+kqueue = "1.0"
+libc = "0.2.4"
+log = "0.4.17"
+mio = { version = "0.8", features = ["os-ext"] }
+mock_instant = "0.3.0"
+nix = "0.23.1"
+notify = { path = "notify" }
+notify-debouncer-full = { path = "notify-debouncer-full" }
+notify-debouncer-mini = { path = "notify-debouncer-mini" }
+notify-types = { path = "notify-types" }
+pretty_assertions = "1.3.0"
+rand = "0.8.5"
+rstest = "0.17.0"
+serde = { version = "1.0.89", features = ["derive"] }
+serde_json = "1.0.39"
+tempfile = "3.2.0"
+walkdir = "2.2.2"
+windows-sys = "0.48.0"

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -5,13 +5,13 @@ publish = false
 edition = "2021"
 
 [dev-dependencies]
-notify = { version = "6.1.1", path = "../notify" }
-notify-debouncer-mini = { version = "0.4.1", path = "../notify-debouncer-mini" }
-notify-debouncer-full = { version = "0.4.0", path = "../notify-debouncer-full" }
-futures = "0.3"
-tempfile = "3.5.0"
-log = "0.4.17"
-env_logger = "0.10.0"
+notify = { workspace = true }
+notify-debouncer-mini = { workspace = true }
+notify-debouncer-full = { workspace = true }
+futures = { workspace = true }
+tempfile = { workspace = true }
+log = { workspace = true }
+env_logger = { workspace = true }
 
 [[example]]
 name = "async_monitor"

--- a/file-id/Cargo.toml
+++ b/file-id/Cargo.toml
@@ -1,28 +1,27 @@
 [package]
 name = "file-id"
 version = "0.2.1"
-rust-version = "1.60"
 description = "Utility for reading inode numbers (Linux, MacOS) and file IDs (Windows)"
 documentation = "https://docs.rs/notify"
-homepage = "https://github.com/notify-rs/notify"
-repository = "https://github.com/notify-rs/notify.git"
 readme = "../README.md"
 license = "MIT OR Apache-2.0"
 keywords = ["filesystem", "inode", "file", "index"]
 categories = ["filesystem"]
 authors = ["Daniel Faust <hessijames@gmail.com>"]
-
-edition = "2021"
+rust-version = { workspace = true }
+edition = { workspace = true }
+homepage = { workspace = true }
+repository = { workspace = true }
 
 [[bin]]
 name = "file-id"
 path = "bin/file_id.rs"
 
 [dependencies]
-serde = { version = "1.0.89", features = ["derive"], optional = true }
+serde = { workspace = true, optional = true }
 
 [target.'cfg(windows)'.dependencies]
-windows-sys = { version = "0.48.0", features = ["Win32_Storage_FileSystem", "Win32_Foundation"] }
+windows-sys = { workspace = true, features = ["Win32_Storage_FileSystem", "Win32_Foundation"] }
 
 [dev-dependencies]
-tempfile = "3.2.0"
+tempfile = { workspace = true }

--- a/notify-debouncer-full/Cargo.toml
+++ b/notify-debouncer-full/Cargo.toml
@@ -2,7 +2,7 @@
 name = "notify-debouncer-full"
 version = "0.4.0"
 edition = "2021"
-rust-version = "1.63"
+rust-version = "1.65"
 description = "notify event debouncer optimized for ease of use"
 documentation = "https://docs.rs/notify-debouncer-full"
 homepage = "https://github.com/notify-rs/notify"
@@ -39,7 +39,7 @@ mock_instant = { version = "0.3.0", optional = true }
 [dev-dependencies]
 notify-debouncer-full = { path = ".", features = ["mock_instant"] }
 pretty_assertions = "1.3.0"
-rstest = "0.18"
+rstest = "0.17.0"
 serde = { version = "1.0.89", features = ["derive"] }
 deser-hjson = "1.1.1"
 rand = "0.8.5"

--- a/notify-debouncer-full/Cargo.toml
+++ b/notify-debouncer-full/Cargo.toml
@@ -12,23 +12,16 @@ edition = { workspace = true }
 homepage = { workspace = true }
 repository = { workspace = true }
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
-[lib]
-name = "notify_debouncer_full"
-path = "src/lib.rs"
-
 [features]
-default = ["crossbeam","macos_fsevent"]
+default = ["macos_fsevent"]
 serde = ["notify-types/serde"]
-mock_instant = ["dep:mock_instant","notify-types/mock_instant"]
-# can't use dep:crossbeam-channel and feature name crossbeam-channel below rust 1.60
-crossbeam = ["crossbeam-channel","notify/crossbeam-channel"]
+mock_instant = ["dep:mock_instant", "notify-types/mock_instant"]
+crossbeam-channel = ["dep:crossbeam-channel", "notify/crossbeam-channel"]
 macos_fsevent = ["notify/macos_fsevent"]
 macos_kqueue = ["notify/macos_kqueue"]
 
 [dependencies]
-notify = { workspace = true, default-features = false }
+notify = { workspace = true }
 notify-types = { workspace = true }
 crossbeam-channel = { workspace = true, optional = true }
 file-id = { workspace = true }

--- a/notify-debouncer-full/Cargo.toml
+++ b/notify-debouncer-full/Cargo.toml
@@ -1,16 +1,16 @@
 [package]
 name = "notify-debouncer-full"
 version = "0.4.0"
-edition = "2021"
-rust-version = "1.65"
 description = "notify event debouncer optimized for ease of use"
 documentation = "https://docs.rs/notify-debouncer-full"
-homepage = "https://github.com/notify-rs/notify"
-repository = "https://github.com/notify-rs/notify.git"
 authors = ["Daniel Faust <hessijames@gmail.com>"]
 keywords = ["events", "filesystem", "notify", "watch"]
 license = "MIT OR Apache-2.0"
 readme = "README.md"
+rust-version = { workspace = true }
+edition = { workspace = true }
+homepage = { workspace = true }
+repository = { workspace = true }
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
@@ -28,18 +28,18 @@ macos_fsevent = ["notify/macos_fsevent"]
 macos_kqueue = ["notify/macos_kqueue"]
 
 [dependencies]
-notify = { version = "6.1.1", path = "../notify", default-features = false }
-notify-types = { version = "1.0.0", path = "../notify-types" }
-crossbeam-channel = { version = "0.5", optional = true }
-file-id = { version = "0.2.1", path = "../file-id" }
-walkdir = "2.2.2"
-log = "0.4.17"
-mock_instant = { version = "0.3.0", optional = true }
+notify = { workspace = true, default-features = false }
+notify-types = { workspace = true }
+crossbeam-channel = { workspace = true, optional = true }
+file-id = { workspace = true }
+walkdir = { workspace = true }
+log = { workspace = true }
+mock_instant = { workspace = true, optional = true }
 
 [dev-dependencies]
-notify-debouncer-full = { path = ".", features = ["mock_instant"] }
-pretty_assertions = "1.3.0"
-rstest = "0.17.0"
-serde = { version = "1.0.89", features = ["derive"] }
-deser-hjson = "1.1.1"
-rand = "0.8.5"
+notify-debouncer-full = { workspace = true, features = ["mock_instant"] }
+pretty_assertions = { workspace = true }
+rstest = { workspace = true }
+serde = { workspace = true }
+deser-hjson = { workspace = true }
+rand = { workspace = true }

--- a/notify-debouncer-full/README.md
+++ b/notify-debouncer-full/README.md
@@ -14,27 +14,7 @@ A debouncer for [notify] that is optimized for ease of use.
 
 ## Features
 
-- `crossbeam` enabled by default, for crossbeam channel support.
-
-  This may create problems used in tokio environments. See [#380](https://github.com/notify-rs/notify/issues/380).  
-  Use something like the following to disable it.
-  
-  ```toml
-  notify-debouncer-full = { version = "*", default-features = false }
-  ```
-  
-  This also passes through to notify as `crossbeam-channel` feature.
-
-  On MacOS, when disabling default features, enable either the `macos_fsevent` feature
-  or, on latest MacOS, the `macos_kqueue` feature to be passed through to notify.
-
-  ```toml
-  # Using FSEvents
-  notify-debouncer-full = { version = "*", default-features = false, features = ["macos_fsevent"] }
-
-  # Using Kernel Queues
-  notify-debouncer-full = { version = "*", default-features = false, features = ["macos_kqueue"] }
-  ```
+- `crossbeam-channel` passed down to notify, off by default
 
 [docs]: https://docs.rs/notify-debouncer-full
 [notify]: https://crates.io/crates/notify

--- a/notify-debouncer-full/src/lib.rs
+++ b/notify-debouncer-full/src/lib.rs
@@ -49,9 +49,7 @@
 //!
 //! The following crate features can be turned on or off in your cargo dependency config:
 //!
-//! - `crossbeam` enabled by default, adds [`DebounceEventHandler`](DebounceEventHandler) support for crossbeam channels.
-//!   Also enables crossbeam-channel in the re-exported notify. You may want to disable this when using the tokio async runtime.
-//! - `serde` enables serde support for events.
+//! - `crossbeam` passed down to notify, off by default
 //!
 //! # Caveats
 //!

--- a/notify-debouncer-mini/Cargo.toml
+++ b/notify-debouncer-mini/Cargo.toml
@@ -2,7 +2,7 @@
 name = "notify-debouncer-mini"
 version = "0.4.1"
 edition = "2021"
-rust-version = "1.63"
+rust-version = "1.65"
 description = "notify mini debouncer for events"
 documentation = "https://docs.rs/notify-debouncer-mini"
 homepage = "https://github.com/notify-rs/notify"

--- a/notify-debouncer-mini/Cargo.toml
+++ b/notify-debouncer-mini/Cargo.toml
@@ -1,16 +1,16 @@
 [package]
 name = "notify-debouncer-mini"
 version = "0.4.1"
-edition = "2021"
-rust-version = "1.65"
 description = "notify mini debouncer for events"
 documentation = "https://docs.rs/notify-debouncer-mini"
-homepage = "https://github.com/notify-rs/notify"
-repository = "https://github.com/notify-rs/notify.git"
 authors = ["Aron Heinecke <Ox0p54r36@t-online.de>"]
 keywords = ["events", "filesystem", "notify", "watch"]
 license = "MIT OR Apache-2.0"
 readme = "README.md"
+rust-version = { workspace = true }
+edition = { workspace = true }
+homepage = { workspace = true }
+repository = { workspace = true }
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
@@ -27,7 +27,7 @@ macos_fsevent = ["notify/macos_fsevent"]
 macos_kqueue = ["notify/macos_kqueue"]
 
 [dependencies]
-notify = { version = "6.1.1", path = "../notify", default-features = false }
-notify-types = { version = "1.0.0", path = "../notify-types" }
-crossbeam-channel = { version = "0.5", optional = true }
-log = "0.4.17"
+notify = { workspace = true, default-features = false }
+notify-types = { workspace = true }
+crossbeam-channel = { workspace = true, optional = true }
+log = { workspace = true }

--- a/notify-debouncer-mini/Cargo.toml
+++ b/notify-debouncer-mini/Cargo.toml
@@ -12,22 +12,15 @@ edition = { workspace = true }
 homepage = { workspace = true }
 repository = { workspace = true }
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
-[lib]
-name = "notify_debouncer_mini"
-path = "src/lib.rs"
-
 [features]
-default = ["crossbeam","macos_fsevent"]
+default = ["macos_fsevent"]
 serde = ["notify-types/serde"]
-# can't use dep:crossbeam-channel and feature name crossbeam-channel below rust 1.60
-crossbeam = ["crossbeam-channel","notify/crossbeam-channel"]
+crossbeam-channel = ["dep:crossbeam-channel", "notify/crossbeam-channel"]
 macos_fsevent = ["notify/macos_fsevent"]
 macos_kqueue = ["notify/macos_kqueue"]
 
 [dependencies]
-notify = { workspace = true, default-features = false }
+notify = { workspace = true }
 notify-types = { workspace = true }
 crossbeam-channel = { workspace = true, optional = true }
 log = { workspace = true }

--- a/notify-debouncer-mini/README.md
+++ b/notify-debouncer-mini/README.md
@@ -6,27 +6,8 @@ Tiny debouncer for [notify]. Filters incoming events and emits only one event pe
 
 ## Features
 
-- `crossbeam` enabled by default, for crossbeam channel support.
+- `crossbeam-channel` passed down to notify, off by default
 
-  This may create problems used in tokio environments. See [#380](https://github.com/notify-rs/notify/issues/380).
-  Use something like the following to disable it.
-
-  ```toml
-  notify-debouncer-mini = { version = "*", default-features = false }
-  ```
-
-  This also passes through to notify as `crossbeam-channel` feature.
-
-  On MacOS, when disabling default features, enable either the `macos_fsevent` feature
-  or, on latest MacOS, the `macos_kqueue` feature to be passed through to notify.
-
-  ```toml
-  # Using FSEvents
-  notify-debouncer-mini = { version = "*", default-features = false, features = ["macos_fsevent"] }
-
-  # Using Kernel Queues
-  notify-debouncer-mini = { version = "*", default-features = false, features = ["macos_kqueue"] }
-  ```
 - `serde` for serde support of event types, off by default
 
 [docs]: https://docs.rs/notify-debouncer-mini

--- a/notify-debouncer-mini/src/lib.rs
+++ b/notify-debouncer-mini/src/lib.rs
@@ -45,9 +45,8 @@
 //!
 //! The following crate features can be turned on or off in your cargo dependency config:
 //!
-//! - `crossbeam` enabled by default, adds [`DebounceEventHandler`](DebounceEventHandler) support for crossbeam channels.
-//!   Also enables crossbeam-channel in the re-exported notify. You may want to disable this when using the tokio async runtime.
-//! - `serde` enables serde support for events.
+//! - `crossbeam` passed down to notify, off by default
+//! - `serde` enables serde support for events, off by default
 //!
 //! # Caveats
 //!

--- a/notify-types/Cargo.toml
+++ b/notify-types/Cargo.toml
@@ -1,24 +1,23 @@
 [package]
 name = "notify-types"
 version = "1.0.0"
-rust-version = "1.65"
 description = "Types used by the notify crate"
 documentation = "https://docs.rs/notify-types"
-homepage = "https://github.com/notify-rs/notify"
-repository = "https://github.com/notify-rs/notify.git"
 readme = "../README.md"
 license = "MIT OR Apache-2.0"
 keywords = ["events", "filesystem", "notify", "watch"]
 categories = ["filesystem"]
 authors = ["Daniel Faust <hessijames@gmail.com>"]
-
-edition = "2021"
+rust-version = { workspace = true }
+edition = { workspace = true }
+homepage = { workspace = true }
+repository = { workspace = true }
 
 [dependencies]
-serde = { version = "1.0.89", features = ["derive"], optional = true }
-mock_instant = { version = "0.3.0", optional = true }
+serde = { workspace = true, optional = true }
+mock_instant = { workspace = true, optional = true }
 
 [dev-dependencies]
-serde_json = "1.0.39"
-insta = "1.34.0"
-rstest = "0.17.0"
+serde_json = { workspace = true }
+insta = { workspace = true }
+rstest = { workspace = true }

--- a/notify-types/Cargo.toml
+++ b/notify-types/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "notify-types"
 version = "1.0.0"
-rust-version = "1.63"
+rust-version = "1.65"
 description = "Types used by the notify crate"
 documentation = "https://docs.rs/notify-types"
 homepage = "https://github.com/notify-rs/notify"

--- a/notify/Cargo.toml
+++ b/notify/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "notify"
 version = "6.1.1"
-rust-version = "1.63"
+rust-version = "1.65"
 description = "Cross-platform filesystem notification library"
 documentation = "https://docs.rs/notify"
 homepage = "https://github.com/notify-rs/notify"

--- a/notify/Cargo.toml
+++ b/notify/Cargo.toml
@@ -17,6 +17,12 @@ edition = { workspace = true }
 homepage = { workspace = true }
 repository = { workspace = true }
 
+[features]
+default = ["macos_fsevent"]
+serde = ["notify-types/serde"]
+macos_kqueue = ["kqueue", "mio"]
+macos_fsevent = ["fsevent-sys"]
+
 [dependencies]
 notify-types = { workspace = true }
 crossbeam-channel = { workspace = true, optional = true }
@@ -48,11 +54,3 @@ tempfile = { workspace = true }
 nix = { workspace = true }
 insta = { workspace = true }
 rstest = { workspace = true }
-
-[features]
-default = ["macos_fsevent","crossbeam-channel"]
-serde = ["notify-types/serde"]
-timing_tests = []
-manual_tests = []
-macos_kqueue = ["kqueue", "mio"]
-macos_fsevent = ["fsevent-sys"]

--- a/notify/Cargo.toml
+++ b/notify/Cargo.toml
@@ -1,11 +1,8 @@
 [package]
 name = "notify"
 version = "6.1.1"
-rust-version = "1.65"
 description = "Cross-platform filesystem notification library"
 documentation = "https://docs.rs/notify"
-homepage = "https://github.com/notify-rs/notify"
-repository = "https://github.com/notify-rs/notify.git"
 readme = "../README.md"
 license = "CC0-1.0"
 keywords = ["events", "filesystem", "notify", "watch"]
@@ -15,40 +12,42 @@ authors = [
   "Daniel Faust <hessijames@gmail.com>",
   "Aron Heinecke <Ox0p54r36@t-online.de>"
 ]
-
-edition = "2021"
+rust-version = { workspace = true }
+edition = { workspace = true }
+homepage = { workspace = true }
+repository = { workspace = true }
 
 [dependencies]
-notify-types = { version = "1.0.0", path = "../notify-types" }
-crossbeam-channel = { version = "0.5.0", optional = true }
-filetime = "0.2.22"
-libc = "0.2.4"
-log = "0.4.17"
-walkdir = "2.2.2"
+notify-types = { workspace = true }
+crossbeam-channel = { workspace = true, optional = true }
+filetime = { workspace = true }
+libc = { workspace = true }
+log = { workspace = true }
+walkdir = { workspace = true }
 
 [target.'cfg(any(target_os="linux", target_os="android"))'.dependencies]
-inotify = { version = "0.10", default-features = false }
-mio = { version = "0.8", features = ["os-ext"] }
+inotify = { workspace = true, default-features = false }
+mio = { workspace = true }
 
 [target.'cfg(target_os="macos")'.dependencies]
-bitflags = "2.3.0"
-fsevent-sys = { version = "4", optional = true }
-kqueue = { version = "1.0", optional = true }
-mio = { version = "0.8", features = ["os-ext"], optional = true }
+bitflags = { workspace = true }
+fsevent-sys = { workspace = true, optional = true }
+kqueue = { workspace = true, optional = true }
+mio = { workspace = true, optional = true }
 
 [target.'cfg(windows)'.dependencies]
-windows-sys = { version = "0.48.0", features = ["Win32_System_Threading", "Win32_Foundation", "Win32_Storage_FileSystem", "Win32_Security", "Win32_System_WindowsProgramming", "Win32_System_IO"] }
+windows-sys = { workspace = true, features = ["Win32_System_Threading", "Win32_Foundation", "Win32_Storage_FileSystem", "Win32_Security", "Win32_System_WindowsProgramming", "Win32_System_IO"] }
 
 [target.'cfg(any(target_os="freebsd", target_os="openbsd", target_os = "netbsd", target_os = "dragonflybsd", target_os = "ios"))'.dependencies]
-kqueue = "^1.0.4" # fix for #344
-mio = { version = "0.8", features = ["os-ext"] }
+kqueue = { workspace = true }
+mio = { workspace = true }
 
 [dev-dependencies]
-serde_json = "1.0.39"
-tempfile = "3.2.0"
-nix = "0.23.1"
-insta = "1.34.0"
-rstest = "0.17.0"
+serde_json = { workspace = true }
+tempfile = { workspace = true }
+nix = { workspace = true }
+insta = { workspace = true }
+rstest = { workspace = true }
 
 [features]
 default = ["macos_fsevent","crossbeam-channel"]

--- a/notify/src/error.rs
+++ b/notify/src/error.rs
@@ -131,25 +131,12 @@ impl From<io::Error> for Error {
     }
 }
 
-#[cfg(feature = "crossbeam-channel")]
-impl<T> From<crossbeam_channel::SendError<T>> for Error {
-    fn from(err: crossbeam_channel::SendError<T>) -> Self {
-        Error::generic(&format!("internal channel disconnect: {:?}", err))
-    }
-}
-#[cfg(not(feature = "crossbeam-channel"))]
 impl<T> From<std::sync::mpsc::SendError<T>> for Error {
     fn from(err: std::sync::mpsc::SendError<T>) -> Self {
         Error::generic(&format!("internal channel disconnect: {:?}", err))
     }
 }
-#[cfg(feature = "crossbeam-channel")]
-impl From<crossbeam_channel::RecvError> for Error {
-    fn from(err: crossbeam_channel::RecvError) -> Self {
-        Error::generic(&format!("internal channel disconnect: {:?}", err))
-    }
-}
-#[cfg(not(feature = "crossbeam-channel"))]
+
 impl From<std::sync::mpsc::RecvError> for Error {
     fn from(err: std::sync::mpsc::RecvError) -> Self {
         Error::generic(&format!("internal channel disconnect: {:?}", err))

--- a/notify/src/lib.rs
+++ b/notify/src/lib.rs
@@ -17,7 +17,7 @@
 //! - `serde` for serialization of events
 //! - `macos_fsevent` enabled by default, for fsevent backend on macos
 //! - `macos_kqueue` for kqueue backend on macos
-//! - `crossbeam-channel` enabled by default, see below
+//! - `crossbeam-channel` see below
 //!
 //! ### Serde
 //!

--- a/notify/src/lib.rs
+++ b/notify/src/lib.rs
@@ -17,7 +17,6 @@
 //! - `serde` for serialization of events
 //! - `macos_fsevent` enabled by default, for fsevent backend on macos
 //! - `macos_kqueue` for kqueue backend on macos
-//! - `crossbeam-channel` see below
 //!
 //! ### Serde
 //!
@@ -26,19 +25,6 @@
 //! ```toml
 //! notify = { version = "6.1.1", features = ["serde"] }
 //! ```
-//!
-//! ### Crossbeam-Channel & Tokio
-//!
-//! By default crossbeam-channel is used internally by notify. Which also allows the [Watcher] to be sync.
-//! This can [cause issues](https://github.com/notify-rs/notify/issues/380) when used inside tokio.
-//!
-//! You can disable crossbeam-channel, letting notify fallback to std channels via
-//!
-//! ```toml
-//! notify = { version = "6.1.1", default-features = false, features = ["macos_kqueue"] }
-//! // Alternatively macos_fsevent instead of macos_kqueue
-//! ```
-//! Note the `macos_kqueue` requirement here, otherwise no native backend is available on macos.
 //!
 //! # Known Problems
 //!
@@ -181,44 +167,18 @@ pub use error::{Error, ErrorKind, Result};
 pub use notify_types::event::{self, Event, EventKind};
 use std::path::Path;
 
-#[allow(dead_code)]
-#[cfg(feature = "crossbeam-channel")]
-pub(crate) type Receiver<T> = crossbeam_channel::Receiver<T>;
-#[allow(dead_code)]
-#[cfg(not(feature = "crossbeam-channel"))]
 pub(crate) type Receiver<T> = std::sync::mpsc::Receiver<T>;
-
-#[allow(dead_code)]
-#[cfg(feature = "crossbeam-channel")]
-pub(crate) type Sender<T> = crossbeam_channel::Sender<T>;
-#[allow(dead_code)]
-#[cfg(not(feature = "crossbeam-channel"))]
 pub(crate) type Sender<T> = std::sync::mpsc::Sender<T>;
-
-// std limitation
-#[allow(dead_code)]
-#[cfg(feature = "crossbeam-channel")]
-pub(crate) type BoundSender<T> = crossbeam_channel::Sender<T>;
-#[allow(dead_code)]
-#[cfg(not(feature = "crossbeam-channel"))]
 pub(crate) type BoundSender<T> = std::sync::mpsc::SyncSender<T>;
 
-#[allow(dead_code)]
 #[inline]
 pub(crate) fn unbounded<T>() -> (Sender<T>, Receiver<T>) {
-    #[cfg(feature = "crossbeam-channel")]
-    return crossbeam_channel::unbounded();
-    #[cfg(not(feature = "crossbeam-channel"))]
-    return std::sync::mpsc::channel();
+    std::sync::mpsc::channel()
 }
 
-#[allow(dead_code)]
 #[inline]
 pub(crate) fn bounded<T>(cap: usize) -> (BoundSender<T>, Receiver<T>) {
-    #[cfg(feature = "crossbeam-channel")]
-    return crossbeam_channel::bounded(cap);
-    #[cfg(not(feature = "crossbeam-channel"))]
-    return std::sync::mpsc::sync_channel(cap);
+    std::sync::mpsc::sync_channel(cap)
 }
 
 #[cfg(all(target_os = "macos", not(feature = "macos_kqueue")))]

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,2 @@
+[toolchain]
+channel = "1.65.0"

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "1.65.0"
+channel = "1.72.1"


### PR DESCRIPTION
- Raise MSRV to 1.72
- Remove internal use of crossbeam because `std::sync::mpsc::Sender` implements `Sync` since version 1.72, so there is no need for crossbeam anymore
- Specify dependencies in workspace

I screwed up a bit and this PR is based on my previous on (#567).