### PR TITLE
Changed tokio crossbeam example from kqueue to fsevent

### DIFF
--- a/notify/src/lib.rs
+++ b/notify/src/lib.rs
@@ -36,10 +36,9 @@
 //! You can disable crossbeam-channel, letting notify fallback to std channels via
 //!
 //! ```toml
-//! notify = { version = "6.1.1", default-features = false, features = ["macos_kqueue"] }
-//! // Alternatively macos_fsevent instead of macos_kqueue
+//! notify = { version = "6.1.1", default-features = false, features = ["macos_fsevent"] }
 //! ```
-//! Note the `macos_kqueue` requirement here, otherwise no native backend is available on macos.
+//! Note the `macos_fsevent` requirement here, otherwise no native backend is available on macos.
 //!
 //! # Known Problems
 //!


### PR DESCRIPTION
- This pull request changes the example code for turning off crossbeam for tokio to use `macos_fsevent` instead of `macos_kqueue`

- I'm suggesting this change based off [the issue I'm seeing with too many open files with kqueue](https://github.com/notify-rs/notify/issues/596)

- My thinking is that this will help prevent folks running into the `kqueue` by using `fsevent` instead

