### PR TITLE
raise MSRV to 1.85

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -14,9 +14,9 @@ task:
     - name: FreeBSD 14.0 - Rust nightly
       env:
         RUST_VERSION: nightly
-    - name: FreeBSD 14.0 - Rust 1.82 (MSRV)
+    - name: FreeBSD 14.0 - Rust 1.85 (MSRV)
       env:
-        RUST_VERSION: 1.82
+        RUST_VERSION: 1.85
 
   setup_script:
     - rm -f rust-toolchain.toml

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,7 +61,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest]
-        rust: [stable, nightly, 1.82]
+        rust: [stable, nightly, 1.85]
         features: [""]
         include:
           # MacOS with fsevent
@@ -72,7 +72,7 @@ jobs:
             rust: nightly
             features: "--no-default-features --features macos_fsevent"
           - os: macos-latest
-            rust: 1.82
+            rust: 1.85
             features: "--no-default-features --features macos_fsevent"
           # MacOS with kqueue
           - os: macos-latest
@@ -82,7 +82,7 @@ jobs:
             rust: nightly
             features: "--no-default-features --features macos_kqueue"
           - os: macos-latest
-            rust: 1.82
+            rust: 1.85
             features: "--no-default-features --features macos_kqueue"
 
     steps:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,7 @@
 # Changelog
+
 ## notify 9.0.0 (unreleased)
-
-- CHANGE: raise MSRV to 1.82 **breaking**
-
-## notify (unreleased)
+- CHANGE: raise MSRV to 1.85 **breaking**
 - FIX: Fix the bug that `FsEventWatcher` crashes when dealing with empty path [#718]
 
 [#718]: https://github.com/notify-rs/notify/pull/718

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ exclude = [
 ]
 
 [workspace.package]
-rust-version = "1.82"
+rust-version = "1.85"
 homepage = "https://github.com/notify-rs/notify"
 repository = "https://github.com/notify-rs/notify.git"
 edition = "2021"

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ _Cross-platform filesystem notification library for Rust._
 - [Examples][examples]
 - [Changelog][changelog]
 - [Upgrading notify from v4](UPGRADING_V4_TO_V5.md)
-- Minimum supported Rust version: **1.82**
+- Minimum supported Rust version: **1.85**
 
 As used by: [alacritty], [cargo watch], [cobalt], [deno], [docket], [mdBook],
 [rust-analyzer], [watchexec], [watchfiles], [xi-editor],

--- a/notify/src/lib.rs
+++ b/notify/src/lib.rs
@@ -367,7 +367,7 @@ pub trait Watcher {
     /// ```
     fn paths_mut<'me>(&'me mut self) -> Box<dyn PathsMut + 'me> {
         struct DefaultPathsMut<'a, T: ?Sized>(&'a mut T);
-        impl<'a, T: Watcher + ?Sized> PathsMut for DefaultPathsMut<'a, T> {
+        impl<T: Watcher + ?Sized> PathsMut for DefaultPathsMut<'_, T> {
             fn add(&mut self, path: &Path, recursive_mode: RecursiveMode) -> Result<()> {
                 self.0.watch(path, recursive_mode)
             }

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,5 +1,5 @@
 [toolchain]
-channel = "1.82"
+channel = "1.85"
 profile = "minimal"
 components = [
   "clippy",


### PR DESCRIPTION
Ok, after the last MSRV change 4 days ago, there has been [new error](https://github.com/notify-rs/notify/actions/runs/18785065449/job/53601117441?pr=705). The crate `trash` for a windows watcher [was updated](https://github.com/Byron/trash-rs/commit/1894bfe4ab6677ca833cc60bbd6e568480abbf77#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542R10-R11) to use 1.85. Fortunately, we haven't released the major update yet