### PR TITLE
Update rstest from 0.24 to 0.26

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,7 +41,7 @@ notify-debouncer-mini = { version = "0.7.0", path = "notify-debouncer-mini" }
 notify-types = { version = "2.0.0", path = "notify-types" }
 pretty_assertions = "1.3.0"
 rand = "0.8.5"
-rstest = "0.24.0"
+rstest = "0.26.0"
 serde = { version = "1.0.89", features = ["derive"] }
 serde_json = "1.0.39"
 tempfile = "3.10.0"


### PR DESCRIPTION
Nothing in https://github.com/la10736/rstest/blob/v0.26.1/CHANGELOG.md looks like it should affect this project, and `cargo test --workspace` still passes.

<!-- By contributing, you agree to the terms of the license, available in the LICENSE.ARTISTIC file, and of the code of conduct, available in the CODE_OF_CONDUCT.md file. Furthermore, you agree to release under CC0, also available in the LICENSE file, until Notify has fully transitioned to Artistic 2.0. -->