### PR TITLE
test(notify): forget tempdir to prevent flakiness

### DIFF
--- a/notify/src/fsevent.rs
+++ b/notify/src/fsevent.rs
@@ -1540,6 +1540,17 @@ mod tests {
         }
 
         assert!(watcher.watcher.update_paths(paths).is_err());
+
+        // Best-effort cleanup: on macOS + recent rustc, `remove_dir_all` can
+        // panic with `closedir: Bad file descriptor` while tearing down the
+        // 4097 directories created above (likely an interaction with fsevents
+        // having held FDs on those paths). Bypass `TempDir`'s Drop and swallow
+        // the potential panic so the test does not flake.
+        let path = tmpdir.path().to_path_buf();
+        std::mem::forget(tmpdir);
+        let _ = std::panic::catch_unwind(|| {
+            let _ = std::fs::remove_dir_all(&path);
+        });
     }
 
     #[test]


### PR DESCRIPTION
<!-- 
## Contribution Agreement
By contributing, you agree to the license terms (CC Zero 1.0 for notify crate, MIT/Apache 2.0 for the rest) and the code of conduct in CODE_OF_CONDUCT.md.

## Changelog
Add an entry to CHANGELOG.md if applicable. Create a new section `## notify (unreleased)` if not already present.

## Testing
The test suite will run after creating this PR. If builds fail, you must either fix the errors, ask for help, or provide a detailed explanation of why failures are expected. If you don't, a maintainer may prompt you, but it will take longer for your contribution to be reviewed.

## Code Quality
Running `cargo fmt` and `cargo clippy` is appreciated but not required.

You can delete this comment after reading.
-->

## Description
<!-- Describe your changes here -->

## Related Issues
<!-- Link any related issues -->
