### PR TITLE
Suppress `dead_code` warnings on some platforms.

### DIFF
--- a/notify/src/lib.rs
+++ b/notify/src/lib.rs
@@ -170,6 +170,7 @@ use std::path::Path;
 
 pub(crate) type Receiver<T> = std::sync::mpsc::Receiver<T>;
 pub(crate) type Sender<T> = std::sync::mpsc::Sender<T>;
+#[allow(dead_code)] // This is not used on all platforms.
 pub(crate) type BoundSender<T> = std::sync::mpsc::SyncSender<T>;
 
 #[inline]
@@ -177,6 +178,7 @@ pub(crate) fn unbounded<T>() -> (Sender<T>, Receiver<T>) {
     std::sync::mpsc::channel()
 }
 
+#[allow(dead_code)] // This is not used on all platforms.
 #[inline]
 pub(crate) fn bounded<T>(cap: usize) -> (BoundSender<T>, Receiver<T>) {
     std::sync::mpsc::sync_channel(cap)


### PR DESCRIPTION
Not all platforms use the `BoundSender` and `bounded` and on those, building results in `dead_code` warnings.
