### PR TITLE
windows: Fix server hangs under some circumstance

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,5 +45,6 @@ rstest = "0.24.0"
 serde = { version = "1.0.89", features = ["derive"] }
 serde_json = "1.0.39"
 tempfile = "3.10.0"
+trash = "5.2.2"
 walkdir = "2.4.0"
 windows-sys = "0.59.0"

--- a/notify-debouncer-full/src/cache.rs
+++ b/notify-debouncer-full/src/cache.rs
@@ -1,9 +1,9 @@
+use file_id::{get_file_id, FileId};
+use notify::RecursiveMode;
 use std::{
     collections::HashMap,
     path::{Path, PathBuf},
 };
-use file_id::{get_file_id, FileId};
-use notify::RecursiveMode;
 use walkdir::WalkDir;
 
 /// The interface of a file ID cache.

--- a/notify/Cargo.toml
+++ b/notify/Cargo.toml
@@ -52,5 +52,6 @@ mio.workspace = true
 [dev-dependencies]
 serde_json.workspace = true
 tempfile.workspace = true
+trash.workspace = true
 nix.workspace = true
 insta.workspace = true

--- a/notify/src/lib.rs
+++ b/notify/src/lib.rs
@@ -447,7 +447,6 @@ mod tests {
         let mut watcher = recommended_watcher(|e| {
             println!("{:?}", e);
         })?;
-        watcher.watch(dir.path(), RecursiveMode::NonRecursive)?;
         watcher.watch(&child_dir, RecursiveMode::NonRecursive)?;
 
         trash::delete(&child_dir)?;

--- a/notify/src/lib.rs
+++ b/notify/src/lib.rs
@@ -441,19 +441,18 @@ mod tests {
     #[cfg(target_os = "windows")]
     fn test_windows_trash_dir() -> std::result::Result<(), Box<dyn std::error::Error>> {
         let dir = tempdir()?;
-        let inner_dir_1 = dir.path().join("Inner1");
-        let inner_dir_2 = inner_dir_1.join("Inner2");
-        fs::create_dir_all(&inner_dir_2)?;
+        let child_dir = dir.path().join("child");
+        fs::create_dir(&child_dir)?;
 
         let mut watcher = recommended_watcher(|e| {
             println!("{:?}", e);
         })?;
-        watcher.watch(&inner_dir_1, RecursiveMode::NonRecursive)?;
-        watcher.watch(&inner_dir_2, RecursiveMode::NonRecursive)?;
+        watcher.watch(dir.path(), RecursiveMode::NonRecursive)?;
+        watcher.watch(&child_dir, RecursiveMode::NonRecursive)?;
 
-        trash::delete(&inner_dir_2)?;
+        trash::delete(&child_dir)?;
 
-        watcher.watch(&inner_dir_1, RecursiveMode::NonRecursive)?;
+        watcher.watch(dir.path(), RecursiveMode::NonRecursive)?;
 
         Ok(())
     }

--- a/notify/src/lib.rs
+++ b/notify/src/lib.rs
@@ -436,4 +436,25 @@ mod tests {
 
         Ok(())
     }
+
+    #[test]
+    #[cfg(target_os = "windows")]
+    fn test_windows_trash_dir() -> std::result::Result<(), Box<dyn std::error::Error>> {
+        let dir = tempdir()?;
+        let inner_dir_1 = dir.path().join("Inner1");
+        let inner_dir_2 = inner_dir_1.join("Inner2");
+        fs::create_dir_all(&inner_dir_2)?;
+
+        let mut watcher = recommended_watcher(|e| {
+            println!("{:?}", e);
+        })?;
+        watcher.watch(&inner_dir_1, RecursiveMode::NonRecursive)?;
+        watcher.watch(&inner_dir_2, RecursiveMode::NonRecursive)?;
+
+        trash::delete(&inner_dir_2)?;
+
+        watcher.watch(&inner_dir_1, RecursiveMode::NonRecursive)?;
+
+        Ok(())
+    }
 }

--- a/notify/src/windows.rs
+++ b/notify/src/windows.rs
@@ -32,7 +32,7 @@ use windows_sys::Win32::Storage::FileSystem::{
     FILE_SHARE_WRITE, OPEN_EXISTING,
 };
 use windows_sys::Win32::System::Threading::{
-    CreateSemaphoreW, ReleaseSemaphore, WaitForSingleObjectEx, INFINITE,
+    CreateSemaphoreW, ReleaseSemaphore, WaitForSingleObject, WaitForSingleObjectEx, INFINITE,
 };
 use windows_sys::Win32::System::IO::{CancelIo, OVERLAPPED};
 
@@ -138,7 +138,7 @@ impl ReadDirectoryChangesServer {
 
             unsafe {
                 // wait with alertable flag so that the completion routine fires
-                let waitres = WaitForSingleObjectEx(self.wakeup_sem, 100, 1);
+                let waitres = WaitForSingleObject(self.wakeup_sem, 100);
                 if waitres == WAIT_OBJECT_0 {
                     let _ = self.meta_tx.send(MetaEvent::WatcherAwakened);
                 }

--- a/notify/src/windows.rs
+++ b/notify/src/windows.rs
@@ -206,7 +206,7 @@ impl ReadDirectoryChangesServer {
         };
         // every watcher gets its own semaphore to signal completion
         let semaphore = unsafe { CreateSemaphoreW(ptr::null_mut(), 0, 1, ptr::null_mut()) };
-        if semaphore == ptr::null_mut() || semaphore == INVALID_HANDLE_VALUE {
+        if semaphore.is_null() || semaphore == INVALID_HANDLE_VALUE {
             unsafe {
                 CloseHandle(handle);
             }
@@ -431,7 +431,7 @@ impl ReadDirectoryChangesWatcher {
         let (cmd_tx, cmd_rx) = unbounded();
 
         let wakeup_sem = unsafe { CreateSemaphoreW(ptr::null_mut(), 0, 1, ptr::null_mut()) };
-        if wakeup_sem == ptr::null_mut() || wakeup_sem == INVALID_HANDLE_VALUE {
+        if wakeup_sem.is_null() || wakeup_sem == INVALID_HANDLE_VALUE {
             return Err(Error::generic("Failed to create wakeup semaphore."));
         }
 


### PR DESCRIPTION
Hi, thank you so much for creating such a high-quality Rust library.

We encountered a tricky issue while using this library in the development of Zed (https://github.com/zed-industries/zed). After testing, we identified the issue as a bug in `notify`. This PR provides a test case, `test_windows_trash_dir()`, which reproduces the bug.

The bug can be reproduced as follows: in a project directory `/path/to/project`, there is a subfolder `/path/to/project/child`. If we monitor changes in the child folder, then move the child folder to the trash (deleting the folder directly does not trigger the bug), and monitor the project directory, the server gets stuck at the `WaitForSingleObjectEx` command. 

This issue seems to be related to the `bAlertable` flag in `WaitForSingleObjectEx`, but we are still unclear why setting `bAlertable` to `TRUE` causes this bug.