### PR TITLE
Update `windows-sys` to `0.52`

### DIFF
--- a/notify/Cargo.toml
+++ b/notify/Cargo.toml
@@ -37,7 +37,7 @@ kqueue = { version = "1.0", optional = true }
 mio = { version = "0.8", features = ["os-ext"], optional = true }
 
 [target.'cfg(windows)'.dependencies]
-windows-sys = { version = "0.48.0", features = ["Win32_System_Threading", "Win32_Foundation", "Win32_Storage_FileSystem", "Win32_Security", "Win32_System_WindowsProgramming", "Win32_System_IO"] }
+windows-sys = { version = "0.52.0", features = ["Win32_System_Threading", "Win32_Foundation", "Win32_Storage_FileSystem", "Win32_Security", "Win32_System_WindowsProgramming", "Win32_System_IO"] }
 
 [target.'cfg(any(target_os="freebsd", target_os="openbsd", target_os = "netbsd", target_os = "dragonflybsd", target_os = "ios"))'.dependencies]
 kqueue = "^1.0.4" # fix for #344


### PR DESCRIPTION
Required for building on certain targets on newer versions of Rust (see https://github.com/microsoft/windows-rs/pull/2774).