### PR TITLE
Bump version to `7.0.0` in `lib.rs` documentation

### DIFF
--- a/notify/src/lib.rs
+++ b/notify/src/lib.rs
@@ -4,7 +4,7 @@
 //!
 //! ```toml
 //! [dependencies]
-//! notify = "6.1.1"
+//! notify = "7.0.0"
 //! ```
 //!
 //! If you want debounced events (or don't need them in-order), see [notify-debouncer-mini](https://docs.rs/notify-debouncer-mini/latest/notify_debouncer_mini/)
@@ -24,7 +24,7 @@
 //! Events are serializable via [serde](https://serde.rs) if the `serde` feature is enabled:
 //!
 //! ```toml
-//! notify = { version = "6.1.1", features = ["serde"] }
+//! notify = { version = "7.0.0", features = ["serde"] }
 //! ```
 //!
 //! # Known Problems


### PR DESCRIPTION
I noticed today that [docs.rs](https://docs.rs/notify/latest/notify/) still shows version `6.1.1`. I made sure to replace all references in the codebase to `7.0.0` where it made sense (e.g. `CHANGELOG.md` was logically excluded).

The only file affected is `lib.rs`.

Cheers.