### PR TITLE
Add kFSEventStreamCreateFlagWatchRoot to FSEvents stream flags

### DIFF
--- a/notify/src/fsevent.rs
+++ b/notify/src/fsevent.rs
@@ -294,7 +294,9 @@ impl FsEventWatcher {
             paths: cf::CFMutableArray::empty(),
             since_when: fs::kFSEventStreamEventIdSinceNow,
             latency: 0.0,
-            flags: fs::kFSEventStreamCreateFlagFileEvents | fs::kFSEventStreamCreateFlagNoDefer,
+            flags: fs::kFSEventStreamCreateFlagFileEvents
+                | fs::kFSEventStreamCreateFlagNoDefer
+                | fs::kFSEventStreamCreateFlagWatchRoot,
             event_handler,
             runloop: None,
             recursive_info: HashMap::new(),


### PR DESCRIPTION
This flag causes the stream to emit events when the watched root directory itself is renamed, deleted, or moved. This matches the behavior of the previous custom fsevent crate used by Zed.