### PR TITLE
ci: Update to `actions/checkout` `v4` from `v3`

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -28,7 +28,7 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: setup toolchain
         # `--no-self-update` is needed due to a permission issue on the GHA env.
@@ -106,7 +106,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: setup toolchain
         # `--no-self-update` is needed due to a permission issue on the GHA env.
@@ -129,7 +129,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: install cargo-audit
         run: |


### PR DESCRIPTION
This updates to a newer version of Node within the GitHub Action and eliminates a warning about using the old version within the Actions UI.
