### PR TITLE
Trigger event when initial scan is complete

### DIFF
--- a/notify/src/poll.rs
+++ b/notify/src/poll.rs
@@ -202,6 +202,11 @@ mod data {
             )
             .collect();
 
+            if let Some(ref emitter) = data_builder.scan_emitter {
+                let close_initial_scan_evt = Event::new(EventKind::Other).set_info(&format!("initial_scan_complete"));
+                data_builder.emitter.emit(Ok(close_initial_scan_evt));
+            } 
+
             Some(Self {
                 root,
                 is_recursive,


### PR DESCRIPTION
For my specific scenario I find it useful to know when the initial scan has finished so I can take further actions after it.