### PR TITLE
Set `WatchMask::OPEN` on inotify

### DIFF
--- a/notify/src/inotify.rs
+++ b/notify/src/inotify.rs
@@ -417,6 +417,7 @@ impl EventLoop {
     ) -> Result<()> {
         let mut watchmask = WatchMask::ATTRIB
             | WatchMask::CREATE
+            | WatchMask::OPEN
             | WatchMask::DELETE
             | WatchMask::CLOSE_WRITE
             | WatchMask::MODIFY


### PR DESCRIPTION
This fixes the problem of `Access(Open(_))` variant not being reported.

The event variant is constructed, but `watchmask` does not have `WatchMask::OPEN` set.

https://github.com/notify-rs/notify/blob/f9c15ebf2cfd6a45f57c45290d0579846739fdbd/notify/src/inotify.rs#L354-L361

<!-- By contributing, you agree to the terms of the license, available in the LICENSE.ARTISTIC file, and of the code of conduct, available in the CODE_OF_CONDUCT.md file. Furthermore, you agree to release under CC0, also available in the LICENSE file, until Notify has fully transitioned to Artistic 2.0. -->

<!-- After creating this pull request, the test suite will run.

It is expected that if any failures occur in the builds, you either:

- fix the errors,
- ask for help, or
- note that the failures are expected with a detailed explanation.

If you do not, a maintainer may prompt you and/or do it themselves, but do note that it will take longer for your contribution to be reviewed if the build does not pass.

Running `cargo fmt` and/or `cargo clippy` is NOT required but appreciated!

You can remove this text. -->
