### PR TITLE
Remove mention of immediate mode in the docs

### DIFF
--- a/notify/src/lib.rs
+++ b/notify/src/lib.rs
@@ -411,10 +411,7 @@ pub type RecommendedWatcher = KqueueWatcher;
 )))]
 pub type RecommendedWatcher = PollWatcher;
 
-/// Convenience method for creating the `RecommendedWatcher` for the current platform in
-/// _immediate_ mode.
-///
-/// See [`Watcher::new_immediate`](trait.Watcher.html#tymethod.new_immediate).
+/// Convenience method for creating the `RecommendedWatcher` for the current platform.
 pub fn recommended_watcher<F>(event_handler: F) -> Result<RecommendedWatcher>
 where
     F: EventHandler,


### PR DESCRIPTION
Notion of "immediate mode" was removed in https://github.com/notify-rs/notify/pull/336.
