### PR TITLE
Prepare release of debouncer full 0.3.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 v5 maintenance branch is on `v5_maintenance` after `5.2.0`  
 v4 commits split out to branch `v4_maintenance` starting with `4.0.16`
 
-## debouncer-full 0.4.1 (unreleased)
+## debouncer-full 0.3.2 (2024-09-29)
 
 - FIX: ordering of debounced events could lead to a panic with Rust 1.81.0 and above [#636]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 v5 maintenance branch is on `v5_maintenance` after `5.2.0`  
 v4 commits split out to branch `v4_maintenance` starting with `4.0.16`
 
+## debouncer-full 0.4.1 (unreleased)
+
+- FIX: ordering of debounced events could lead to a panic with Rust 1.81.0 and above [#636]
+
+[#636]: https://github.com/notify-rs/notify/issues/636
+
 ## debouncer-full 0.3.1 (2023-08-21)
 
 - CHANGE: remove serde binary experiment opt-out after it got removed [#530]

--- a/notify-debouncer-full/Cargo.toml
+++ b/notify-debouncer-full/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "notify-debouncer-full"
-version = "0.3.1"
+version = "0.3.2"
 edition = "2021"
 rust-version = "1.60"
 description = "notify event debouncer optimized for ease of use"

--- a/notify-debouncer-full/src/lib.rs
+++ b/notify-debouncer-full/src/lib.rs
@@ -249,17 +249,7 @@ impl<T: FileIdCache> DebounceDataInner<T> {
 
         self.queues = queues_remaining;
 
-        // order events for different files chronologically, but keep the order of events for the same file
-        events_expired.sort_by(|event_a, event_b| {
-            // use the last path because rename events are emitted for the target path
-            if event_a.paths.last() == event_b.paths.last() {
-                std::cmp::Ordering::Equal
-            } else {
-                event_a.time.cmp(&event_b.time)
-            }
-        });
-
-        events_expired
+        sort_events(events_expired)
     }
 
     /// Returns all currently stored errors
@@ -654,6 +644,39 @@ pub fn new_debouncer<F: DebounceEventHandler>(
     )
 }
 
+fn sort_events(events: Vec<DebouncedEvent>) -> Vec<DebouncedEvent> {
+    let mut sorted = Vec::with_capacity(events.len());
+
+    // group events by path
+    let mut events_by_path: HashMap<_, VecDeque<_>> =
+        events.into_iter().fold(HashMap::new(), |mut acc, event| {
+            acc.entry(event.paths.last().cloned().unwrap_or_default())
+                .or_default()
+                .push_back(event);
+            acc
+        });
+
+    // push events for different paths in chronological order and keep the order of events with the same path
+    while !events_by_path.is_empty() {
+        let min_time = events_by_path
+            .values()
+            .map(|events| events[0].time)
+            .min()
+            .unwrap();
+
+        for events in events_by_path.values_mut() {
+            while events.front().is_some_and(|event| event.time <= min_time) {
+                let event = events.pop_front().unwrap();
+                sorted.push(event);
+            }
+        }
+
+        events_by_path.retain(|_, events| !events.is_empty());
+    }
+
+    sorted
+}
+
 #[cfg(test)]
 mod tests {
     use std::{fs, path::Path};
@@ -702,7 +725,9 @@ mod tests {
             "emit_close_events_only_once",
             "emit_modify_event_after_close_event",
             "emit_needs_rescan_event",
-            "read_file_id_without_create_event"
+            "read_file_id_without_create_event",
+            "sort_events_chronologically",
+            "sort_events_with_reordering"
         )]
         file_name: &str,
     ) {

--- a/notify-debouncer-full/src/lib.rs
+++ b/notify-debouncer-full/src/lib.rs
@@ -671,7 +671,7 @@ fn sort_events(events: Vec<DebouncedEvent>) -> Vec<DebouncedEvent> {
 
         let mut push_next = false;
 
-        while events.front().is_some_and(|event| event.time <= min_time) {
+        while events.front().map_or(false, |event| event.time <= min_time) {
             // unwrap is safe beause `pop_front` mus return some in order to enter the loop
             let event = events.pop_front().unwrap();
             sorted.push(event);

--- a/notify-debouncer-full/test_cases/sort_events_chronologically.hjson
+++ b/notify-debouncer-full/test_cases/sort_events_chronologically.hjson
@@ -1,0 +1,42 @@
+{
+    state: {
+        queues: {
+            /watch/file-1: {
+                events: [
+                    { kind: "create-any", paths: ["*"], time: 2 }
+                    { kind: "modify-any", paths: ["*"], time: 3 }
+                ]
+            }
+            /watch/file-2: {
+                events: [
+                    { kind: "create-any", paths: ["*"], time: 1 }
+                    { kind: "modify-any", paths: ["*"], time: 4 }
+                ]
+            }
+        }
+    }
+    expected: {
+        queues: {
+            /watch/file-1: {
+                events: [
+                    { kind: "create-any", paths: ["*"], time: 2 }
+                    { kind: "modify-any", paths: ["*"], time: 3 }
+                ]
+            }
+            /watch/file-2: {
+                events: [
+                    { kind: "create-any", paths: ["*"], time: 1 }
+                    { kind: "modify-any", paths: ["*"], time: 4 }
+                ]
+            }
+        }
+        events: {
+            long: [
+                { kind: "create-any", paths: ["/watch/file-2"], time: 1 }
+                { kind: "create-any", paths: ["/watch/file-1"], time: 2 }
+                { kind: "modify-any", paths: ["/watch/file-1"], time: 3 }
+                { kind: "modify-any", paths: ["/watch/file-2"], time: 4 }
+            ]
+        }
+    }
+}

--- a/notify-debouncer-full/test_cases/sort_events_with_reordering.hjson
+++ b/notify-debouncer-full/test_cases/sort_events_with_reordering.hjson
@@ -1,0 +1,42 @@
+{
+    state: {
+        queues: {
+            /watch/file-1: {
+                events: [
+                    { kind: "create-any", paths: ["*"], time: 2 }
+                    { kind: "modify-any", paths: ["*"], time: 3 }
+                ]
+            }
+            /watch/file-2: {
+                events: [
+                    { kind: "rename-to", paths: ["*"], time: 4 }
+                    { kind: "modify-any", paths: ["*"], time: 1 }
+                ]
+            }
+        }
+    }
+    expected: {
+        queues: {
+            /watch/file-1: {
+                events: [
+                    { kind: "create-any", paths: ["*"], time: 2 }
+                    { kind: "modify-any", paths: ["*"], time: 3 }
+                ]
+            }
+            /watch/file-2: {
+                events: [
+                    { kind: "rename-to", paths: ["*"], time: 4 }
+                    { kind: "modify-any", paths: ["*"], time: 1 }
+                ]
+            }
+        }
+        events: {
+            long: [
+                { kind: "create-any", paths: ["/watch/file-1"], time: 2 }
+                { kind: "modify-any", paths: ["/watch/file-1"], time: 3 }
+                { kind: "rename-to", paths: ["/watch/file-2"], time: 4 }
+                { kind: "modify-any", paths: ["/watch/file-2"], time: 1 }
+            ]
+        }
+    }
+}


### PR DESCRIPTION
- Cherry-picked the two commits to fix #636.
- Updated version number - now with the correct version: 0.3.2

This PR is based in commit 4a00121 (tag: debouncer-full-0.3.1) - but I don't think I can request to create a new branch ... so let's see what github will do when I press the Create PR button...