### PR TITLE
fix: debounce events

### DIFF
--- a/notify-debouncer-full/src/lib.rs
+++ b/notify-debouncer-full/src/lib.rs
@@ -226,18 +226,18 @@ impl<T: FileIdCache> DebounceDataInner<T> {
             let mut kind_index = HashMap::new();
 
             while let Some(event) = queue.events.pop_front() {
+                // remove previous event of the same kind
+                if let Some(idx) = kind_index.get(&event.kind).copied() {
+                    events_expired.remove(idx);
+
+                    kind_index.values_mut().for_each(|i| {
+                        if *i > idx {
+                            *i -= 1
+                        }
+                    })
+                }
+
                 if now.saturating_duration_since(event.time) >= self.timeout {
-                    // remove previous event of the same kind
-                    if let Some(idx) = kind_index.get(&event.kind).copied() {
-                        events_expired.remove(idx);
-
-                        kind_index.values_mut().for_each(|i| {
-                            if *i > idx {
-                                *i -= 1
-                            }
-                        })
-                    }
-
                     kind_index.insert(event.kind, events_expired.len());
 
                     events_expired.push(event);

--- a/notify-debouncer-full/src/lib.rs
+++ b/notify-debouncer-full/src/lib.rs
@@ -812,6 +812,7 @@ mod tests {
             "add_remove_event_after_create_and_modify_event",
             "add_remove_parent_event_after_remove_child_event",
             "add_errors",
+            "debounce_modify_events",
             "emit_continuous_modify_content_events",
             "emit_events_in_chronological_order",
             "emit_events_with_a_prepended_rename_event",

--- a/notify-debouncer-full/test_cases/debounce_modify_events.hjson
+++ b/notify-debouncer-full/test_cases/debounce_modify_events.hjson
@@ -20,12 +20,8 @@
             2: []
             3: []
             4: []
-            5: [
-                { kind: "modify-any", paths: ["/watch/file"], time: 2 }
-            ]
-            6: [
-                { kind: "modify-any", paths: ["/watch/file"], time: 2 }
-            ]
+            5: []
+            6: []
             7: [
                 { kind: "modify-any", paths: ["/watch/file"], time: 4 }
             ]

--- a/notify-debouncer-full/test_cases/debounce_modify_events.hjson
+++ b/notify-debouncer-full/test_cases/debounce_modify_events.hjson
@@ -1,0 +1,49 @@
+{
+    state: {
+        timeout: 3
+    }
+    events: [
+        { kind: "modify-any", paths: ["/watch/file"], time: 2 }
+        { kind: "modify-any", paths: ["/watch/file"], time: 4 }
+    ]
+    expected: {
+        queues: {
+            /watch/file: {
+                events: [
+                    { kind: "modify-any", paths: ["*"], time: 2 }
+                    { kind: "modify-any", paths: ["*"], time: 4 }
+                ]
+            }
+        }
+        events: {
+            1: []
+            2: []
+            3: []
+            4: []
+            5: [
+                { kind: "modify-any", paths: ["/watch/file"], time: 2 }
+            ]
+            6: [
+                { kind: "modify-any", paths: ["/watch/file"], time: 2 }
+            ]
+            7: [
+                { kind: "modify-any", paths: ["/watch/file"], time: 4 }
+            ]
+            8: [
+                { kind: "modify-any", paths: ["/watch/file"], time: 4 }
+            ]
+            9: [
+                { kind: "modify-any", paths: ["/watch/file"], time: 4 }
+            ]
+            10: [
+                { kind: "modify-any", paths: ["/watch/file"], time: 4 }
+            ]
+            100: [
+                { kind: "modify-any", paths: ["/watch/file"], time: 4 }
+            ]
+            1000: [
+                { kind: "modify-any", paths: ["/watch/file"], time: 4 }
+            ]
+        }
+    }
+}

--- a/notify-debouncer-full/test_cases/emit_continuous_modify_content_events.hjson
+++ b/notify-debouncer-full/test_cases/emit_continuous_modify_content_events.hjson
@@ -23,12 +23,8 @@
             3: []
             4: []
             5: []
-            6: [
-                { kind: "modify-data-content", paths: ["/watch/file"], time: 1 }
-            ]
-            7: [
-                { kind: "modify-data-content", paths: ["/watch/file"], time: 2 }
-            ]
+            6: []
+            7: []
             8: [
                 { kind: "modify-data-content", paths: ["/watch/file"], time: 3 }
             ]


### PR DESCRIPTION
When multiple events happened within the timeout, the events were not deduped.

To explain it more precisely, the return value of `DebounceDataInner::debounced_events` never contained a duplicate event, but `event_handler` was called multiple times for events within the timeout.

For example, when the timeout is 8 and the tick rate is 2, consider the following events:
- 0: modify event
- 3: modify event

`event_handler` is called with `0: modify event` on 2, and `3: modify event` on 4. But these two events are within the timeout so the `event_handler` should be only called with `3: modify event` on 12. (It is 12 because that is the first tick after the timeout has passed from the last event)
