### PR TITLE
Fix: throw fsevents stream start error properly

### DIFF
--- a/notify/src/fsevent.rs
+++ b/notify/src/fsevent.rs
@@ -464,7 +464,7 @@ impl FsEventWatcher {
                         &cur_runloop,
                         cf::kCFRunLoopDefaultMode.expect("Failed to get default runloop mode"),
                     );
-                    if fs::FSEventStreamStart(stream) == 0 {
+                    if !fs::FSEventStreamStart(stream) {
                         fs::FSEventStreamInvalidate(stream);
                         fs::FSEventStreamRelease(stream);
                         rl_tx


### PR DESCRIPTION
fsevents seems to not allow watching more than 4096 paths at once.
But notify did not throw an error when that happened.
This PR makes the error to be thrown properly.
