### PR TITLE
feat: support wasm build

### DIFF
--- a/notify-debouncer-full/src/lib.rs
+++ b/notify-debouncer-full/src/lib.rs
@@ -79,7 +79,7 @@ use std::{
 
 use time::now;
 
-pub use cache::{FileIdCache, FileIdMap, NoCache, RecommendedCache};
+pub use cache::{FileIdCache, NoCache, RecommendedCache};
 
 pub use file_id;
 pub use notify;


### PR DESCRIPTION
<!-- By contributing, you agree to the terms of the license, available in the LICENSE.ARTISTIC file, and of the code of conduct, available in the CODE_OF_CONDUCT.md file. Furthermore, you agree to release under CC0, also available in the LICENSE file, until Notify has fully transitioned to Artistic 2.0. -->

<!-- After creating this pull request, the test suite will run.

It is expected that if any failures occur in the builds, you either:

- fix the errors,
- ask for help, or
- note that the failures are expected with a detailed explanation.

If you do not, a maintainer may prompt you and/or do it themselves, but do note that it will take longer for your contribution to be reviewed if the build does not pass.

Running `cargo fmt` and/or `cargo clippy` is NOT required but appreciated!

You can remove this text. -->

We are using `notify` as watcher and build it to [wasm32-wasip2](https://doc.rust-lang.org/rustc/platform-support/wasm32-wasip2.html) and run it at https://stackblitz.com/. 

But when using `notify-debouncer-full` to instead of `notify`, it can't build because the `get_file_id` is not implement at wasm. The `std::os::wasi::fs::MetadataExt` is implement at nightly rust, the stable version hasn't it. So here using `NoCache` for wasm to avoid the issue.

I try to add a build wasm32-wasip2 ci, but the rust toolchain version is 1.77.2, it hasn't support the wasm32-wasip2 target.It need to bump rust toolchain at first. If you approved it, please ping me i will upgrade it at first.

Thank your excellent work!
