### PR TITLE
In notify-types, relicense src/event.rs to (MIT OR Apache-2.0)

### DIFF
--- a/notify-types/src/event.rs
+++ b/notify-types/src/event.rs
@@ -1,5 +1,3 @@
-// This file is dual-licensed under the Artistic License 2.0 as per the
-// LICENSE.ARTISTIC file, and the Creative Commons Zero 1.0 license.
 //! The `Event` type and the hierarchical `EventKind` descriptor.
 
 use std::{


### PR DESCRIPTION
This file was copied from the main `notify` crate and had a header comment that indicated it was licensed `CC0-1.0` or `Artistic-2.0` with an additional clause (see https://github.com/notify-rs/notify/issues/514);

Since @dfaust indicates in https://github.com/notify-rs/notify/pull/661#discussion_r1901262603 that this file can be relicensed, we simply remove the old header comment to indicate that (by default) it falls under the overall `(MIT OR Apache-2.0)` license of the `notify-types` crate.

The [suggestion](https://github.com/notify-rs/notify/pull/661#discussion_r1901306684) to add `CC0-1.0` as an additional license option for `notify-types` could be done, if desired, as a follow-up PR.

<!-- By contributing, you agree to the terms of the license, available in the LICENSE.ARTISTIC file, and of the code of conduct, available in the CODE_OF_CONDUCT.md file. Furthermore, you agree to release under CC0, also available in the LICENSE file, until Notify has fully transitioned to Artistic 2.0. -->

<!-- After creating this pull request, the test suite will run.

It is expected that if any failures occur in the builds, you either:

- fix the errors,
- ask for help, or
- note that the failures are expected with a detailed explanation.

If you do not, a maintainer may prompt you and/or do it themselves, but do note that it will take longer for your contribution to be reviewed if the build does not pass.

Running `cargo fmt` and/or `cargo clippy` is NOT required but appreciated!

You can remove this text. -->
