### PR TITLE
Fix advisory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,10 @@ New crate containing public type definitions for the notify and debouncer crates
 [#568]: https://github.com/notify-rs/notify/pull/568
 [#570]: https://github.com/notify-rs/notify/pull/570
 
+## notify-types 2.0.0 (unreleased)
+
+- CHANGE: replace instant crate with web-time **breaking**
+
 ## debouncer-mini 0.5.0 (2024-10-25)
 
 - CHANGE: update notify to version 7.0.0

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,7 @@ kqueue = "1.0.8"
 libc = "0.2.4"
 log = "0.4.17"
 mio = { version = "1.0", features = ["os-ext"] }
-instant = "0.1.12"
+web-time = "1.1.0"
 nix = "0.27.0"
 notify = { version = "7.0.0", path = "notify" }
 notify-debouncer-full = { version = "0.4.0", path = "notify-debouncer-full" }

--- a/notify-types/Cargo.toml
+++ b/notify-types/Cargo.toml
@@ -18,7 +18,7 @@ serialization-compat-6 = []
 
 [dependencies]
 serde = { workspace = true, optional = true }
-instant.workspace = true
+web-time.workspace = true
 
 [dev-dependencies]
 serde_json.workspace = true

--- a/notify-types/src/debouncer_full.rs
+++ b/notify-types/src/debouncer_full.rs
@@ -1,6 +1,6 @@
 use std::ops::{Deref, DerefMut};
 
-use instant::Instant;
+use web_time::Instant;
 
 use crate::event::Event;
 


### PR DESCRIPTION
Fixes a security advisory. `instant` is no longer maintained, but there is a drop-in replacement.
![image](https://github.com/user-attachments/assets/7b099558-166e-409f-a078-25953ce0e1de)
