### PR TITLE
Add `must_use` annotation to config builder methods

### DIFF
--- a/notify/CHANGELOG.md
+++ b/notify/CHANGELOG.md
@@ -8,6 +8,7 @@
 - FIX: [windows] make `unwatch()` wait until the watch is fully removed so later filesystem changes do not leak events [#730]
 - FIX: [macOS] annotate FSEvents clone-related events with `info = "is: clone"` [#465]
 - FIX: avoid panicking in `unwatch` when internal mutexes are poisoned
+- CHANGE: add `#[must_use]` annotations to Config builder apis.
 
 [#375]: https://github.com/notify-rs/notify/issues/375
 [#465]: https://github.com/notify-rs/notify/issues/465

--- a/notify/src/config.rs
+++ b/notify/src/config.rs
@@ -84,6 +84,7 @@ impl Config {
     /// The default poll frequency is 30 seconds.
     ///
     /// This will enable automatic polling, overwriting [`with_manual_polling()`](Config::with_manual_polling).
+    #[must_use]
     pub fn with_poll_interval(mut self, dur: Duration) -> Self {
         // TODO: v7.0 break signature to option
         self.poll_interval = Some(dur);
@@ -101,6 +102,7 @@ impl Config {
     /// Disable automatic polling. Requires calling [`crate::PollWatcher::poll()`] manually.
     ///
     /// This will disable automatic polling, overwriting [`with_poll_interval()`](Config::with_poll_interval).
+    #[must_use]
     pub fn with_manual_polling(mut self) -> Self {
         self.poll_interval = None;
         self
@@ -116,6 +118,7 @@ impl Config {
     /// need to be read and hashed at each `poll_interval`.
     ///
     /// This can't be changed during runtime. Off by default.
+    #[must_use]
     pub fn with_compare_contents(mut self, compare_contents: bool) -> Self {
         self.compare_contents = compare_contents;
         self
@@ -132,6 +135,7 @@ impl Config {
     /// Determine if symbolic links should be followed when recursively watching a directory.
     ///
     /// This can't be changed during runtime. On by default.
+    #[must_use]
     pub fn with_follow_symlinks(mut self, follow_symlinks: bool) -> Self {
         self.follow_symlinks = follow_symlinks;
         self
@@ -186,6 +190,7 @@ impl Config {
     /// separator style implied by each watched input path.
     ///
     /// This can't be changed during runtime.
+    #[must_use]
     pub fn with_windows_path_separator_style(mut self, style: WindowsPathSeparatorStyle) -> Self {
         self.windows_path_separator_style = style;
         self


### PR DESCRIPTION
## Description
Add `must_use` annodations to the `with_*` functions on `Config`.  This way rust will warn if callers fail to use the result

## Related Issues
https://github.com/vercel/next.js/pull/92631 fixed a long standing bug in next.js because we failed to capture this return value
