### PR TITLE
Bump kqueue to 1.1.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ fsevent-sys = "4.0.0"
 futures = "0.3.30"
 inotify = { version = "0.11.0", default-features = false }
 insta = "1.34.0"
-kqueue = "1.0.8"
+kqueue = "1.1.1"
 libc = "0.2.4"
 log = "0.4.17"
 mio = { version = "1.0", features = ["os-ext"] }


### PR DESCRIPTION
This release fixes some file descriptor leaks, reduces memory usage and also fixes a bug where unknown filenames would try and unwatch fd 0.

---

btw, feel free to tag me on kqueue-backend bugs, since I maintain the upstream kqueue lib