### PR TITLE
Do not clone paths while walking dirs

### DIFF
--- a/notify/src/inotify.rs
+++ b/notify/src/inotify.rs
@@ -404,7 +404,7 @@ impl EventLoop {
             .into_iter()
             .filter_map(filter_dir)
         {
-            self.add_single_watch(entry.path().to_path_buf(), is_recursive, watch_self)?;
+            self.add_single_watch(entry.into_path(), is_recursive, watch_self)?;
             watch_self = false;
         }
 

--- a/notify/src/kqueue.rs
+++ b/notify/src/kqueue.rs
@@ -303,7 +303,7 @@ impl EventLoop {
                 .into_iter()
             {
                 let entry = entry.map_err(map_walkdir_error)?;
-                self.add_single_watch(entry.path().to_path_buf(), is_recursive)?;
+                self.add_single_watch(entry.into_path(), is_recursive)?;
             }
         }
 
@@ -347,7 +347,7 @@ impl EventLoop {
                         .follow_links(self.follow_symlinks)
                         .into_iter()
                     {
-                        let p = entry.map_err(map_walkdir_error)?.path().to_path_buf();
+                        let p = entry.map_err(map_walkdir_error)?.into_path();
                         self.kqueue
                             .remove_filename(&p, EventFilter::EVFILT_VNODE)
                             .map_err(|e| Error::io(e).add_path(p))?;


### PR DESCRIPTION
To avoid unneeded allocations, this commit uses `walkdir::DirEntry::into_path` instead

<!-- By contributing, you agree to the terms of the license, available in the LICENSE.ARTISTIC file, and of the code of conduct, available in the CODE_OF_CONDUCT.md file. Furthermore, you agree to release under CC0, also available in the LICENSE file, until Notify has fully transitioned to Artistic 2.0. -->
