### PR TITLE
Remove mock instant

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,18 +14,20 @@ v4 commits split out to branch `v4_maintenance` starting with `4.0.16`
 
 ## notify 7.0.0 (unreleased)
 
-- CHANGE: raise MSRV to 1.72 [#569] [#610]
+- CHANGE: raise MSRV to 1.72 [#569] [#610] **breaking**
 - CHANGE: move event type to notify-types crate [#559]
 - CHANGE: flatten serialization of events and use camelCase [#558]
-- CHANGE: remove internal use of crossbeam-channels [#569] [#610]
-- CHANGE: rename feature `crossbeam` to `crossbeam-channels`
+- CHANGE: remove internal use of crossbeam channels [#569] [#610]
+- CHANGE: rename feature `crossbeam` to `crossbeam-channel` and disable it by default [#610] **breaking**
 - CHANGE: upgrade mio to 1.0 [#623]
+- CHANGE: add log statements [#499]
 - FIX: prevent UB with illegal instruction for the windows backend [#604] [#607]
 - FIX: on Linux report deleted directories correctly [#545]
 - FEATURE: enable kqueue on iOS [#533]
 - MISC: various minor doc updates and fixes [#535] [#536] [#543] [#565] [#592] [#595]
 - MISC: update inotify to 0.10 [#547]
 
+[#499]: https://github.com/notify-rs/notify/pull/499
 [#533]: https://github.com/notify-rs/notify/pull/533
 [#535]: https://github.com/notify-rs/notify/pull/535
 [#536]: https://github.com/notify-rs/notify/pull/536
@@ -44,13 +46,16 @@ v4 commits split out to branch `v4_maintenance` starting with `4.0.16`
 
 ## notify-types 1.0.0 (unreleased)
 
-New crate containing public type definitions for the notify and debouncer crates.
+New crate containing public type definitions for the notify and debouncer crates. [#559]
 
 - CHANGE: the serialization format for events has been changed to be easier to use in environments like JavaScript;
-  the old behavior can be restored using the new feature flag `serialization-compat-6` [#558] [#568]
+  the old behavior can be restored using the new feature flag **breaking**`serialization-compat-6` [#558] [#568]
+- CHANGE: use instant crate (which provides an `Instant` type that works in Wasm environments) [#570]
 
 [#558]: https://github.com/notify-rs/notify/pull/558
+[#559]: https://github.com/notify-rs/notify/pull/559
 [#568]: https://github.com/notify-rs/notify/pull/568
+[#570]: https://github.com/notify-rs/notify/pull/570
 
 ## debouncer-full 0.4.0 (unreleased)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ v4 commits split out to branch `v4_maintenance` starting with `4.0.16`
 - CHANGE: move event type to notify-types crate [#559]
 - CHANGE: flatten serialization of events and use camelCase [#558]
 - CHANGE: remove internal use of crossbeam-channels [#569] [#610]
+- CHANGE: rename feature `crossbeam` to `crossbeam-channels`
 - CHANGE: upgrade mio to 1.0 [#623]
 - FIX: prevent UB with illegal instruction for the windows backend [#604] [#607]
 - FIX: on Linux report deleted directories correctly [#545]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,6 @@ kqueue = "1.0.8"
 libc = "0.2.4"
 log = "0.4.17"
 mio = { version = "1.0", features = ["os-ext"] }
-mock_instant = "0.3.0"
 instant = "0.1.12"
 nix = "0.27.0"
 notify = { path = "notify" }

--- a/notify-debouncer-full/Cargo.toml
+++ b/notify-debouncer-full/Cargo.toml
@@ -15,7 +15,6 @@ repository.workspace = true
 [features]
 default = ["macos_fsevent"]
 serde = ["notify-types/serde"]
-mock_instant = ["dep:mock_instant", "notify-types/mock_instant"]
 crossbeam-channel = ["dep:crossbeam-channel", "notify/crossbeam-channel"]
 macos_fsevent = ["notify/macos_fsevent"]
 macos_kqueue = ["notify/macos_kqueue"]
@@ -28,10 +27,8 @@ crossbeam-channel = { workspace = true, optional = true }
 file-id.workspace = true
 walkdir.workspace = true
 log.workspace = true
-mock_instant = { workspace = true, optional = true }
 
 [dev-dependencies]
-notify-debouncer-full = { workspace = true, features = ["mock_instant"] }
 pretty_assertions.workspace = true
 rstest.workspace = true
 serde.workspace = true

--- a/notify-debouncer-full/Cargo.toml
+++ b/notify-debouncer-full/Cargo.toml
@@ -34,3 +34,4 @@ rstest.workspace = true
 serde.workspace = true
 deser-hjson.workspace = true
 rand.workspace = true
+tempfile.workspace = true

--- a/notify-debouncer-full/src/lib.rs
+++ b/notify-debouncer-full/src/lib.rs
@@ -208,6 +208,7 @@ impl<T: FileIdCache> DebounceDataInner<T> {
             }
         }
 
+        // drain the entire queue, then process the expired events and re-add the rest
         // TODO: perfect fit for drain_filter https://github.com/rust-lang/rust/issues/59618
         for (path, mut queue) in self.queues.drain() {
             let mut kind_index = HashMap::new();
@@ -246,13 +247,13 @@ impl<T: FileIdCache> DebounceDataInner<T> {
 
     /// Returns all currently stored errors
     pub fn errors(&mut self) -> Vec<Error> {
-        let mut v = Vec::new();
-        std::mem::swap(&mut v, &mut self.errors);
-        v
+        std::mem::take(&mut self.errors)
     }
 
     /// Add an error entry to re-send later on
     pub fn add_error(&mut self, error: Error) {
+        log::trace!("raw error: {error:?}");
+
         self.errors.push(error);
     }
 

--- a/notify-debouncer-full/src/lib.rs
+++ b/notify-debouncer-full/src/lib.rs
@@ -49,7 +49,7 @@
 //!
 //! The following crate features can be turned on or off in your cargo dependency config:
 //!
-//! - `crossbeam` passed down to notify, off by default
+//! - `crossbeam-channel` passed down to notify, off by default
 //! - `serialization-compat-6` passed down to notify, off by default
 //!
 //! # Caveats
@@ -124,7 +124,7 @@ where
     }
 }
 
-#[cfg(feature = "crossbeam")]
+#[cfg(feature = "crossbeam-channel")]
 impl DebounceEventHandler for crossbeam_channel::Sender<DebounceEventResult> {
     fn handle_event(&mut self, event: DebounceEventResult) {
         let _ = self.send(event);

--- a/notify-debouncer-full/src/testing.rs
+++ b/notify-debouncer-full/src/testing.rs
@@ -1,11 +1,10 @@
 use std::{
     collections::{HashMap, VecDeque},
     path::{Path, PathBuf},
-    time::Duration,
+    time::{Duration, Instant},
 };
 
 use file_id::FileId;
-use mock_instant::Instant;
 use notify::{
     event::{
         AccessKind, AccessMode, CreateKind, DataChange, Flag, MetadataKind, ModifyKind, RemoveKind,

--- a/notify-debouncer-full/src/time.rs
+++ b/notify-debouncer-full/src/time.rs
@@ -1,0 +1,47 @@
+#[cfg(not(test))]
+mod build {
+    use std::time::Instant;
+
+    pub fn now() -> Instant {
+        Instant::now()
+    }
+}
+
+#[cfg(not(test))]
+pub use build::*;
+
+#[cfg(test)]
+mod test {
+    use std::{
+        sync::Mutex,
+        time::{Duration, Instant},
+    };
+
+    thread_local! {
+        static NOW: Mutex<Option<Instant>> = Mutex::new(None);
+    }
+
+    pub fn now() -> Instant {
+        let time = NOW.with(|now| *now.lock().unwrap());
+        time.unwrap_or_else(|| Instant::now())
+    }
+
+    pub struct MockTime;
+
+    impl MockTime {
+        pub fn set_time(time: Instant) {
+            NOW.with(|now| *now.lock().unwrap() = Some(time));
+        }
+
+        pub fn advance(delta: Duration) {
+            NOW.with(|now| {
+                if let Some(n) = &mut *now.lock().unwrap() {
+                    *n += delta;
+                }
+            });
+        }
+    }
+}
+
+#[cfg(test)]
+pub use test::*;

--- a/notify-debouncer-mini/Cargo.toml
+++ b/notify-debouncer-mini/Cargo.toml
@@ -25,3 +25,4 @@ notify.workspace = true
 notify-types.workspace = true
 crossbeam-channel = { workspace = true, optional = true }
 log.workspace = true
+tempfile.workspace = true

--- a/notify-debouncer-mini/src/lib.rs
+++ b/notify-debouncer-mini/src/lib.rs
@@ -45,7 +45,7 @@
 //!
 //! The following crate features can be turned on or off in your cargo dependency config:
 //!
-//! - `crossbeam` passed down to notify, off by default
+//! - `crossbeam-channel` passed down to notify, off by default
 //! - `serde` enables serde support for events, off by default
 //! - `serialization-compat-6` passed down to notify, off by default
 //!
@@ -152,7 +152,7 @@ where
     }
 }
 
-#[cfg(feature = "crossbeam")]
+#[cfg(feature = "crossbeam-channel")]
 impl DebounceEventHandler for crossbeam_channel::Sender<DebounceEventResult> {
     fn handle_event(&mut self, event: DebounceEventResult) {
         let _ = self.send(event);

--- a/notify-types/Cargo.toml
+++ b/notify-types/Cargo.toml
@@ -18,7 +18,6 @@ serialization-compat-6 = []
 
 [dependencies]
 serde = { workspace = true, optional = true }
-mock_instant = { workspace = true, optional = true }
 instant.workspace = true
 
 [dev-dependencies]

--- a/notify-types/src/debouncer_full.rs
+++ b/notify-types/src/debouncer_full.rs
@@ -1,9 +1,5 @@
 use std::ops::{Deref, DerefMut};
 
-#[cfg(feature = "mock_instant")]
-use mock_instant::Instant;
-
-#[cfg(not(feature = "mock_instant"))]
 use instant::Instant;
 
 use crate::event::Event;
@@ -35,23 +31,5 @@ impl Deref for DebouncedEvent {
 impl DerefMut for DebouncedEvent {
     fn deref_mut(&mut self) -> &mut Self::Target {
         &mut self.event
-    }
-}
-
-impl Default for DebouncedEvent {
-    fn default() -> Self {
-        Self {
-            event: Default::default(),
-            time: Instant::now(),
-        }
-    }
-}
-
-impl From<Event> for DebouncedEvent {
-    fn from(event: Event) -> Self {
-        Self {
-            event,
-            time: Instant::now(),
-        }
     }
 }


### PR DESCRIPTION
Fixes a couple of issues:

- Fix notify-debouncer-full by removing mock_instant crate.
  Trying to use mock_instant across multiple crates was a bad idea. All functions requiring a clock were removed from the notify-types crate and custom time mocking functions were added.
- The `crossbeam` feature was renamed to `crossbeam-channel` but that wasn't updated everywhere.
- Add some basic integration tests.
  These tests are meant to just test if the watchers work at all, not all of their features. That was tried in previous versions of notify, but lead to very flaky tests.
- Update change log.