### PR TITLE
Skip all `Modify` events right after a `Create` event, unless it's a rename event

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,9 @@
 ## debouncer-full 0.6.0 (unreleased)
 - FEATURE: allow `FileIdCache` trait implementations to choose ownership of the returned file-ids
 - FEATURE: added support for the [`flume`](https://docs.rs/flume) crate
+- FIX: skip all `Modify` events right after a `Create` event, unless it's a rename event [#701]
+
+[#701]: https://github.com/notify-rs/notify/pull/701
 
 ## debouncer-mini 0.7.0 (unreleased)
 - FEATURE: added support for the [`flume`](https://docs.rs/flume) crate

--- a/notify-debouncer-full/src/lib.rs
+++ b/notify-debouncer-full/src/lib.rs
@@ -509,9 +509,15 @@ impl<T: FileIdCache> DebounceDataInner<T> {
         let path = &event.paths[0];
 
         if let Some(queue) = self.queues.get_mut(path) {
-            // skip duplicate create events and modifications right after creation
+            // Skip duplicate create events and modifications right after creation.
+            // This code relies on backends never emitting a `Modify` event with kind other than `Name` for a rename event.
             if match event.kind {
-                EventKind::Modify(ModifyKind::Data(_) | ModifyKind::Metadata(_))
+                EventKind::Modify(
+                    ModifyKind::Any
+                    | ModifyKind::Data(_)
+                    | ModifyKind::Metadata(_)
+                    | ModifyKind::Other,
+                )
                 | EventKind::Create(_) => !queue.was_created(),
                 _ => true,
             } {
@@ -639,16 +645,14 @@ pub fn new_debouncer_opt<F: DebounceEventHandler, T: Watcher, C: FileIdCache + S
         Some(v) => {
             if v > timeout {
                 return Err(Error::new(ErrorKind::Generic(format!(
-                    "Invalid tick_rate, tick rate {:?} > {:?} timeout!",
-                    v, timeout
+                    "Invalid tick_rate, tick rate {v:?} > {timeout:?} timeout!"
                 ))));
             }
             v
         }
         None => timeout.checked_div(tick_div).ok_or_else(|| {
             Error::new(ErrorKind::Generic(format!(
-                "Failed to calculate tick as {:?}/{}!",
-                timeout, tick_div
+                "Failed to calculate tick as {timeout:?}/{tick_div}!"
             )))
         })?,
     };
@@ -782,6 +786,7 @@ mod tests {
             "add_create_event_after_remove_event",
             "add_create_dir_event_twice",
             "add_event_with_no_paths_is_ok",
+            "add_modify_any_event_after_create_event",
             "add_modify_content_event_after_create_event",
             "add_rename_from_event",
             "add_rename_from_event_after_create_event",
@@ -868,7 +873,7 @@ mod tests {
             state
                 .errors
                 .iter()
-                .map(|e| format!("{:?}", e))
+                .map(|e| format!("{e:?}"))
                 .collect::<Vec<_>>(),
             expected_errors
                 .iter()

--- a/notify-debouncer-full/test_cases/add_modify_any_event_after_create_event.hjson
+++ b/notify-debouncer-full/test_cases/add_modify_any_event_after_create_event.hjson
@@ -1,0 +1,26 @@
+// https://github.com/notify-rs/notify/issues/671
+
+// Windows may emit a Create Any and then a Modify Anyevent when a file is created.
+{
+    state: {
+        queues: {
+            /watch/file: {
+                events: [
+                    { kind: "create-any", paths: ["*"] }
+                ]
+            }
+        }
+    }
+    events: [
+        { kind: "modify-any", paths: ["/watch/file"] }
+    ]
+    expected: {
+        queues: {
+            /watch/file: {
+                events: [
+                    { kind: "create-any", paths: ["*"] }
+                ]
+            }
+        }
+    }
+}


### PR DESCRIPTION
Fixes #671.

Relies on backends never emitting a `Modify` event with kind other than `Name` for a rename event.
I checked and this is the case now and I don't see why that would change in the future.