### PR TITLE
Fix build for DragonFlyBSD.

### DIFF
--- a/notify/Cargo.toml
+++ b/notify/Cargo.toml
@@ -39,7 +39,7 @@ mio = { version = "0.8", features = ["os-ext"], optional = true }
 [target.'cfg(windows)'.dependencies]
 windows-sys = { version = "0.48.0", features = ["Win32_System_Threading", "Win32_Foundation", "Win32_Storage_FileSystem", "Win32_Security", "Win32_System_WindowsProgramming", "Win32_System_IO"] }
 
-[target.'cfg(any(target_os="freebsd", target_os="openbsd", target_os = "netbsd", target_os = "dragonflybsd", target_os = "ios"))'.dependencies]
+[target.'cfg(any(target_os="freebsd", target_os="openbsd", target_os = "netbsd", target_os = "dragonfly", target_os = "ios"))'.dependencies]
 kqueue = "^1.0.4" # fix for #344
 mio = { version = "0.8", features = ["os-ext"] }
 

--- a/notify/src/lib.rs
+++ b/notify/src/lib.rs
@@ -120,7 +120,7 @@
 //! #     #[cfg(not(any(
 //! #     target_os = "freebsd",
 //! #     target_os = "openbsd",
-//! #     target_os = "dragonflybsd",
+//! #     target_os = "dragonfly",
 //! #     target_os = "netbsd")))]
 //! #     { // "." doesn't exist on BSD for some reason in CI
 //!     watcher.watch(Path::new("."), RecursiveMode::Recursive)?;
@@ -163,7 +163,7 @@
 //! #     #[cfg(not(any(
 //! #     target_os = "freebsd",
 //! #     target_os = "openbsd",
-//! #     target_os = "dragonflybsd",
+//! #     target_os = "dragonfly",
 //! #     target_os = "netbsd")))]
 //! #     { // "." doesn't exist on BSD for some reason in CI
 //! #     watcher1.watch(Path::new("."), RecursiveMode::Recursive)?;
@@ -230,7 +230,7 @@ pub use crate::inotify::INotifyWatcher;
     target_os = "freebsd",
     target_os = "openbsd",
     target_os = "netbsd",
-    target_os = "dragonflybsd",
+    target_os = "dragonfly",
     target_os = "ios",
     all(target_os = "macos", feature = "macos_kqueue")
 ))]
@@ -247,7 +247,7 @@ pub mod inotify;
 #[cfg(any(
     target_os = "freebsd",
     target_os = "openbsd",
-    target_os = "dragonflybsd",
+    target_os = "dragonfly",
     target_os = "netbsd",
     target_os = "ios",
     all(target_os = "macos", feature = "macos_kqueue")
@@ -393,7 +393,7 @@ pub type RecommendedWatcher = ReadDirectoryChangesWatcher;
     target_os = "freebsd",
     target_os = "openbsd",
     target_os = "netbsd",
-    target_os = "dragonflybsd",
+    target_os = "dragonfly",
     target_os = "ios",
     all(target_os = "macos", feature = "macos_kqueue")
 ))]
@@ -407,7 +407,7 @@ pub type RecommendedWatcher = KqueueWatcher;
     target_os = "freebsd",
     target_os = "openbsd",
     target_os = "netbsd",
-    target_os = "dragonflybsd",
+    target_os = "dragonfly",
     target_os = "ios"
 )))]
 pub type RecommendedWatcher = PollWatcher;


### PR DESCRIPTION
The correct `target_os` for this is `dragonfly`, not `dragonflybsd`.

This was introduced in 8399e4195b31f6f188109363292ed220226146f4.
