### PR TITLE
Remove unused import in docs

### DIFF
--- a/notify/src/lib.rs
+++ b/notify/src/lib.rs
@@ -89,7 +89,7 @@
 //!
 //! ```rust
 //! # use std::path::Path;
-//! use notify::{recommended_watcher, Event, RecursiveMode, Result, Watcher};
+//! use notify::{Event, RecursiveMode, Result, Watcher};
 //! use std::sync::mpsc;
 //!
 //! fn main() -> Result<()> {


### PR DESCRIPTION
<!-- By contributing, you agree to the terms of the license, available in the LICENSE.ARTISTIC file, and of the code of conduct, available in the CODE_OF_CONDUCT.md file. Furthermore, you agree to release under CC0, also available in the LICENSE file, until Notify has fully transitioned to Artistic 2.0. -->

<!-- After creating this pull request, the test suite will run.

It is expected that if any failures occur in the builds, you either:

- fix the errors,
- ask for help, or
- note that the failures are expected with a detailed explanation.

If you do not, a maintainer may prompt you and/or do it themselves, but do note that it will take longer for your contribution to be reviewed if the build does not pass.

Running `cargo fmt` and/or `cargo clippy` is NOT required but appreciated!

You can remove this text. -->

Consider also uncommenting the `Path` import or merging with the `sync::mspc` import to allow for easy copy and pasting of the example