### PR TITLE
Fix: Low Res and high Res ID inversion

### DIFF
--- a/file-id/src/lib.rs
+++ b/file-id/src/lib.rs
@@ -129,7 +129,7 @@ pub fn get_file_id(path: impl AsRef<Path>) -> io::Result<FileId> {
 pub fn get_low_res_file_id(path: impl AsRef<Path>) -> io::Result<FileId> {
     let file = open_file(path)?;
 
-    unsafe { get_file_info_ex(&file) }
+    unsafe { get_file_info(&file) }
 }
 
 /// Get the `FileId` with the high resolution variant for the file or directory at `path`
@@ -137,7 +137,7 @@ pub fn get_low_res_file_id(path: impl AsRef<Path>) -> io::Result<FileId> {
 pub fn get_high_res_file_id(path: impl AsRef<Path>) -> io::Result<FileId> {
     let file = open_file(path)?;
 
-    unsafe { get_file_info(&file) }
+    unsafe { get_file_info_ex(&file) }
 }
 
 #[cfg(target_family = "windows")]


### PR DESCRIPTION
<!-- By contributing, you agree to the terms of the license, available in the LICENSE.ARTISTIC file, and of the code of conduct, available in the CODE_OF_CONDUCT.md file. Furthermore, you agree to release under CC0, also available in the LICENSE file, until Notify has fully transitioned to Artistic 2.0. -->

<!-- After creating this pull request, the test suite will run.

It is expected that if any failures occur in the builds, you either:

- fix the errors,
- ask for help, or
- note that the failures are expected with a detailed explanation.

If you do not, a maintainer may prompt you and/or do it themselves, but do note that it will take longer for your contribution to be reviewed if the build does not pass.

Running `cargo fmt` and/or `cargo clippy` is NOT required but appreciated!

You can remove this text. -->

It looks like the get_low_res_file_id() and get_high_res_file_id() functions in the file_id crate are mistakenly calling opposite underlying functions. At least that's how I understand it, there's something wrong here.
