### PR TITLE
deps: Update `mio` to 1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ v4 commits split out to branch `v4_maintenance` starting with `4.0.16`
 
 - CHANGE: raise MSRV to 1.72
 - CHANGE: remove internal use of crossbeam-channels
+- CHANGE: upgrade mio to 1.0
 
 ## notify-types 1.0.0
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,7 @@ insta = "1.34.0"
 kqueue = "1.0.8"
 libc = "0.2.4"
 log = "0.4.17"
-mio = { version = "0.8.10", features = ["os-ext"] }
+mio = { version = "1.0", features = ["os-ext"] }
 mock_instant = "0.3.0"
 instant = "0.1.12"
 nix = "0.27.0"


### PR DESCRIPTION
This removes building a version of the Windows API bindings and now only one is built.