### PR TITLE
file-id: Get file stats without read permission

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ v5 maintenance branch is on `v5_maintenance` after `5.2.0`
 
 v4 commits split out to branch `v4_maintenance` starting with `4.0.16`
 
+## file-id 0.2.2 (unreleased)
+
+- CHANGE: get file stats without read permission [#625]
+
+[#625]: https://github.com/notify-rs/notify/issues/625
+
 ## debouncer-full 0.4.1 (unreleased)
 
 - FIX: ordering of debounced events could lead to a panic with Rust 1.81.0 and above [#636]

--- a/file-id/src/lib.rs
+++ b/file-id/src/lib.rs
@@ -192,7 +192,7 @@ fn open_file<P: AsRef<Path>>(path: P) -> io::Result<fs::File> {
     use windows_sys::Win32::Storage::FileSystem::FILE_FLAG_BACKUP_SEMANTICS;
 
     OpenOptions::new()
-        .read(true)
+        .access_mode(0)
         .custom_flags(FILE_FLAG_BACKUP_SEMANTICS)
         .open(path)
 }


### PR DESCRIPTION
> The dwDesiredAccess parameter can be zero, allowing the application to query file attributes without accessing the file if the application is running with adequate security settings. This is useful to test for the existence of a file without opening it for read and/or write access, or to obtain other statistics about the file or directory.

Closes #625.