### PR TITLE
FileIdCache: Allow flexible handle instead of direct borrow for file ids

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## debouncer-full 0.6.0 (unreleased)
+- FEATURE: allow `FileIdCache` trait implementations to choose ownership of the returned file-ids
+
+## file-id 0.2.3 (unreleased)
+- CHANGE: implement `AsRef<FileId>` for `FileId`
+
 ## notify 8.0.0 (2025-01-10)
 
 - CHANGE: update notify-types to version 2.0.0

--- a/file-id/src/lib.rs
+++ b/file-id/src/lib.rs
@@ -106,6 +106,12 @@ impl FileId {
     }
 }
 
+impl AsRef<FileId> for FileId {
+    fn as_ref(&self) -> &FileId {
+        self
+    }
+}
+
 /// Get the `FileId` for the file or directory at `path`
 #[cfg(target_family = "unix")]
 pub fn get_file_id(path: impl AsRef<Path>) -> io::Result<FileId> {

--- a/notify-debouncer-full/src/cache.rs
+++ b/notify-debouncer-full/src/cache.rs
@@ -2,7 +2,6 @@ use std::{
     collections::HashMap,
     path::{Path, PathBuf},
 };
-
 use file_id::{get_file_id, FileId};
 use notify::RecursiveMode;
 use walkdir::WalkDir;
@@ -14,7 +13,7 @@ pub trait FileIdCache {
     /// Get a `FileId` from the cache for a given `path`.
     ///
     /// If the path is not cached, `None` should be returned and there should not be any attempt to read the file ID from disk.
-    fn cached_file_id(&self, path: &Path) -> Option<&FileId>;
+    fn cached_file_id(&self, path: &Path) -> Option<impl AsRef<FileId>>;
 
     /// Add a new path to the cache or update its value.
     ///
@@ -64,7 +63,7 @@ impl FileIdMap {
 }
 
 impl FileIdCache for FileIdMap {
-    fn cached_file_id(&self, path: &Path) -> Option<&FileId> {
+    fn cached_file_id(&self, path: &Path) -> Option<impl AsRef<FileId>> {
         self.paths.get(path)
     }
 
@@ -104,8 +103,8 @@ impl NoCache {
 }
 
 impl FileIdCache for NoCache {
-    fn cached_file_id(&self, _path: &Path) -> Option<&FileId> {
-        None
+    fn cached_file_id(&self, _path: &Path) -> Option<impl AsRef<FileId>> {
+        Option::<&FileId>::None
     }
 
     fn add_path(&mut self, _path: &Path, _recursive_mode: RecursiveMode) {}

--- a/notify-debouncer-full/src/lib.rs
+++ b/notify-debouncer-full/src/lib.rs
@@ -340,7 +340,7 @@ impl<T: FileIdCache> DebounceDataInner<T> {
         let path = &event.paths[0];
 
         // store event
-        let file_id = self.cache.cached_file_id(path).cloned();
+        let file_id = self.cache.cached_file_id(path).map(|id| *id.as_ref());
         self.rename_event = Some((DebouncedEvent::new(event.clone(), time), file_id));
 
         self.cache.remove_path(path);
@@ -372,7 +372,7 @@ impl<T: FileIdCache> DebounceDataInner<T> {
             .and_then(|from_file_id| {
                 self.cache
                     .cached_file_id(&event.paths[0])
-                    .map(|to_file_id| from_file_id == to_file_id)
+                    .map(|to_file_id| from_file_id == to_file_id.as_ref())
             })
             .unwrap_or_default();
 


### PR DESCRIPTION
Hi, 
I suggest changing the return type of the `cached_file_id` method in the `FileIdCache` from `Option<&FileId>` to `Option<impl Deref<Target=FileId>>;` (breaking change)

This allows trait consumers to choose more freely how to return the FileId. 
In a FileIdCache implementation I had to do I was required to return a owned copy of the file id. 
The changed return type allows eg. a Cow::Owned or any other new-type implementation that dereferences to a FileId.

This is now doable with the recent MSRV raise to 1.77.

<!-- By contributing, you agree to the terms of the license, available in the LICENSE.ARTISTIC file, and of the code of conduct, available in the CODE_OF_CONDUCT.md file. Furthermore, you agree to release under CC0, also available in the LICENSE file, until Notify has fully transitioned to Artistic 2.0. -->

<!-- After creating this pull request, the test suite will run.

It is expected that if any failures occur in the builds, you either:

- fix the errors,
- ask for help, or
- note that the failures are expected with a detailed explanation.

If you do not, a maintainer may prompt you and/or do it themselves, but do note that it will take longer for your contribution to be reviewed if the build does not pass.

Running `cargo fmt` and/or `cargo clippy` is NOT required but appreciated!

You can remove this text. -->
