### PR TITLE
Fix `Event::kind` serialization with serialization-compat-6

### DIFF
--- a/notify-types/src/event.rs
+++ b/notify-types/src/event.rs
@@ -307,6 +307,10 @@ pub struct Event {
         all(feature = "serde", not(feature = "serialization-compat-6")),
         serde(flatten)
     )]
+    #[cfg_attr(
+        all(feature = "serde", feature = "serialization-compat-6"),
+        serde(rename = "type")
+    )]
     pub kind: EventKind,
 
     /// Paths the event is about, if known.


### PR DESCRIPTION
<!-- By contributing, you agree to the terms of the license, available in the LICENSE.ARTISTIC file, and of the code of conduct, available in the CODE_OF_CONDUCT.md file. Furthermore, you agree to release under CC0, also available in the LICENSE file, until Notify has fully transitioned to Artistic 2.0. -->

<!-- After creating this pull request, the test suite will run.

It is expected that if any failures occur in the builds, you either:

- fix the errors,
- ask for help, or
- note that the failures are expected with a detailed explanation.

If you do not, a maintainer may prompt you and/or do it themselves, but do note that it will take longer for your contribution to be reviewed if the build does not pass.

Running `cargo fmt` and/or `cargo clippy` is NOT required but appreciated!

You can remove this text. -->

The `kind` field in `Event` was serialized as `type` in v6, but is `kind` with `serialization-compat-6` feature

Reference: https://github.com/tauri-apps/plugins-workspace/issues/2221

I'm not sure how the release process work here, let me know if I need to add a change log entry (if so please also tell me what version should this change be in, since I see there's already a `notify-types 2.0.0 (unreleased)` entry) or do I need to target another branch