### PR TITLE
Fix a typo and add a typo CI check.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -125,6 +125,15 @@ jobs:
       - name: check build without crossbeam/default features
         run: cargo build -p notify --no-default-features --target ${{ matrix.target }}
 
+  # If this fails, consider changing your text or adding something to .typos.toml
+  typos:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: check typos
+        uses: crate-ci/typos@v1.26.0
+
   audit:
     runs-on: ubuntu-latest
 

--- a/.typos.toml
+++ b/.typos.toml
@@ -1,0 +1,22 @@
+# See the configuration reference at
+# https://github.com/crate-ci/typos/blob/master/docs/reference.md
+
+# Corrections take the form of a key/value pair. The key is the incorrect word
+# and the value is the correct word. If the key and value are the same, the
+# word is treated as always correct. If the value is an empty string, the word
+# is treated as always incorrect.
+
+# Match Identifier - Case Sensitive
+[default.extend-identifiers]
+ecd686ba = "ecd686ba" # In the CHANGELOG.md
+waitres = "waitres"
+
+# Match Inside a Word - Case Insensitive
+[default.extend-words]
+
+[files]
+# Include .github, .cargo, etc.
+ignore-hidden = false
+# /.git isn't in .gitignore, because git never tracks it.
+# Typos doesn't know that, though.
+extend-exclude = ["/.git"]

--- a/notify-debouncer-full/src/lib.rs
+++ b/notify-debouncer-full/src/lib.rs
@@ -731,7 +731,7 @@ fn sort_events(events: Vec<DebouncedEvent>) -> Vec<DebouncedEvent> {
         let mut push_next = false;
 
         while events.front().is_some_and(|event| event.time <= min_time) {
-            // unwrap is safe beause `pop_front` mus return some in order to enter the loop
+            // unwrap is safe because `pop_front` mus return some in order to enter the loop
             let event = events.pop_front().unwrap();
             sorted.push(event);
             push_next = true;


### PR DESCRIPTION
The new typo was added in 7b73ab3b481623fe2a678eaa161afce2b61aec4d

The CI configuration will help keep the code free of further common typos.
