### PR TITLE
clippy: Fix (nightly) `legacy_numeric_constants` lints.

### DIFF
--- a/notify-debouncer-full/src/cache.rs
+++ b/notify-debouncer-full/src/cache.rs
@@ -53,7 +53,7 @@ impl FileIdMap {
 
     fn dir_scan_depth(is_recursive: bool) -> usize {
         if is_recursive {
-            usize::max_value()
+            usize::MAX
         } else {
             1
         }

--- a/notify/src/poll.rs
+++ b/notify/src/poll.rs
@@ -307,7 +307,7 @@ mod data {
 
         fn dir_scan_depth(is_recursive: bool) -> usize {
             if is_recursive {
-                usize::max_value()
+                usize::MAX
             } else {
                 1
             }


### PR DESCRIPTION
These functions are marked as pending deprecation and it is suggested to use the associated consts instead.