### PR TITLE
Do not remove a filename twice

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## notify 9.0.0 (unreleased)
 - FEATURE: added support for the [`flume`](https://docs.rs/flume) crate
+- FIX: kqueue-backend: do not double unwatch top-level directory when recursively unwatching [#683]
 
 ## debouncer-full 0.6.0 (unreleased)
 - FEATURE: allow `FileIdCache` trait implementations to choose ownership of the returned file-ids


### PR DESCRIPTION
When unwatching a directory that was watched recursively, notify's kqueue impl would first unwatch the containing directory, then walk it to unwatch all the items inside.

However, walking the directory first processes the containing directory, and unwatching a directory twice can cause an error in the kqueue crate.

Fixes #665 and adds a test to prevent regressions.
