### PR TITLE
Enable PollWatcher to identify folder and file events

### DIFF
--- a/notify/src/poll.rs
+++ b/notify/src/poll.rs
@@ -401,7 +401,7 @@ mod data {
                     if _new.path_type.is_dir() {
                         Some(EventKind::Create(CreateKind::Folder))
                     }
-                    else if _new.path_type.is_dir() {
+                    else if _new.path_type.is_file() {
                         Some(EventKind::Create(CreateKind::File))
                     }
                     else {
@@ -413,7 +413,7 @@ mod data {
                     if _old.path_type.is_dir() {
                         Some(EventKind::Remove(RemoveKind::Folder))
                     }
-                    else if _old.path_type.is_dir() {
+                    else if _old.path_type.is_file() {
                         Some(EventKind::Remove(RemoveKind::File))
                     }
                     else {

--- a/notify/src/poll.rs
+++ b/notify/src/poll.rs
@@ -351,7 +351,7 @@ mod data {
                     }),
 
                 last_check: data_builder.now,
-                path_type: file_type.clone(),
+                path_type: *file_type,
             }
         }
 


### PR DESCRIPTION
Enable PollWatcher to identify folder and file events.

While doing WalkDir we can identify which type of event to trigger and trigger event specifying it.
