### PR TITLE
Make `ErrorKind::PathNotFound` consistent on inotify

### DIFF
--- a/notify/src/error.rs
+++ b/notify/src/error.rs
@@ -81,6 +81,15 @@ impl Error {
         Self::new(ErrorKind::Io(err))
     }
 
+    /// Similar to [`Error::io`], but specifically handles [`io::ErrorKind::NotFound`].
+    pub fn io_watch(err: io::Error) -> Self {
+        if err.kind() == io::ErrorKind::NotFound {
+            Self::path_not_found()
+        } else {
+            Self::io(err)
+        }
+    }
+
     /// Creates a new "path not found" error.
     pub fn path_not_found() -> Self {
         Self::new(ErrorKind::PathNotFound)

--- a/notify/src/inotify.rs
+++ b/notify/src/inotify.rs
@@ -393,7 +393,7 @@ impl EventLoop {
     fn add_watch(&mut self, path: PathBuf, is_recursive: bool, mut watch_self: bool) -> Result<()> {
         // If the watch is not recursive, or if we determine (by stat'ing the path to get its
         // metadata) that the watched path is not a directory, add a single path watch.
-        if !is_recursive || !metadata(&path).map_err(Error::io)?.is_dir() {
+        if !is_recursive || !metadata(&path).map_err(Error::io_watch)?.is_dir() {
             return self.add_single_watch(path, false, true);
         }
 


### PR DESCRIPTION
Before this patch, watching a nonexistent path using inotify backend would give an `ErrorKind::Io` variant. This behavior was inconsistent with other backends.

I am not sure if this is expected but taking #110 into consideration I think the path error ought to be consistent.

Run the inotify watcher on Linux:
```rust
let error = watcher.watch(Path::new("/nonexistent"), notify::RecursiveMode::Recursive).unwrap_err();
```

Before:
```
Error { kind: Io(Os { code: 2, kind: NotFound, message: "No such file or directory" }), paths: [] }
```

After:
```
Error { kind: PathNotFound, paths: [] }
```


<!-- By contributing, you agree to the terms of the license, available in the LICENSE.ARTISTIC file, and of the code of conduct, available in the CODE_OF_CONDUCT.md file. Furthermore, you agree to release under CC0, also available in the LICENSE file, until Notify has fully transitioned to Artistic 2.0. -->

<!-- After creating this pull request, the test suite will run.

It is expected that if any failures occur in the builds, you either:

- fix the errors,
- ask for help, or
- note that the failures are expected with a detailed explanation.

If you do not, a maintainer may prompt you and/or do it themselves, but do note that it will take longer for your contribution to be reviewed if the build does not pass.

Running `cargo fmt` and/or `cargo clippy` is NOT required but appreciated!

You can remove this text. -->
