### PR TITLE
Use instant crate

### DIFF
--- a/notify-types/Cargo.toml
+++ b/notify-types/Cargo.toml
@@ -15,6 +15,7 @@ authors = ["Daniel Faust <hessijames@gmail.com>"]
 edition = "2021"
 
 [dependencies]
+instant = "0.1.12"
 serde = { version = "1.0.89", features = ["derive"], optional = true }
 mock_instant = { version = "0.3.0", optional = true }
 

--- a/notify-types/src/debouncer_full.rs
+++ b/notify-types/src/debouncer_full.rs
@@ -4,7 +4,7 @@ use std::ops::{Deref, DerefMut};
 use mock_instant::Instant;
 
 #[cfg(not(feature = "mock_instant"))]
-use std::time::Instant;
+use instant::Instant;
 
 use crate::event::Event;
 


### PR DESCRIPTION
Prevents ugly surprises when using notify-types in a wasm environment.

I screwed up a bit and this PR is based on my previous on (#567).