### PR TITLE
perf(debouncer-full): speed up hashing by `rustc-hash`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -703,6 +703,7 @@ dependencies = [
  "pretty_assertions",
  "rand",
  "rstest",
+ "rustc-hash",
  "serde",
  "tempfile",
  "tokio",
@@ -960,6 +961,12 @@ dependencies = [
  "syn",
  "unicode-ident",
 ]
+
+[[package]]
+name = "rustc-hash"
+version = "2.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
 
 [[package]]
 name = "rustc_version"

--- a/notify-debouncer-full/CHANGELOG.md
+++ b/notify-debouncer-full/CHANGELOG.md
@@ -3,6 +3,7 @@
 
 - CHANGE: raise MSRV to 1.88
 - CHANGE: use `HashMap::extract_if` to reduce debouncer flush overhead
+- CHANGE: speed up debouncer event flushing and file ID cache lookups while preserving stable path ordering for equal-timestamp events
 - FEATURE: impl `EventHandler` for `futures::channel::mpsc::UnboundedSender` and `tokio::sync::mpsc::UnboundedSender` behind the `futures` and `tokio` feature flags [#767]
 - FEATURE: add support of a watcher's method `update_paths`  [#705]
 - FEATURE: add `Debouncer::watched_paths` for `Debouncer` [#710]

--- a/notify-debouncer-full/Cargo.toml
+++ b/notify-debouncer-full/Cargo.toml
@@ -34,6 +34,7 @@ tokio = { workspace = true, optional = true }
 file-id.workspace = true
 walkdir.workspace = true
 log.workspace = true
+rustc-hash = "2.1.2"
 
 [dev-dependencies]
 pretty_assertions.workspace = true

--- a/notify-debouncer-full/src/file_id_map.rs
+++ b/notify-debouncer-full/src/file_id_map.rs
@@ -1,10 +1,8 @@
 use crate::FileIdCache;
 use file_id::{get_file_id, FileId};
 use notify::RecursiveMode;
-use std::{
-    collections::HashMap,
-    path::{Path, PathBuf},
-};
+use rustc_hash::FxHashMap as HashMap;
+use std::path::{Path, PathBuf};
 use walkdir::WalkDir;
 
 /// A cache to hold the file system IDs of all watched files.

--- a/notify-debouncer-full/src/lib.rs
+++ b/notify-debouncer-full/src/lib.rs
@@ -72,7 +72,7 @@ mod file_id_map;
 
 use std::{
     cmp::Reverse,
-    collections::{BinaryHeap, HashMap, VecDeque},
+    collections::{BinaryHeap, VecDeque},
     path::{Path, PathBuf},
     sync::{
         atomic::{AtomicBool, Ordering},
@@ -81,6 +81,7 @@ use std::{
     time::{Duration, Instant},
 };
 
+use rustc_hash::FxHashMap as HashMap;
 use time::now;
 
 pub use cache::{FileIdCache, NoCache, RecommendedCache};
@@ -216,7 +217,7 @@ pub(crate) struct DebounceDataInner<T> {
 impl<T: FileIdCache> DebounceDataInner<T> {
     pub(crate) fn new(cache: T, timeout: Duration) -> Self {
         Self {
-            queues: HashMap::new(),
+            queues: HashMap::default(),
             roots: Vec::new(),
             cache,
             rename_event: None,
@@ -243,29 +244,20 @@ impl<T: FileIdCache> DebounceDataInner<T> {
         // Visit each queue in place and remove only the ones that become empty.
         self.queues
             .extract_if(|_, queue| {
-                let mut kind_index = Vec::<(EventKind, usize)>::new();
+                let mut kind_index: HashMap<EventKind, usize> = HashMap::default();
                 let mut queue_expired = Vec::new();
 
                 while let Some(event) = queue.events.pop_front() {
                     // remove previous event of the same kind
                     if now.saturating_duration_since(event.time) >= self.timeout {
-                        if let Some((_, idx)) =
-                            kind_index.iter_mut().find(|(kind, _)| *kind == event.kind)
-                        {
-                            queue_expired[*idx] = None;
-                            *idx = queue_expired.len();
-                        } else {
-                            kind_index.push((event.kind, queue_expired.len()));
+                        if let Some(idx) = kind_index.insert(event.kind, queue_expired.len()) {
+                            queue_expired[idx] = None;
                         }
 
                         queue_expired.push(Some(event));
                     } else {
-                        if let Some((_, idx)) =
-                            kind_index.iter_mut().find(|(kind, _)| *kind == event.kind)
-                        {
-                            queue_expired[*idx] = None;
-                        } else {
-                            kind_index.push((event.kind, queue_expired.len()));
+                        if let Some(&idx) = kind_index.get(&event.kind) {
+                            queue_expired[idx] = None;
                         }
                         queue.events.push_front(event);
                         break;
@@ -827,25 +819,35 @@ fn sort_events(events: Vec<DebouncedEvent>) -> Vec<DebouncedEvent> {
     let mut sorted = Vec::with_capacity(events.len());
 
     // group events by path
-    let mut events_by_path: HashMap<_, VecDeque<_>> =
-        events.into_iter().fold(HashMap::new(), |mut acc, event| {
-            acc.entry(event.paths.last().cloned().unwrap_or_default())
-                .or_default()
-                .push_back(event);
-            acc
-        });
+    let mut groups = Vec::<(PathBuf, VecDeque<DebouncedEvent>)>::new();
+    let mut group_indexes: HashMap<PathBuf, usize> = HashMap::default();
+    group_indexes.reserve(events.len());
+    groups.reserve(events.len());
+
+    for event in events {
+        let path = event.paths.last().cloned().unwrap_or_default();
+
+        if let Some(&index) = group_indexes.get(&path) {
+            groups[index].1.push_back(event);
+        } else {
+            group_indexes.insert(path.clone(), groups.len());
+            groups.push((path, [event].into()));
+        }
+    }
+
+    // Keep path order as the tie-breaker for identical timestamps.
+    groups.sort_unstable_by(|(left_path, _), (right_path, _)| left_path.cmp(right_path));
 
     // push events for different paths in chronological order and keep the order of events with the same path
 
-    let mut min_time_heap = events_by_path
+    let mut min_time_heap = groups
         .iter()
-        .map(|(path, events)| Reverse((events[0].time, path.clone())))
+        .enumerate()
+        .map(|(index, (_, events))| Reverse((events[0].time, index)))
         .collect::<BinaryHeap<_>>();
 
-    while let Some(Reverse((min_time, path))) = min_time_heap.pop() {
-        // unwrap is safe because only paths from `events_by_path` are added to `min_time_heap`
-        // and they are never removed from `events_by_path`.
-        let events = events_by_path.get_mut(&path).unwrap();
+    while let Some(Reverse((min_time, index))) = min_time_heap.pop() {
+        let events = &mut groups[index].1;
 
         let mut push_next = false;
 
@@ -858,7 +860,7 @@ fn sort_events(events: Vec<DebouncedEvent>) -> Vec<DebouncedEvent> {
 
         if push_next {
             if let Some(event) = events.front() {
-                min_time_heap.push(Reverse((event.time, path)));
+                min_time_heap.push(Reverse((event.time, index)));
             }
         }
     }
@@ -871,6 +873,7 @@ mod tests {
     use std::{
         fs,
         path::{Path, PathBuf},
+        time::Duration,
     };
 
     use super::*;
@@ -1089,6 +1092,32 @@ mod tests {
                 "debounced events after a `{delay}` delay"
             );
         }
+    }
+
+    #[test]
+    fn sort_events_ties_by_path() {
+        let time = now();
+        let events = vec![
+            DebouncedEvent::new(
+                Event::new(EventKind::Any).add_path(PathBuf::from("/watch/b")),
+                time,
+            ),
+            DebouncedEvent::new(
+                Event::new(EventKind::Any).add_path(PathBuf::from("/watch/a")),
+                time,
+            ),
+        ];
+
+        let sorted = sort_events(events);
+        let paths = sorted
+            .into_iter()
+            .map(|event| event.paths[0].clone())
+            .collect::<Vec<_>>();
+
+        assert_eq!(
+            paths,
+            vec![PathBuf::from("/watch/a"), PathBuf::from("/watch/b")]
+        );
     }
 
     #[test]


### PR DESCRIPTION
<!-- 
## Contribution Agreement
By contributing, you agree to the license terms (CC Zero 1.0 for notify crate, MIT/Apache 2.0 for the rest) and the code of conduct in CODE_OF_CONDUCT.md.

## Changelog
Add an entry to CHANGELOG.md if applicable. Create a new section `## notify (unreleased)` if not already present.

## Testing
The test suite will run after creating this PR. If builds fail, you must either fix the errors, ask for help, or provide a detailed explanation of why failures are expected. If you don't, a maintainer may prompt you, but it will take longer for your contribution to be reviewed.

## Code Quality
Running `cargo fmt` and `cargo clippy` is appreciated but not required.

You can delete this comment after reading.
-->

## Description
<!-- Describe your changes here -->

This replaces std's hashmap with rustc-hash as it's speedy and we don't require cryptography correctness here.
On my local, it speeds up by 20-50% (N.B. it depends on user's env so I don't call it official).

## Related Issues
<!-- Link any related issues -->
