### PR TITLE
feat(notify): preserve watched path representations across backends

### DIFF
--- a/docs/UPGRADING_V8_TO_V9.md
+++ b/docs/UPGRADING_V8_TO_V9.md
@@ -60,6 +60,22 @@ This lets you retry only unfinished operations if needed.
 
 If you implemented a custom watcher and overrode `paths_mut`, migrate that logic to `update_paths`.
 
+### 3) Event paths preserve the watched path representation
+
+`Event.paths` and `Watcher::watched_paths()` now use the same root representation that was passed
+to `Watcher::watch` or `Watcher::update_paths`.
+
+For example, watching `src` now reports `src/lib.rs`. Watching `/repo/src` reports
+`/repo/src/lib.rs`.
+
+If your code relied on Linux or Windows backends converting relative watch paths to absolute event
+paths, convert the path before calling `watch`:
+
+```rust
+let path = std::env::current_dir()?.join("src");
+watcher.watch(&path, notify::RecursiveMode::Recursive)?;
+```
+
 ## Non-breaking changes but worth mentioning
 
 ### Event-kind filtering was added

--- a/notify-types/src/event.rs
+++ b/notify-types/src/event.rs
@@ -458,6 +458,10 @@ pub struct Event {
 
     /// Paths the event is about, if known.
     ///
+    /// Notify backends report paths using the same root representation that was passed to
+    /// `Watcher::watch`. For example, watching `src` reports paths like `src/lib.rs`, while
+    /// watching an absolute path reports absolute event paths.
+    ///
     /// If an event concerns two or more paths, and the paths are known at the time of event
     /// creation, they should all go in this `Vec`. Otherwise, using the `Tracker` attr may be more
     /// appropriate.

--- a/notify/CHANGELOG.md
+++ b/notify/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## unreleased
 
+- CHANGE: preserve watched path representation in `Event.paths` and `Watcher::watched_paths`; relative watch paths now produce relative event paths consistently across backends [#453] [#740]
+
 ## notify 9.0.0-rc.3 (2026-04-16)
 
 - CHANGE: raise MSRV to 1.88
@@ -16,6 +18,8 @@
 [#465]: https://github.com/notify-rs/notify/issues/465
 [#730]: https://github.com/notify-rs/notify/issues/730
 [#739]: https://github.com/notify-rs/notify/issues/739
+[#453]: https://github.com/notify-rs/notify/issues/453
+[#740]: https://github.com/notify-rs/notify/issues/740
 
 ## notify 9.0.0-rc.2 (2026-02-14)
 

--- a/notify/src/fsevent.rs
+++ b/notify/src/fsevent.rs
@@ -14,6 +14,7 @@
 
 #![allow(non_upper_case_globals, dead_code)]
 
+use crate::paths::{absolute_path, reported_path};
 use crate::{event::*, PathOp};
 use crate::{
     unbounded, Config, Error, EventHandler, EventKindMask, RecursiveMode, Result, Sender, Watcher,
@@ -69,8 +70,14 @@ pub struct FsEventWatcher {
     flags: fs::FSEventStreamCreateFlags,
     event_handler: Arc<Mutex<dyn EventHandler>>,
     runloop: Option<RunLoopHandle>,
-    recursive_info: HashMap<PathBuf, bool>,
+    recursive_info: HashMap<PathBuf, WatchInfo>,
     event_kinds: EventKindMask,
+}
+
+#[derive(Clone, Debug)]
+struct WatchInfo {
+    is_recursive: bool,
+    reported_path: PathBuf,
 }
 
 #[derive(Debug)]
@@ -278,7 +285,7 @@ fn translate_flags(flags: StreamFlags, precise: bool) -> Vec<Event> {
 
 struct StreamContextInfo {
     event_handler: Arc<Mutex<dyn EventHandler>>,
-    recursive_info: HashMap<PathBuf, bool>,
+    recursive_info: HashMap<PathBuf, WatchInfo>,
     event_kinds: EventKindMask,
 }
 
@@ -390,8 +397,19 @@ impl FsEventWatcher {
     }
 
     fn remove_path(&mut self, path: &Path) -> Result<()> {
+        let p = path
+            .canonicalize()
+            .ok()
+            .or_else(|| {
+                self.recursive_info
+                    .iter()
+                    .find(|(_, info)| info.reported_path == path)
+                    .map(|(path, _)| path.clone())
+            })
+            .or_else(|| absolute_path(path).ok())
+            .unwrap_or_else(|| path.to_owned());
         let mut err: *mut cf::CFError = ptr::null_mut();
-        let Some(cf_path) = (unsafe { path_to_cfstring_ref(path, &mut err) }) else {
+        let Some(cf_path) = (unsafe { path_to_cfstring_ref(&p, &mut err) }) else {
             if let Some(err) = NonNull::new(err) {
                 let _ = unsafe { cf::CFRetained::from_raw(err) };
             }
@@ -415,11 +433,6 @@ impl FsEventWatcher {
             };
         }
 
-        let p = if let Ok(canonicalized_path) = path.canonicalize() {
-            canonicalized_path
-        } else {
-            path.to_owned()
-        };
         match self.recursive_info.remove(&p) {
             Some(_) => Ok(()),
             None => Err(Error::watch_not_found()),
@@ -433,7 +446,7 @@ impl FsEventWatcher {
         }
         let canonical_path = path.to_path_buf().canonicalize()?;
         let mut err: *mut cf::CFError = ptr::null_mut();
-        let Some(cf_path) = (unsafe { path_to_cfstring_ref(path, &mut err) }) else {
+        let Some(cf_path) = (unsafe { path_to_cfstring_ref(&canonical_path, &mut err) }) else {
             if let Some(err) = NonNull::new(err) {
                 let _ = unsafe { cf::CFRetained::from_raw(err) };
             }
@@ -443,8 +456,13 @@ impl FsEventWatcher {
         };
         self.paths.append(&cf_path);
 
-        self.recursive_info
-            .insert(canonical_path, recursive_mode.is_recursive());
+        self.recursive_info.insert(
+            canonical_path,
+            WatchInfo {
+                is_recursive: recursive_mode.is_recursive(),
+                reported_path: path.to_path_buf(),
+            },
+        );
         Ok(())
     }
 
@@ -636,30 +654,40 @@ unsafe fn callback_impl(
             log::trace!("unknown FSEventStreamEventFlags bits: 0x{unknown_bits:08x}");
         }
 
-        let mut handle_event = false;
-        for (p, r) in &(*info).recursive_info {
+        let mut watch_match = None;
+        for (p, watch_info) in &(*info).recursive_info {
             if path.starts_with(p) {
-                if *r || &path == p {
-                    handle_event = true;
-                    break;
+                let matches_watch = if watch_info.is_recursive || &path == p {
+                    true
                 } else if let Some(parent_path) = path.parent() {
-                    if parent_path == p {
-                        handle_event = true;
-                        break;
-                    }
+                    parent_path == p
+                } else {
+                    false
+                };
+
+                if matches_watch
+                    && watch_match.as_ref().is_none_or(
+                        |(matched_path, _): &(&PathBuf, &WatchInfo)| {
+                            p.as_os_str().as_bytes().len()
+                                > matched_path.as_os_str().as_bytes().len()
+                        },
+                    )
+                {
+                    watch_match = Some((p, watch_info));
                 }
             }
         }
 
-        if !handle_event {
+        let Some((watch_path, watch_info)) = watch_match else {
             continue;
-        }
+        };
+        let event_path = reported_path(watch_path, &watch_info.reported_path, &path);
 
         log::trace!("FSEvent: path = `{}`, flag = {:?}", path.display(), flag);
 
         for ev in translate_flags(flag, true).into_iter() {
             // TODO: precise
-            let ev = ev.add_path(path.clone());
+            let ev = ev.add_path(event_path.clone());
             // Filter events based on EventKindMask
             if !(*info).event_kinds.matches(&ev.kind) {
                 continue; // Skip events that don't match the mask
@@ -711,10 +739,10 @@ impl Watcher for FsEventWatcher {
         Ok(self
             .recursive_info
             .iter()
-            .map(|(path, is_recursive)| {
+            .map(|(_path, info)| {
                 (
-                    path.clone(),
-                    if *is_recursive {
+                    info.reported_path.clone(),
+                    if info.is_recursive {
                         RecursiveMode::Recursive
                     } else {
                         RecursiveMode::NonRecursive
@@ -930,7 +958,13 @@ mod tests {
         let event_handler: Arc<Mutex<dyn EventHandler>> = Arc::new(Mutex::new(tx));
 
         let mut recursive_info = HashMap::new();
-        recursive_info.insert(PathBuf::from("/tmp"), true);
+        recursive_info.insert(
+            PathBuf::from("/tmp"),
+            WatchInfo {
+                is_recursive: true,
+                reported_path: PathBuf::from("/tmp"),
+            },
+        );
 
         let context = Box::new(StreamContextInfo {
             event_handler,
@@ -988,7 +1022,13 @@ mod tests {
         let event_handler: Arc<Mutex<dyn EventHandler>> = Arc::new(Mutex::new(tx));
 
         let mut recursive_info = HashMap::new();
-        recursive_info.insert(PathBuf::from("/tmp"), true);
+        recursive_info.insert(
+            PathBuf::from("/tmp"),
+            WatchInfo {
+                is_recursive: true,
+                reported_path: PathBuf::from("/tmp"),
+            },
+        );
 
         let context = Box::new(StreamContextInfo {
             event_handler,

--- a/notify/src/inotify.rs
+++ b/notify/src/inotify.rs
@@ -6,12 +6,14 @@
 
 use super::event::*;
 use super::{Config, Error, ErrorKind, EventHandler, RecursiveMode, Result, Watcher};
+use crate::paths::{
+    absolute_path, is_preserved_watch_root, preserved_watch_mode, reported_path, WatchPath,
+};
 use crate::{bounded, unbounded, BoundSender, Receiver, Sender};
 use inotify as inotify_sys;
 use inotify_sys::{EventMask, Inotify, WatchDescriptor, WatchMask};
 use notify_types::event::EventKindMask;
 use std::collections::HashMap;
-use std::env;
 use std::ffi::OsStr;
 use std::fs::metadata;
 use std::os::unix::io::AsRawFd;
@@ -99,6 +101,9 @@ struct Watch {
     watch_mask: WatchMask,
     is_recursive: bool,
     is_dir: bool,
+    reported_path: PathBuf,
+    is_user_watch: bool,
+    user_is_recursive: bool,
 }
 
 /// Watcher implementation based on inotify
@@ -109,7 +114,7 @@ pub struct INotifyWatcher {
 }
 
 enum EventLoopMsg {
-    AddWatch(PathBuf, RecursiveMode, Sender<Result<()>>),
+    AddWatch(WatchPath, RecursiveMode, Sender<Result<()>>),
     RemoveWatch(PathBuf, Sender<Result<()>>),
     GetWatchedPaths(Sender<Vec<(PathBuf, RecursiveMode)>>),
     Shutdown,
@@ -121,13 +126,16 @@ fn add_watch_by_event(
     path: &PathBuf,
     event: &inotify_sys::Event<&OsStr>,
     watches: &HashMap<PathBuf, Watch>,
-    add_watches: &mut Vec<PathBuf>,
+    add_watches: &mut Vec<WatchPath>,
 ) {
     if event.mask.contains(EventMask::ISDIR) {
         if let Some(parent_path) = path.parent() {
             if let Some(watch) = watches.get(parent_path) {
                 if watch.is_recursive {
-                    add_watches.push(path.to_owned());
+                    add_watches.push(WatchPath::from_parts(
+                        path.to_owned(),
+                        reported_path(parent_path, &watch.reported_path, path),
+                    ));
                 }
             }
         }
@@ -245,10 +253,11 @@ impl EventLoop {
                     let _ = tx.send(
                         self.watches
                             .iter()
-                            .map(|(path, watch)| {
+                            .filter(|(_path, watch)| watch.is_user_watch)
+                            .map(|(_path, watch)| {
                                 (
-                                    path.clone(),
-                                    if watch.is_recursive {
+                                    watch.reported_path.clone(),
+                                    if watch.user_is_recursive {
                                         RecursiveMode::Recursive
                                     } else {
                                         RecursiveMode::NonRecursive
@@ -299,13 +308,20 @@ impl EventLoop {
                                 self.event_handler.handle_event(ev);
                             }
 
-                            let path = match event.name {
-                                Some(name) => self.paths.get(&event.wd).map(|root| root.join(name)),
-                                None => self.paths.get(&event.wd).cloned(),
-                            };
+                            let paths = self.paths.get(&event.wd).and_then(|root| {
+                                self.watches.get(root).map(|watch| match event.name {
+                                    Some(name) => {
+                                        let path = root.join(name);
+                                        let reported_path =
+                                            reported_path(root, &watch.reported_path, &path);
+                                        (path, reported_path)
+                                    }
+                                    None => (root.clone(), watch.reported_path.clone()),
+                                })
+                            });
 
-                            let path = match path {
-                                Some(path) => path,
+                            let (path, event_path) = match paths {
+                                Some(paths) => paths,
                                 None => {
                                     log::debug!("inotify event with unknown descriptor: {event:?}");
                                     continue;
@@ -320,7 +336,7 @@ impl EventLoop {
                                 let event = Event::new(EventKind::Modify(ModifyKind::Name(
                                     RenameMode::From,
                                 )))
-                                .add_path(path.clone())
+                                .add_path(event_path.clone())
                                 .set_tracker(event.cookie as usize);
 
                                 self.rename_event = Some(event.clone());
@@ -330,7 +346,7 @@ impl EventLoop {
                                 evs.push(
                                     Event::new(EventKind::Modify(ModifyKind::Name(RenameMode::To)))
                                         .set_tracker(event.cookie as usize)
-                                        .add_path(path.clone()),
+                                        .add_path(event_path.clone()),
                                 );
 
                                 let trackers_match =
@@ -345,7 +361,7 @@ impl EventLoop {
                                         )))
                                         .set_tracker(event.cookie as usize)
                                         .add_some_path(rename_event.paths.first().cloned())
-                                        .add_path(path.clone()),
+                                        .add_path(event_path.clone()),
                                     );
                                 }
                                 add_watch_by_event(&path, &event, &self.watches, &mut add_watches);
@@ -355,7 +371,7 @@ impl EventLoop {
                                     Event::new(EventKind::Modify(ModifyKind::Name(
                                         RenameMode::From,
                                     )))
-                                    .add_path(path.clone()),
+                                    .add_path(event_path.clone()),
                                 );
                                 // TODO stat the path and get to new path
                                 // - emit To and Both events
@@ -370,7 +386,7 @@ impl EventLoop {
                                             CreateKind::File
                                         },
                                     ))
-                                    .add_path(path.clone()),
+                                    .add_path(event_path.clone()),
                                 );
                                 add_watch_by_event(&path, &event, &self.watches, &mut add_watches);
                             }
@@ -383,7 +399,7 @@ impl EventLoop {
                                             RemoveKind::File
                                         },
                                     ))
-                                    .add_path(path.clone()),
+                                    .add_path(event_path.clone()),
                                 );
                                 remove_watch_by_event(&path, &self.watches, &mut remove_watches);
                             }
@@ -395,12 +411,12 @@ impl EventLoop {
                                 };
                                 evs.push(
                                     Event::new(EventKind::Remove(remove_kind))
-                                        .add_path(path.clone()),
+                                        .add_path(event_path.clone()),
                                 );
                                 remove_watch_by_event(&path, &self.watches, &mut remove_watches);
                             }
                             if event.mask.contains(EventMask::UNMOUNT) {
-                                evs.push(unmount_event(path.clone()));
+                                evs.push(unmount_event(event_path.clone()));
                                 // The kernel has already removed this watch descriptor and will
                                 // emit IGNORED; clean up internal state without inotify_rm_watch.
                                 // ref. https://www.man7.org/linux/man-pages/man7/inotify.7.html
@@ -415,7 +431,7 @@ impl EventLoop {
                                     Event::new(EventKind::Modify(ModifyKind::Data(
                                         DataChange::Any,
                                     )))
-                                    .add_path(path.clone()),
+                                    .add_path(event_path.clone()),
                                 );
                             }
                             if event.mask.contains(EventMask::CLOSE_WRITE) {
@@ -423,7 +439,7 @@ impl EventLoop {
                                     Event::new(EventKind::Access(AccessKind::Close(
                                         AccessMode::Write,
                                     )))
-                                    .add_path(path.clone()),
+                                    .add_path(event_path.clone()),
                                 );
                             }
                             if event.mask.contains(EventMask::CLOSE_NOWRITE) {
@@ -431,7 +447,7 @@ impl EventLoop {
                                     Event::new(EventKind::Access(AccessKind::Close(
                                         AccessMode::Read,
                                     )))
-                                    .add_path(path.clone()),
+                                    .add_path(event_path.clone()),
                                 );
                             }
                             if event.mask.contains(EventMask::ATTRIB) {
@@ -439,7 +455,7 @@ impl EventLoop {
                                     Event::new(EventKind::Modify(ModifyKind::Metadata(
                                         MetadataKind::Any,
                                     )))
-                                    .add_path(path.clone()),
+                                    .add_path(event_path.clone()),
                                 );
                             }
                             if event.mask.contains(EventMask::OPEN) {
@@ -447,7 +463,7 @@ impl EventLoop {
                                     Event::new(EventKind::Access(AccessKind::Open(
                                         AccessMode::Any,
                                     )))
-                                    .add_path(path.clone()),
+                                    .add_path(event_path.clone()),
                                 );
                             }
 
@@ -504,18 +520,19 @@ impl EventLoop {
         }
     }
 
-    fn add_watch(&mut self, path: PathBuf, is_recursive: bool, watch_self: bool) -> Result<()> {
+    fn add_watch(&mut self, path: WatchPath, is_recursive: bool, watch_self: bool) -> Result<()> {
         // If the watch is not recursive, or if we determine (by stat'ing the path to get its
         // metadata) that the watched path is not a directory, add a single path watch.
-        if !is_recursive || !metadata(&path).map_err(Error::io_watch)?.is_dir() {
+        if !is_recursive || !metadata(&path.absolute).map_err(Error::io_watch)?.is_dir() {
             return self.add_single_watch(path, false, true);
         }
 
-        let entries = WalkDir::new(path)
+        let root = path.clone();
+        let entries = WalkDir::new(&root.absolute)
             .follow_links(self.follow_links)
             .into_iter()
             .filter_map(filter_dir)
-            .map(|entry| entry.into_path());
+            .map(move |entry| root.child(entry.into_path()));
 
         self.add_watches_for_paths(entries, is_recursive, watch_self)
     }
@@ -527,7 +544,7 @@ impl EventLoop {
         mut watch_self: bool,
     ) -> Result<()>
     where
-        I: IntoIterator<Item = PathBuf>,
+        I: IntoIterator<Item = WatchPath>,
     {
         for path in paths {
             match self.add_single_watch(path, is_recursive, watch_self) {
@@ -545,7 +562,7 @@ impl EventLoop {
 
     fn add_single_watch(
         &mut self,
-        path: PathBuf,
+        path: WatchPath,
         is_recursive: bool,
         watch_self: bool,
     ) -> Result<()> {
@@ -557,15 +574,16 @@ impl EventLoop {
             watchmask.insert(WatchMask::MOVE_SELF);
         }
 
-        if let Some(watch) = self.watches.get(&path) {
+        let existing_watch = self.watches.get(&path.absolute);
+        if let Some(watch) = existing_watch {
             watchmask.insert(watch.watch_mask);
             watchmask.insert(WatchMask::MASK_ADD);
         }
 
         if let Some(ref mut inotify) = self.inotify {
-            log::trace!("adding inotify watch: {}", path.display());
+            log::trace!("adding inotify watch: {}", path.absolute.display());
 
-            match inotify.watches().add(&path, watchmask) {
+            match inotify.watches().add(&path.absolute, watchmask) {
                 Err(e) => {
                     Err(if e.raw_os_error() == Some(libc::ENOSPC) {
                         // do not report inotify limits as "no more space" on linux #266
@@ -575,29 +593,68 @@ impl EventLoop {
                     } else {
                         Error::io(e)
                     }
-                    .add_path(path))
+                    .add_path(path.requested))
                 }
                 Ok(w) => {
                     watchmask.remove(WatchMask::MASK_ADD);
-                    let is_dir = match metadata(&path) {
+                    let is_dir = match metadata(&path.absolute) {
                         Ok(metadata) => metadata.is_dir(),
                         Err(e) => {
                             // Avoid leaking an inotify watch if we can't stat after adding it.
                             // This can happen due to racy deletions.
                             let _ = inotify.watches().remove(w.clone());
-                            return Err(Error::io_watch(e).add_path(path));
+                            return Err(Error::io_watch(e).add_path(path.requested));
                         }
                     };
+                    let existing_reported_path =
+                        existing_watch.map(|watch| watch.reported_path.clone());
+                    let existing_is_user_watch =
+                        existing_watch.is_some_and(|watch| watch.is_user_watch);
+                    let existing_user_is_recursive =
+                        existing_watch.is_some_and(|watch| watch.user_is_recursive);
+                    let existing_is_recursive =
+                        existing_watch.is_some_and(|watch| watch.is_recursive);
+
+                    let reported_path = if watch_self {
+                        path.requested.clone()
+                    } else if existing_is_user_watch {
+                        existing_reported_path.unwrap_or_else(|| path.requested.clone())
+                    } else {
+                        self.watches
+                            .iter()
+                            .filter(|(candidate, watch)| {
+                                watch.is_user_watch
+                                    && watch.user_is_recursive
+                                    && path.absolute.starts_with(candidate)
+                            })
+                            .max_by_key(|(candidate, _)| candidate.as_os_str().len())
+                            .map_or_else(
+                                || path.requested.clone(),
+                                |(root, watch)| {
+                                    reported_path(root, &watch.reported_path, &path.absolute)
+                                },
+                            )
+                    };
+                    let is_user_watch = watch_self || existing_is_user_watch;
+                    let user_is_recursive = if watch_self {
+                        is_recursive
+                    } else {
+                        existing_user_is_recursive
+                    };
+
                     self.watches.insert(
-                        path.clone(),
+                        path.absolute.clone(),
                         Watch {
                             watch_descriptor: w.clone(),
                             watch_mask: watchmask,
-                            is_recursive,
+                            is_recursive: is_recursive || existing_is_recursive,
                             is_dir,
+                            reported_path,
+                            is_user_watch,
+                            user_is_recursive,
                         },
                     );
-                    self.paths.insert(w, path);
+                    self.paths.insert(w, path.absolute);
                     Ok(())
                 }
             }
@@ -607,6 +664,18 @@ impl EventLoop {
     }
 
     fn remove_watch(&mut self, path: PathBuf, remove_recursive: bool) -> Result<()> {
+        let preserved_roots: Vec<_> = if remove_recursive {
+            Vec::new()
+        } else {
+            self.watches
+                .iter()
+                .filter(|(candidate, watch)| {
+                    *candidate != &path && candidate.starts_with(&path) && watch.is_user_watch
+                })
+                .map(|(path, watch)| (path.clone(), watch.user_is_recursive))
+                .collect()
+        };
+
         match self.watches.remove(&path) {
             None => return Err(Error::watch_not_found().add_path(path)),
             Some(watch) => {
@@ -622,8 +691,20 @@ impl EventLoop {
 
                     if watch.is_recursive || remove_recursive {
                         let mut remove_list = Vec::new();
+                        let mut reset_list = Vec::new();
                         for (w, p) in &self.paths {
                             if p.starts_with(&path) {
+                                if let Some(user_is_recursive) =
+                                    preserved_watch_mode(p, &preserved_roots)
+                                {
+                                    if !user_is_recursive
+                                        || is_preserved_watch_root(p, &preserved_roots)
+                                    {
+                                        reset_list.push(p.clone());
+                                    }
+                                    continue;
+                                }
+
                                 Self::remove_single_descriptor(&mut inotify_watches, w.clone());
                                 self.watches.remove(p);
                                 remove_list.push(w.clone());
@@ -631,6 +712,11 @@ impl EventLoop {
                         }
                         for w in remove_list {
                             self.paths.remove(&w);
+                        }
+                        for p in reset_list {
+                            if let Some(watch) = self.watches.get_mut(&p) {
+                                watch.is_recursive = watch.user_is_recursive;
+                            }
                         }
                     }
                 }
@@ -644,6 +730,18 @@ impl EventLoop {
         path: PathBuf,
         remove_recursive: bool,
     ) -> Result<()> {
+        let preserved_roots: Vec<_> = if remove_recursive {
+            Vec::new()
+        } else {
+            self.watches
+                .iter()
+                .filter(|(candidate, watch)| {
+                    *candidate != &path && candidate.starts_with(&path) && watch.is_user_watch
+                })
+                .map(|(path, watch)| (path.clone(), watch.user_is_recursive))
+                .collect()
+        };
+
         match self.watches.remove(&path) {
             None => return Err(Error::watch_not_found().add_path(path)),
             Some(watch) => {
@@ -651,14 +749,31 @@ impl EventLoop {
 
                 if watch.is_recursive || remove_recursive {
                     let mut remove_list = Vec::new();
+                    let mut reset_list = Vec::new();
                     for (w, p) in &self.paths {
                         if p.starts_with(&path) {
+                            if let Some(user_is_recursive) =
+                                preserved_watch_mode(p, &preserved_roots)
+                            {
+                                if !user_is_recursive
+                                    || is_preserved_watch_root(p, &preserved_roots)
+                                {
+                                    reset_list.push(p.clone());
+                                }
+                                continue;
+                            }
+
                             self.watches.remove(p);
                             remove_list.push(w.clone());
                         }
                     }
                     for w in remove_list {
                         self.paths.remove(&w);
+                    }
+                    for p in reset_list {
+                        if let Some(watch) = self.watches.get_mut(&p) {
+                            watch.is_recursive = watch.user_is_recursive;
+                        }
                     }
                 }
             }
@@ -732,12 +847,7 @@ impl INotifyWatcher {
     }
 
     fn watch_inner(&mut self, path: &Path, recursive_mode: RecursiveMode) -> Result<()> {
-        let pb = if path.is_absolute() {
-            path.to_owned()
-        } else {
-            let p = env::current_dir().map_err(Error::io)?;
-            p.join(path)
-        };
+        let pb = WatchPath::new(path)?;
         let (tx, rx) = unbounded();
         let msg = EventLoopMsg::AddWatch(pb, recursive_mode, tx);
 
@@ -747,12 +857,7 @@ impl INotifyWatcher {
     }
 
     fn unwatch_inner(&mut self, path: &Path) -> Result<()> {
-        let pb = if path.is_absolute() {
-            path.to_owned()
-        } else {
-            let p = env::current_dir().map_err(Error::io)?;
-            p.join(path)
-        };
+        let pb = absolute_path(path)?;
         let (tx, rx) = unbounded();
         let msg = EventLoopMsg::RemoveWatch(pb, tx);
 
@@ -819,7 +924,7 @@ mod tests {
     use super::inotify_sys::WatchMask;
     use super::{
         Config, Error, ErrorKind, Event, EventKind, EventLoop, INotifyWatcher, RecursiveMode,
-        Result, Watcher,
+        Result, WatchPath, Watcher,
     };
     use notify_types::event::{EventKindMask, RemoveKind};
 
@@ -879,7 +984,13 @@ mod tests {
 
         // Simulate the TOCTOU: we *intend* to watch a subdirectory discovered during initial scan,
         // but it's already gone by the time we call `inotify_add_watch`.
-        let result = event_loop.add_watches_for_paths(vec![root, disappearing], true, true);
+        let result = event_loop.add_watches_for_paths(
+            [root, disappearing]
+                .into_iter()
+                .map(|path| WatchPath::new(&path).unwrap()),
+            true,
+            true,
+        );
         assert!(
             result.is_ok(),
             "expected recursive watch to succeed, got: {result:?}"
@@ -1050,7 +1161,7 @@ mod tests {
         let mut event_loop = EventLoop::new(inotify, Box::new(|_| {}), &Config::default()).unwrap();
 
         event_loop
-            .add_watch(watched.clone(), false, true)
+            .add_watch(WatchPath::new(&watched).unwrap(), false, true)
             .expect("add_watch");
 
         event_loop

--- a/notify/src/inotify.rs
+++ b/notify/src/inotify.rs
@@ -7,7 +7,8 @@
 use super::event::*;
 use super::{Config, Error, ErrorKind, EventHandler, RecursiveMode, Result, Watcher};
 use crate::paths::{
-    absolute_path, is_preserved_watch_root, preserved_watch_mode, reported_path, WatchPath,
+    absolute_path, is_preserved_watch_root, preserved_watch_mode, preserved_watch_roots,
+    reported_path, WatchMetadata, WatchPath,
 };
 use crate::{bounded, unbounded, BoundSender, Receiver, Sender};
 use inotify as inotify_sys;
@@ -88,7 +89,7 @@ struct EventLoop {
     event_loop_rx: Receiver<EventLoopMsg>,
     inotify: Option<Inotify>,
     event_handler: Box<dyn EventHandler>,
-    /// PathBuf -> (WatchDescriptor, WatchMask, is_recursive, is_dir)
+    /// Absolute path -> inotify descriptor and watch metadata.
     watches: HashMap<PathBuf, Watch>,
     paths: HashMap<WatchDescriptor, PathBuf>,
     rename_event: Option<Event>,
@@ -99,11 +100,8 @@ struct EventLoop {
 struct Watch {
     watch_descriptor: WatchDescriptor,
     watch_mask: WatchMask,
-    is_recursive: bool,
     is_dir: bool,
-    reported_path: PathBuf,
-    is_user_watch: bool,
-    user_is_recursive: bool,
+    metadata: WatchMetadata,
 }
 
 /// Watcher implementation based on inotify
@@ -131,10 +129,10 @@ fn add_watch_by_event(
     if event.mask.contains(EventMask::ISDIR) {
         if let Some(parent_path) = path.parent() {
             if let Some(watch) = watches.get(parent_path) {
-                if watch.is_recursive {
+                if watch.metadata.is_recursive {
                     add_watches.push(WatchPath::from_parts(
                         path.to_owned(),
-                        reported_path(parent_path, &watch.reported_path, path),
+                        reported_path(parent_path, &watch.metadata.reported_path, path),
                     ));
                 }
             }
@@ -253,11 +251,11 @@ impl EventLoop {
                     let _ = tx.send(
                         self.watches
                             .iter()
-                            .filter(|(_path, watch)| watch.is_user_watch)
+                            .filter(|(_path, watch)| watch.metadata.is_user_watch)
                             .map(|(_path, watch)| {
                                 (
-                                    watch.reported_path.clone(),
-                                    if watch.user_is_recursive {
+                                    watch.metadata.reported_path.clone(),
+                                    if watch.metadata.user_is_recursive {
                                         RecursiveMode::Recursive
                                     } else {
                                         RecursiveMode::NonRecursive
@@ -312,11 +310,14 @@ impl EventLoop {
                                 self.watches.get(root).map(|watch| match event.name {
                                     Some(name) => {
                                         let path = root.join(name);
-                                        let reported_path =
-                                            reported_path(root, &watch.reported_path, &path);
+                                        let reported_path = reported_path(
+                                            root,
+                                            &watch.metadata.reported_path,
+                                            &path,
+                                        );
                                         (path, reported_path)
                                     }
-                                    None => (root.clone(), watch.reported_path.clone()),
+                                    None => (root.clone(), watch.metadata.reported_path.clone()),
                                 })
                             });
 
@@ -606,52 +607,23 @@ impl EventLoop {
                             return Err(Error::io_watch(e).add_path(path.requested));
                         }
                     };
-                    let existing_reported_path =
-                        existing_watch.map(|watch| watch.reported_path.clone());
-                    let existing_is_user_watch =
-                        existing_watch.is_some_and(|watch| watch.is_user_watch);
-                    let existing_user_is_recursive =
-                        existing_watch.is_some_and(|watch| watch.user_is_recursive);
-                    let existing_is_recursive =
-                        existing_watch.is_some_and(|watch| watch.is_recursive);
-
-                    let reported_path = if watch_self {
-                        path.requested.clone()
-                    } else if existing_is_user_watch {
-                        existing_reported_path.unwrap_or_else(|| path.requested.clone())
-                    } else {
+                    let metadata = WatchMetadata::new(
+                        &path,
+                        is_recursive,
+                        watch_self,
+                        existing_watch.map(|watch| &watch.metadata),
                         self.watches
                             .iter()
-                            .filter(|(candidate, watch)| {
-                                watch.is_user_watch
-                                    && watch.user_is_recursive
-                                    && path.absolute.starts_with(candidate)
-                            })
-                            .max_by_key(|(candidate, _)| candidate.as_os_str().len())
-                            .map_or_else(
-                                || path.requested.clone(),
-                                |(root, watch)| {
-                                    reported_path(root, &watch.reported_path, &path.absolute)
-                                },
-                            )
-                    };
-                    let is_user_watch = watch_self || existing_is_user_watch;
-                    let user_is_recursive = if watch_self {
-                        is_recursive
-                    } else {
-                        existing_user_is_recursive
-                    };
+                            .map(|(path, watch)| (path, &watch.metadata)),
+                    );
 
                     self.watches.insert(
                         path.absolute.clone(),
                         Watch {
                             watch_descriptor: w.clone(),
                             watch_mask: watchmask,
-                            is_recursive: is_recursive || existing_is_recursive,
                             is_dir,
-                            reported_path,
-                            is_user_watch,
-                            user_is_recursive,
+                            metadata,
                         },
                     );
                     self.paths.insert(w, path.absolute);
@@ -664,17 +636,13 @@ impl EventLoop {
     }
 
     fn remove_watch(&mut self, path: PathBuf, remove_recursive: bool) -> Result<()> {
-        let preserved_roots: Vec<_> = if remove_recursive {
-            Vec::new()
-        } else {
+        let preserved_roots = preserved_watch_roots(
+            &path,
+            remove_recursive,
             self.watches
                 .iter()
-                .filter(|(candidate, watch)| {
-                    *candidate != &path && candidate.starts_with(&path) && watch.is_user_watch
-                })
-                .map(|(path, watch)| (path.clone(), watch.user_is_recursive))
-                .collect()
-        };
+                .map(|(path, watch)| (path, &watch.metadata)),
+        );
 
         match self.watches.remove(&path) {
             None => return Err(Error::watch_not_found().add_path(path)),
@@ -689,7 +657,7 @@ impl EventLoop {
                     );
                     self.paths.remove(&watch.watch_descriptor);
 
-                    if watch.is_recursive || remove_recursive {
+                    if watch.metadata.is_recursive || remove_recursive {
                         let mut remove_list = Vec::new();
                         let mut reset_list = Vec::new();
                         for (w, p) in &self.paths {
@@ -715,7 +683,7 @@ impl EventLoop {
                         }
                         for p in reset_list {
                             if let Some(watch) = self.watches.get_mut(&p) {
-                                watch.is_recursive = watch.user_is_recursive;
+                                watch.metadata.is_recursive = watch.metadata.user_is_recursive;
                             }
                         }
                     }
@@ -730,24 +698,20 @@ impl EventLoop {
         path: PathBuf,
         remove_recursive: bool,
     ) -> Result<()> {
-        let preserved_roots: Vec<_> = if remove_recursive {
-            Vec::new()
-        } else {
+        let preserved_roots = preserved_watch_roots(
+            &path,
+            remove_recursive,
             self.watches
                 .iter()
-                .filter(|(candidate, watch)| {
-                    *candidate != &path && candidate.starts_with(&path) && watch.is_user_watch
-                })
-                .map(|(path, watch)| (path.clone(), watch.user_is_recursive))
-                .collect()
-        };
+                .map(|(path, watch)| (path, &watch.metadata)),
+        );
 
         match self.watches.remove(&path) {
             None => return Err(Error::watch_not_found().add_path(path)),
             Some(watch) => {
                 self.paths.remove(&watch.watch_descriptor);
 
-                if watch.is_recursive || remove_recursive {
+                if watch.metadata.is_recursive || remove_recursive {
                     let mut remove_list = Vec::new();
                     let mut reset_list = Vec::new();
                     for (w, p) in &self.paths {
@@ -772,7 +736,7 @@ impl EventLoop {
                     }
                     for p in reset_list {
                         if let Some(watch) = self.watches.get_mut(&p) {
-                            watch.is_recursive = watch.user_is_recursive;
+                            watch.metadata.is_recursive = watch.metadata.user_is_recursive;
                         }
                     }
                 }

--- a/notify/src/kqueue.rs
+++ b/notify/src/kqueue.rs
@@ -6,10 +6,12 @@
 
 use super::event::*;
 use super::{Config, Error, EventHandler, EventKindMask, RecursiveMode, Result, Watcher};
+use crate::paths::{
+    absolute_path, is_preserved_watch_root, preserved_watch_mode, reported_path, WatchPath,
+};
 use crate::{unbounded, Receiver, Sender};
 use kqueue::{EventData, EventFilter, FilterFlag, Ident};
 use std::collections::HashMap;
-use std::env;
 use std::fs::metadata;
 use std::os::unix::io::AsRawFd;
 use std::path::{Path, PathBuf};
@@ -33,9 +35,16 @@ struct EventLoop {
     event_loop_rx: Receiver<EventLoopMsg>,
     kqueue: kqueue::Watcher,
     event_handler: Box<dyn EventHandler>,
-    watches: HashMap<PathBuf, bool>,
+    watches: HashMap<PathBuf, Watch>,
     follow_symlinks: bool,
     event_kinds: EventKindMask,
+}
+
+struct Watch {
+    is_recursive: bool,
+    reported_path: PathBuf,
+    is_user_watch: bool,
+    user_is_recursive: bool,
 }
 
 /// Watcher implementation based on inotify
@@ -46,7 +55,7 @@ pub struct KqueueWatcher {
 }
 
 enum EventLoopMsg {
-    AddWatch(PathBuf, RecursiveMode, Sender<Result<()>>),
+    AddWatch(WatchPath, RecursiveMode, Sender<Result<()>>),
     RemoveWatch(PathBuf, Sender<Result<()>>),
     GetWatchedPaths(Sender<Vec<(PathBuf, RecursiveMode)>>),
     Shutdown,
@@ -135,7 +144,7 @@ impl EventLoop {
         while let Ok(msg) = self.event_loop_rx.try_recv() {
             match msg {
                 EventLoopMsg::AddWatch(path, recursive_mode, tx) => {
-                    let _ = tx.send(self.add_watch(path, recursive_mode.is_recursive()));
+                    let _ = tx.send(self.add_watch(path, recursive_mode.is_recursive(), true));
                 }
                 EventLoopMsg::RemoveWatch(path, tx) => {
                     let _ = tx.send(self.remove_watch(path, false));
@@ -144,10 +153,11 @@ impl EventLoop {
                     let _ = tx.send(
                         self.watches
                             .iter()
-                            .map(|(path, is_recursive)| {
+                            .filter(|(_path, watch)| watch.is_user_watch)
+                            .map(|(_path, watch)| {
                                 (
-                                    path.clone(),
-                                    if *is_recursive {
+                                    watch.reported_path.clone(),
+                                    if watch.user_is_recursive {
                                         RecursiveMode::Recursive
                                     } else {
                                         RecursiveMode::NonRecursive
@@ -178,6 +188,11 @@ impl EventLoop {
                     ident: Ident::Filename(_, path),
                 } => {
                     let path = PathBuf::from(path);
+                    let watch = self.watches.get(&path);
+                    let event_path = watch
+                        .map(|watch| watch.reported_path.clone())
+                        .unwrap_or_else(|| path.clone());
+                    let is_user_watch = watch.is_some_and(|watch| watch.is_user_watch);
                     let event = match data {
                         /*
                         TODO: Differentiate folders and files
@@ -187,8 +202,8 @@ impl EventLoop {
                         lookup.
                         */
                         kqueue::Vnode::Delete => {
-                            remove_watches.push(path.clone());
-                            Ok(Event::new(EventKind::Remove(RemoveKind::Any)).add_path(path))
+                            remove_watches.push((path.clone(), true));
+                            Ok(Event::new(EventKind::Remove(RemoveKind::Any)).add_path(event_path))
                         }
 
                         // a write to a directory means that a new file was created in it, let's
@@ -205,7 +220,15 @@ impl EventLoop {
                                 .map(|file| {
                                     if let Some(file) = file {
                                         // watch this new file
-                                        add_watches.push(file.clone());
+                                        let reported_file =
+                                            reported_path(&path, &event_path, &file);
+                                        add_watches.push((
+                                            WatchPath::from_parts(
+                                                file.clone(),
+                                                reported_file.clone(),
+                                            ),
+                                            false,
+                                        ));
 
                                         Event::new(EventKind::Create(if file.is_dir() {
                                             CreateKind::Folder
@@ -214,12 +237,12 @@ impl EventLoop {
                                         } else {
                                             CreateKind::Other
                                         }))
-                                        .add_path(file)
+                                        .add_path(reported_file)
                                     } else {
                                         Event::new(EventKind::Modify(ModifyKind::Data(
                                             DataChange::Any,
                                         )))
-                                        .add_path(path)
+                                        .add_path(event_path)
                                     }
                                 })
                                 .map_err(Into::into)
@@ -229,7 +252,7 @@ impl EventLoop {
                         kqueue::Vnode::Write => Ok(Event::new(EventKind::Modify(
                             ModifyKind::Data(DataChange::Any),
                         ))
-                        .add_path(path)),
+                        .add_path(event_path)),
 
                         /*
                         Extend and Truncate are just different names for the same
@@ -239,7 +262,7 @@ impl EventLoop {
                         kqueue::Vnode::Extend | kqueue::Vnode::Truncate => Ok(Event::new(
                             EventKind::Modify(ModifyKind::Data(DataChange::Size)),
                         )
-                        .add_path(path)),
+                        .add_path(event_path)),
 
                         /*
                         this kevent has the same problem as the delete kevent. The
@@ -251,7 +274,7 @@ impl EventLoop {
                         kqueue::Vnode::Attrib => Ok(Event::new(EventKind::Modify(
                             ModifyKind::Metadata(MetadataKind::Any),
                         ))
-                        .add_path(path)),
+                        .add_path(event_path)),
 
                         /*
                         The link count on a file changed => subdirectory created or
@@ -272,25 +295,28 @@ impl EventLoop {
                             // readd the whole directory.
                             // This is a expensive operation, as we recursive through all
                             // subdirectories.
-                            remove_watches.push(path.clone());
-                            add_watches.push(path.clone());
-                            Ok(Event::new(EventKind::Modify(ModifyKind::Any)).add_path(path))
+                            remove_watches.push((path.clone(), false));
+                            add_watches.push((
+                                WatchPath::from_parts(path.clone(), event_path.clone()),
+                                is_user_watch,
+                            ));
+                            Ok(Event::new(EventKind::Modify(ModifyKind::Any)).add_path(event_path))
                         }
 
                         // Kqueue not provide us with the information necessary to provide
                         // the new file name to the event.
                         kqueue::Vnode::Rename => {
-                            remove_watches.push(path.clone());
+                            remove_watches.push((path.clone(), true));
                             Ok(
                                 Event::new(EventKind::Modify(ModifyKind::Name(RenameMode::Any)))
-                                    .add_path(path),
+                                    .add_path(event_path),
                             )
                         }
 
                         // Access to the file was revoked via revoke(2) or the underlying file system was unmounted.
                         kqueue::Vnode::Revoke => {
-                            remove_watches.push(path.clone());
-                            Ok(Event::new(EventKind::Remove(RemoveKind::Any)).add_path(path))
+                            remove_watches.push((path.clone(), true));
+                            Ok(Event::new(EventKind::Remove(RemoveKind::Any)).add_path(event_path))
                         }
 
                         // On different BSD variants, different extra events may be present
@@ -311,27 +337,40 @@ impl EventLoop {
             }
         }
 
-        for path in remove_watches {
-            self.remove_watch(path, true).ok();
+        for (path, remove_recursive) in remove_watches {
+            self.remove_watch(path, remove_recursive).ok();
         }
 
-        for path in add_watches {
-            self.add_watch(path, true).ok();
+        for (path, is_user_watch) in add_watches {
+            self.add_watch(path, true, is_user_watch).ok();
         }
     }
 
-    fn add_watch(&mut self, path: PathBuf, is_recursive: bool) -> Result<()> {
+    fn add_watch(
+        &mut self,
+        path: WatchPath,
+        is_recursive: bool,
+        is_user_watch: bool,
+    ) -> Result<()> {
         // If the watch is not recursive, or if we determine (by stat'ing the path to get its
         // metadata) that the watched path is not a directory, add a single path watch.
-        if !is_recursive || !metadata(&path).map_err(Error::io)?.is_dir() {
-            self.add_single_watch(path, false)?;
+        if !is_recursive || !metadata(&path.absolute).map_err(Error::io)?.is_dir() {
+            self.add_single_watch(path, false, is_user_watch)?;
         } else {
-            for entry in WalkDir::new(path)
+            let root = path;
+            let mut first = true;
+            for entry in WalkDir::new(&root.absolute)
                 .follow_links(self.follow_symlinks)
                 .into_iter()
             {
                 let entry = entry.map_err(map_walkdir_error)?;
-                self.add_single_watch(entry.into_path(), is_recursive)?;
+                // WalkDir yields the root first; only it is the user-requested watch.
+                self.add_single_watch(
+                    root.child(entry.into_path()),
+                    is_recursive,
+                    is_user_watch && first,
+                )?;
+                first = false;
             }
         }
 
@@ -344,7 +383,12 @@ impl EventLoop {
     /// Adds a single watch to the kqueue.
     ///
     /// The caller of this function must call `self.kqueue.watch()` afterwards to register the new watch.
-    fn add_single_watch(&mut self, path: PathBuf, is_recursive: bool) -> Result<()> {
+    fn add_single_watch(
+        &mut self,
+        path: WatchPath,
+        is_recursive: bool,
+        is_user_watch: bool,
+    ) -> Result<()> {
         let event_filter = EventFilter::EVFILT_VNODE;
         let filter_flags = FilterFlag::NOTE_DELETE
             | FilterFlag::NOTE_WRITE
@@ -354,12 +398,50 @@ impl EventLoop {
             | FilterFlag::NOTE_RENAME
             | FilterFlag::NOTE_REVOKE;
 
-        log::trace!("adding kqueue watch: {}", path.display());
+        log::trace!("adding kqueue watch: {}", path.absolute.display());
 
         self.kqueue
-            .add_filename(&path, event_filter, filter_flags)
-            .map_err(|e| Error::io(e).add_path(path.clone()))?;
-        self.watches.insert(path, is_recursive);
+            .add_filename(&path.absolute, event_filter, filter_flags)
+            .map_err(|e| Error::io(e).add_path(path.requested.clone()))?;
+        let existing_watch = self.watches.get(&path.absolute);
+        let existing_reported_path = existing_watch.map(|watch| watch.reported_path.clone());
+        let existing_is_user_watch = existing_watch.is_some_and(|watch| watch.is_user_watch);
+        let existing_user_is_recursive =
+            existing_watch.is_some_and(|watch| watch.user_is_recursive);
+        let existing_is_recursive = existing_watch.is_some_and(|watch| watch.is_recursive);
+
+        let reported_path = if is_user_watch {
+            path.requested.clone()
+        } else if existing_is_user_watch {
+            existing_reported_path.unwrap_or_else(|| path.requested.clone())
+        } else {
+            self.watches
+                .iter()
+                .filter(|(candidate, watch)| {
+                    watch.is_user_watch
+                        && watch.user_is_recursive
+                        && path.absolute.starts_with(candidate)
+                })
+                .max_by_key(|(candidate, _)| candidate.as_os_str().len())
+                .map_or_else(
+                    || path.requested.clone(),
+                    |(root, watch)| reported_path(root, &watch.reported_path, &path.absolute),
+                )
+        };
+        let user_is_recursive = if is_user_watch {
+            is_recursive
+        } else {
+            existing_user_is_recursive
+        };
+        self.watches.insert(
+            path.absolute,
+            Watch {
+                is_recursive: is_recursive || existing_is_recursive,
+                reported_path,
+                is_user_watch: is_user_watch || existing_is_user_watch,
+                user_is_recursive,
+            },
+        );
 
         Ok(())
     }
@@ -367,18 +449,47 @@ impl EventLoop {
     fn remove_watch(&mut self, path: PathBuf, remove_recursive: bool) -> Result<()> {
         log::trace!("removing kqueue watch: {}", path.display());
 
+        let preserved_roots: Vec<_> = if remove_recursive {
+            Vec::new()
+        } else {
+            self.watches
+                .iter()
+                .filter(|(candidate, watch)| {
+                    *candidate != &path && candidate.starts_with(&path) && watch.is_user_watch
+                })
+                .map(|(path, watch)| (path.clone(), watch.user_is_recursive))
+                .collect()
+        };
+
         match self.watches.remove(&path) {
             None => return Err(Error::watch_not_found()),
-            Some(is_recursive) => {
-                if is_recursive || remove_recursive {
-                    for entry in WalkDir::new(path)
+            Some(watch) => {
+                if watch.is_recursive || remove_recursive {
+                    let mut reset_list = Vec::new();
+                    for entry in WalkDir::new(path.clone())
                         .follow_links(self.follow_symlinks)
                         .into_iter()
                     {
                         let p = entry.map_err(map_walkdir_error)?.into_path();
+                        if let Some(user_is_recursive) = preserved_watch_mode(&p, &preserved_roots)
+                        {
+                            if !user_is_recursive || is_preserved_watch_root(&p, &preserved_roots) {
+                                reset_list.push(p);
+                            }
+                            continue;
+                        }
+
                         self.kqueue
                             .remove_filename(&p, EventFilter::EVFILT_VNODE)
-                            .map_err(|e| Error::io(e).add_path(p))?;
+                            .map_err(|e| Error::io(e).add_path(p.clone()))?;
+                        if p != path {
+                            self.watches.remove(&p);
+                        }
+                    }
+                    for p in reset_list {
+                        if let Some(watch) = self.watches.get_mut(&p) {
+                            watch.is_recursive = watch.user_is_recursive;
+                        }
                     }
                 } else {
                     self.kqueue
@@ -417,12 +528,7 @@ impl KqueueWatcher {
     }
 
     fn watch_inner(&mut self, path: &Path, recursive_mode: RecursiveMode) -> Result<()> {
-        let pb = if path.is_absolute() {
-            path.to_owned()
-        } else {
-            let p = env::current_dir().map_err(Error::io)?;
-            p.join(path)
-        };
+        let pb = WatchPath::new(path)?;
         let (tx, rx) = unbounded();
         let msg = EventLoopMsg::AddWatch(pb, recursive_mode, tx);
 
@@ -438,12 +544,7 @@ impl KqueueWatcher {
     }
 
     fn unwatch_inner(&mut self, path: &Path) -> Result<()> {
-        let pb = if path.is_absolute() {
-            path.to_owned()
-        } else {
-            let p = env::current_dir().map_err(Error::io)?;
-            p.join(path)
-        };
+        let pb = absolute_path(path)?;
         let (tx, rx) = unbounded();
         let msg = EventLoopMsg::RemoveWatch(pb, tx);
 
@@ -524,6 +625,42 @@ mod tests {
             "unwatch yielded error: {}",
             result.unwrap_err()
         );
+        Ok(())
+    }
+
+    #[test]
+    fn internal_recursive_refresh_preserves_explicit_child(
+    ) -> std::result::Result<(), Box<dyn std::error::Error>> {
+        let dir = tempfile::tempdir()?;
+        let child = dir.path().join("child");
+        std::fs::create_dir(&child)?;
+
+        let kqueue = kqueue::Watcher::new()?;
+        let mut event_loop = EventLoop::new(kqueue, Box::new(|_| {}), false, EventKindMask::ALL)?;
+
+        event_loop.add_watch(WatchPath::new(dir.path())?, true, true)?;
+        event_loop.add_watch(WatchPath::new(&child)?, false, true)?;
+
+        event_loop.remove_watch(dir.path().to_path_buf(), false)?;
+        assert!(
+            event_loop
+                .watches
+                .get(&child)
+                .is_some_and(|watch| watch.is_user_watch && !watch.user_is_recursive),
+            "internal refresh removed explicit child watch"
+        );
+
+        event_loop.add_watch(WatchPath::new(dir.path())?, true, true)?;
+
+        let watched: HashMap<_, _> = event_loop
+            .watches
+            .iter()
+            .filter(|(_path, watch)| watch.is_user_watch)
+            .map(|(path, watch)| (path.clone(), watch.user_is_recursive))
+            .collect();
+        assert_eq!(watched.get(dir.path()), Some(&true));
+        assert_eq!(watched.get(&child), Some(&false));
+
         Ok(())
     }
 

--- a/notify/src/kqueue.rs
+++ b/notify/src/kqueue.rs
@@ -7,7 +7,8 @@
 use super::event::*;
 use super::{Config, Error, EventHandler, EventKindMask, RecursiveMode, Result, Watcher};
 use crate::paths::{
-    absolute_path, is_preserved_watch_root, preserved_watch_mode, reported_path, WatchPath,
+    absolute_path, is_preserved_watch_root, preserved_watch_mode, preserved_watch_roots,
+    reported_path, WatchMetadata as Watch, WatchPath,
 };
 use crate::{unbounded, Receiver, Sender};
 use kqueue::{EventData, EventFilter, FilterFlag, Ident};
@@ -38,13 +39,6 @@ struct EventLoop {
     watches: HashMap<PathBuf, Watch>,
     follow_symlinks: bool,
     event_kinds: EventKindMask,
-}
-
-struct Watch {
-    is_recursive: bool,
-    reported_path: PathBuf,
-    is_user_watch: bool,
-    user_is_recursive: bool,
 }
 
 /// Watcher implementation based on inotify
@@ -404,44 +398,14 @@ impl EventLoop {
             .add_filename(&path.absolute, event_filter, filter_flags)
             .map_err(|e| Error::io(e).add_path(path.requested.clone()))?;
         let existing_watch = self.watches.get(&path.absolute);
-        let existing_reported_path = existing_watch.map(|watch| watch.reported_path.clone());
-        let existing_is_user_watch = existing_watch.is_some_and(|watch| watch.is_user_watch);
-        let existing_user_is_recursive =
-            existing_watch.is_some_and(|watch| watch.user_is_recursive);
-        let existing_is_recursive = existing_watch.is_some_and(|watch| watch.is_recursive);
-
-        let reported_path = if is_user_watch {
-            path.requested.clone()
-        } else if existing_is_user_watch {
-            existing_reported_path.unwrap_or_else(|| path.requested.clone())
-        } else {
-            self.watches
-                .iter()
-                .filter(|(candidate, watch)| {
-                    watch.is_user_watch
-                        && watch.user_is_recursive
-                        && path.absolute.starts_with(candidate)
-                })
-                .max_by_key(|(candidate, _)| candidate.as_os_str().len())
-                .map_or_else(
-                    || path.requested.clone(),
-                    |(root, watch)| reported_path(root, &watch.reported_path, &path.absolute),
-                )
-        };
-        let user_is_recursive = if is_user_watch {
-            is_recursive
-        } else {
-            existing_user_is_recursive
-        };
-        self.watches.insert(
-            path.absolute,
-            Watch {
-                is_recursive: is_recursive || existing_is_recursive,
-                reported_path,
-                is_user_watch: is_user_watch || existing_is_user_watch,
-                user_is_recursive,
-            },
+        let watch = Watch::new(
+            &path,
+            is_recursive,
+            is_user_watch,
+            existing_watch,
+            self.watches.iter(),
         );
+        self.watches.insert(path.absolute, watch);
 
         Ok(())
     }
@@ -449,17 +413,7 @@ impl EventLoop {
     fn remove_watch(&mut self, path: PathBuf, remove_recursive: bool) -> Result<()> {
         log::trace!("removing kqueue watch: {}", path.display());
 
-        let preserved_roots: Vec<_> = if remove_recursive {
-            Vec::new()
-        } else {
-            self.watches
-                .iter()
-                .filter(|(candidate, watch)| {
-                    *candidate != &path && candidate.starts_with(&path) && watch.is_user_watch
-                })
-                .map(|(path, watch)| (path.clone(), watch.user_is_recursive))
-                .collect()
-        };
+        let preserved_roots = preserved_watch_roots(&path, remove_recursive, self.watches.iter());
 
         match self.watches.remove(&path) {
             None => return Err(Error::watch_not_found()),

--- a/notify/src/lib.rs
+++ b/notify/src/lib.rs
@@ -234,6 +234,7 @@ pub mod poll;
 
 mod config;
 mod error;
+mod paths;
 
 #[cfg(test)]
 pub(crate) mod test;
@@ -359,6 +360,11 @@ pub trait Watcher {
     /// If the `path` is a file, `recursive_mode` will be ignored and events will be delivered only
     /// for the file.
     ///
+    /// Event paths are reported using the same root representation as `path`. If `path` is
+    /// relative, emitted event paths are relative to the process current directory at the time this
+    /// method is called. If `path` is absolute, emitted event paths are absolute. Convert `path`
+    /// before calling this method if your application needs a specific representation.
+    ///
     /// On some platforms, if the `path` is renamed or removed while being watched, behaviour may
     /// be unexpected. See discussions in [#165] and [#166]. If less surprising behaviour is wanted
     /// one may non-recursively watch the _parent_ directory as well and manage related events.
@@ -435,8 +441,8 @@ pub trait Watcher {
 
     /// Returns the currently watched paths and their recursive modes.
     ///
-    /// Backends may normalize paths (for example converting to absolute or canonical paths)
-    /// before storing them. The returned list uses that internal representation.
+    /// Returned paths use the same representation that was passed to [`Watcher::watch`] or
+    /// [`Watcher::update_paths`].
     ///
     /// # Errors
     ///
@@ -660,6 +666,46 @@ mod tests {
     }
 
     #[test]
+    fn event_paths_preserve_relative_watch_root(
+    ) -> std::result::Result<(), Box<dyn std::error::Error>> {
+        let cwd = std::env::current_dir()?;
+        let dir = tempfile::Builder::new()
+            .prefix("notify-relative-")
+            .tempdir_in(&cwd)?;
+        let relative_dir = dir.path().strip_prefix(&cwd)?.to_path_buf();
+        let relative_file = relative_dir.join("file.txt");
+        let absolute_file = dir.path().join("file.txt");
+
+        let (tx, rx) = std::sync::mpsc::channel();
+        let mut watcher = RecommendedWatcher::new(tx, Config::default())?;
+        watcher.watch(&relative_dir, RecursiveMode::Recursive)?;
+
+        assert!(
+            watcher
+                .watched_paths()?
+                .iter()
+                .any(|(path, mode)| path == &relative_dir && *mode == RecursiveMode::Recursive),
+            "watched_paths() did not preserve relative watch path"
+        );
+
+        fs::write(&absolute_file, b"Lorem ipsum")?;
+
+        for event in iter_with_timeout(&rx) {
+            if event.paths.iter().any(|path| path == &relative_file) {
+                assert!(
+                    event.paths.iter().all(|path| path.is_relative()),
+                    "relative watch emitted absolute path: {event:?}"
+                );
+                return Ok(());
+            }
+
+            println!("unexpected event: {event:?}");
+        }
+
+        panic!("did not receive expected relative event path");
+    }
+
+    #[test]
     #[cfg(target_os = "windows")]
     fn test_windows_trash_dir() -> std::result::Result<(), Box<dyn std::error::Error>> {
         use crate::recommended_watcher;
@@ -782,6 +828,84 @@ mod tests {
         assert!(watched.contains(&(canonical_or_path(&dir_b), RecursiveMode::NonRecursive)));
 
         Ok(())
+    }
+
+    #[test]
+    fn overlapping_recursive_watch_preserves_explicit_child(
+    ) -> std::result::Result<(), Box<dyn std::error::Error>> {
+        let dir = tempdir()?;
+        let child = dir.path().join("child");
+        fs::create_dir(&child)?;
+
+        let (tx, _rx) = std::sync::mpsc::channel();
+        let mut watcher = RecommendedWatcher::new(tx, Config::default())?;
+
+        watcher.watch(&child, RecursiveMode::NonRecursive)?;
+        watcher.watch(dir.path(), RecursiveMode::Recursive)?;
+
+        let watched = canonical_watch_set(watcher.watched_paths()?);
+        assert!(watched.contains(&(canonical_or_path(dir.path()), RecursiveMode::Recursive)));
+        assert!(watched.contains(&(canonical_or_path(&child), RecursiveMode::NonRecursive)));
+
+        watcher.unwatch(dir.path())?;
+
+        let watched = canonical_watch_set(watcher.watched_paths()?);
+        assert!(!watched.contains(&(canonical_or_path(dir.path()), RecursiveMode::Recursive)));
+        assert!(watched.contains(&(canonical_or_path(&child), RecursiveMode::NonRecursive)));
+
+        Ok(())
+    }
+
+    #[test]
+    fn overlapping_recursive_child_rewrites_descendant_event_paths(
+    ) -> std::result::Result<(), Box<dyn std::error::Error>> {
+        let cwd = std::env::current_dir()?;
+        let dir = tempfile::Builder::new()
+            .prefix("notify-overlap-")
+            .tempdir_in(&cwd)?;
+        let relative_dir = dir.path().strip_prefix(&cwd)?.to_path_buf();
+        let child = dir.path().join("child");
+        let grandchild = child.join("grandchild");
+        fs::create_dir_all(&grandchild)?;
+
+        let (tx, rx) = std::sync::mpsc::channel();
+        let mut watcher = RecommendedWatcher::new(tx, Config::default())?;
+
+        watcher.watch(&relative_dir, RecursiveMode::Recursive)?;
+        watcher.watch(&child, RecursiveMode::Recursive)?;
+        watcher.unwatch(&relative_dir)?;
+
+        let watched = watcher.watched_paths()?;
+        assert!(
+            watched
+                .iter()
+                .any(|(path, mode)| path == &child && *mode == RecursiveMode::Recursive),
+            "watched_paths() did not preserve explicit child path: {watched:?}"
+        );
+
+        let file = grandchild.join("file.txt");
+        let stale_file = relative_dir
+            .join("child")
+            .join("grandchild")
+            .join("file.txt");
+        fs::write(&file, b"Lorem ipsum")?;
+
+        for event in iter_with_timeout(&rx) {
+            if event.paths.iter().any(|path| path == &file) {
+                assert!(
+                    event.paths.iter().all(|path| path.is_absolute()),
+                    "absolute child watch emitted non-absolute path: {event:?}"
+                );
+                return Ok(());
+            }
+
+            assert!(
+                !event.paths.iter().any(|path| path == &stale_file),
+                "stale parent-relative file path after parent unwatch: {event:?}"
+            );
+        }
+
+        panic!("did not receive expected child event path");
     }
 
     #[test]

--- a/notify/src/paths.rs
+++ b/notify/src/paths.rs
@@ -10,6 +10,14 @@ pub(crate) struct WatchPath {
     pub(crate) requested: PathBuf,
 }
 
+#[derive(Clone, Debug)]
+pub(crate) struct WatchMetadata {
+    pub(crate) is_recursive: bool,
+    pub(crate) reported_path: PathBuf,
+    pub(crate) is_user_watch: bool,
+    pub(crate) user_is_recursive: bool,
+}
+
 impl WatchPath {
     pub(crate) fn new(path: &Path) -> Result<Self> {
         Ok(Self {
@@ -28,6 +36,55 @@ impl WatchPath {
     pub(crate) fn child(&self, path: PathBuf) -> Self {
         let requested = reported_path(&self.absolute, &self.requested, &path);
         Self::from_parts(path, requested)
+    }
+}
+
+impl WatchMetadata {
+    pub(crate) fn new<'a, I>(
+        path: &WatchPath,
+        is_recursive: bool,
+        is_user_watch: bool,
+        existing_watch: Option<&Self>,
+        user_roots: I,
+    ) -> Self
+    where
+        I: IntoIterator<Item = (&'a PathBuf, &'a Self)>,
+    {
+        let existing_reported_path = existing_watch.map(|watch| watch.reported_path.clone());
+        let existing_is_user_watch = existing_watch.is_some_and(|watch| watch.is_user_watch);
+        let existing_user_is_recursive =
+            existing_watch.is_some_and(|watch| watch.user_is_recursive);
+        let existing_is_recursive = existing_watch.is_some_and(|watch| watch.is_recursive);
+
+        let reported_path = if is_user_watch {
+            path.requested.clone()
+        } else if existing_is_user_watch {
+            existing_reported_path.unwrap_or_else(|| path.requested.clone())
+        } else {
+            user_roots
+                .into_iter()
+                .filter(|(candidate, watch)| {
+                    watch.is_user_watch
+                        && watch.user_is_recursive
+                        && path.absolute.starts_with(candidate)
+                })
+                .max_by_key(|(candidate, _)| candidate.as_os_str().len())
+                .map_or_else(
+                    || path.requested.clone(),
+                    |(root, watch)| reported_path(root, &watch.reported_path, &path.absolute),
+                )
+        };
+
+        Self {
+            is_recursive: is_recursive || existing_is_recursive,
+            reported_path,
+            is_user_watch: is_user_watch || existing_is_user_watch,
+            user_is_recursive: if is_user_watch {
+                is_recursive
+            } else {
+                existing_user_is_recursive
+            },
+        }
     }
 }
 
@@ -63,6 +120,27 @@ pub(crate) fn preserved_watch_mode(
             path == root || (*user_is_recursive && path.starts_with(root))
         })
         .map(|(_, user_is_recursive)| *user_is_recursive)
+}
+
+pub(crate) fn preserved_watch_roots<'a, I>(
+    path: &Path,
+    remove_recursive: bool,
+    watches: I,
+) -> Vec<(PathBuf, bool)>
+where
+    I: IntoIterator<Item = (&'a PathBuf, &'a WatchMetadata)>,
+{
+    if remove_recursive {
+        Vec::new()
+    } else {
+        watches
+            .into_iter()
+            .filter(|(candidate, watch)| {
+                *candidate != path && candidate.starts_with(path) && watch.is_user_watch
+            })
+            .map(|(path, watch)| (path.clone(), watch.user_is_recursive))
+            .collect()
+    }
 }
 
 pub(crate) fn is_preserved_watch_root(path: &Path, preserved_roots: &[(PathBuf, bool)]) -> bool {

--- a/notify/src/paths.rs
+++ b/notify/src/paths.rs
@@ -1,0 +1,70 @@
+use crate::{Error, Result};
+use std::{
+    env,
+    path::{Path, PathBuf},
+};
+
+#[derive(Clone, Debug)]
+pub(crate) struct WatchPath {
+    pub(crate) absolute: PathBuf,
+    pub(crate) requested: PathBuf,
+}
+
+impl WatchPath {
+    pub(crate) fn new(path: &Path) -> Result<Self> {
+        Ok(Self {
+            absolute: absolute_path(path)?,
+            requested: path.to_path_buf(),
+        })
+    }
+
+    pub(crate) fn from_parts(absolute: PathBuf, requested: PathBuf) -> Self {
+        Self {
+            absolute,
+            requested,
+        }
+    }
+
+    pub(crate) fn child(&self, path: PathBuf) -> Self {
+        let requested = reported_path(&self.absolute, &self.requested, &path);
+        Self::from_parts(path, requested)
+    }
+}
+
+pub(crate) fn absolute_path(path: &Path) -> Result<PathBuf> {
+    if path.is_absolute() {
+        Ok(path.to_path_buf())
+    } else {
+        Ok(env::current_dir().map_err(Error::io)?.join(path))
+    }
+}
+
+pub(crate) fn reported_path(root_absolute: &Path, root_requested: &Path, path: &Path) -> PathBuf {
+    debug_assert!(
+        path.starts_with(root_absolute),
+        "reported_path called with path outside root: root={}, path={}",
+        root_absolute.display(),
+        path.display()
+    );
+
+    match path.strip_prefix(root_absolute) {
+        Ok(relative) if !relative.as_os_str().is_empty() => root_requested.join(relative),
+        _ => root_requested.to_path_buf(),
+    }
+}
+
+pub(crate) fn preserved_watch_mode(
+    path: &Path,
+    preserved_roots: &[(PathBuf, bool)],
+) -> Option<bool> {
+    preserved_roots
+        .iter()
+        .find(|(root, user_is_recursive)| {
+            path == root || (*user_is_recursive && path.starts_with(root))
+        })
+        .map(|(_, user_is_recursive)| *user_is_recursive)
+}
+
+pub(crate) fn is_preserved_watch_root(path: &Path, preserved_roots: &[(PathBuf, bool)]) -> bool {
+    preserved_roots.iter().any(|(root, _)| path == root)
+}

--- a/notify/src/poll.rs
+++ b/notify/src/poll.rs
@@ -3,7 +3,10 @@
 //! Checks the `watch`ed paths periodically to detect changes. This implementation only uses
 //! Rust stdlib APIs and should work on all of the platforms it supports.
 
-use crate::{unbounded, Config, Error, EventHandler, Receiver, RecursiveMode, Sender, Watcher};
+use crate::{
+    paths::{absolute_path, WatchPath},
+    unbounded, Config, Error, EventHandler, Receiver, RecursiveMode, Sender, Watcher,
+};
 use std::{
     collections::HashMap,
     path::{Path, PathBuf},
@@ -69,6 +72,7 @@ use data::{DataBuilder, WatchData};
 mod data {
     use crate::{
         event::{CreateKind, DataChange, Event, EventKind, MetadataKind, ModifyKind, RemoveKind},
+        paths::{reported_path, WatchPath},
         EventHandler, RecursiveMode,
     };
     use notify_types::event::EventKindMask;
@@ -142,7 +146,7 @@ mod data {
         /// the path location. (e.g., not found).
         pub(super) fn build_watch_data(
             &self,
-            root: PathBuf,
+            root: WatchPath,
             is_recursive: bool,
             follow_symlinks: bool,
         ) -> Option<WatchData> {
@@ -168,6 +172,7 @@ mod data {
     pub(super) struct WatchData {
         // config part, won't change.
         root: PathBuf,
+        requested_root: PathBuf,
         is_recursive: bool,
         follow_symlinks: bool,
 
@@ -183,7 +188,7 @@ mod data {
         /// This function may send event by `data_builder.emitter`.
         fn new(
             data_builder: &DataBuilder,
-            root: PathBuf,
+            root: WatchPath,
             is_recursive: bool,
             follow_symlinks: bool,
         ) -> Option<Self> {
@@ -205,14 +210,15 @@ mod data {
             //
             // FIXME: Can we always allow to watch a path, even file not
             // found at this path?
-            if let Err(e) = fs::metadata(&root) {
-                data_builder.emitter.emit_io_err(e, Some(&root));
+            if let Err(e) = fs::metadata(&root.absolute) {
+                data_builder.emitter.emit_io_err(e, Some(&root.requested));
                 return None;
             }
 
             let all_path_data = Self::scan_all_path_data(
                 data_builder,
-                root.clone(),
+                root.absolute.clone(),
+                root.requested.clone(),
                 is_recursive,
                 follow_symlinks,
                 true,
@@ -220,7 +226,8 @@ mod data {
             .collect();
 
             Some(Self {
-                root,
+                root: root.absolute,
+                requested_root: root.requested,
                 is_recursive,
                 follow_symlinks,
                 all_path_data,
@@ -237,6 +244,7 @@ mod data {
             for (path, new_path_data) in Self::scan_all_path_data(
                 data_builder,
                 self.root.clone(),
+                self.requested_root.clone(),
                 self.is_recursive,
                 self.follow_symlinks,
                 false,
@@ -246,8 +254,11 @@ mod data {
                     .insert(path.clone(), new_path_data.clone());
 
                 // emit event
-                let event =
-                    PathData::compare_to_event(path, old_path_data.as_ref(), Some(&new_path_data));
+                let event = PathData::compare_to_event(
+                    reported_path(&self.root, &self.requested_root, &path),
+                    old_path_data.as_ref(),
+                    Some(&new_path_data),
+                );
                 if let Some(event) = event {
                     data_builder.emitter.emit_ok(event);
                 }
@@ -266,7 +277,11 @@ mod data {
                 let old_path_data = self.all_path_data.remove(&path);
 
                 // emit event
-                let event = PathData::compare_to_event(path, old_path_data.as_ref(), None);
+                let event = PathData::compare_to_event(
+                    reported_path(&self.root, &self.requested_root, &path),
+                    old_path_data.as_ref(),
+                    None,
+                );
                 if let Some(event) = event {
                     data_builder.emitter.emit_ok(event);
                 }
@@ -281,6 +296,7 @@ mod data {
         fn scan_all_path_data(
             data_builder: &'_ DataBuilder,
             root: PathBuf,
+            requested_root: PathBuf,
             is_recursive: bool,
             follow_symlinks: bool,
             // whether this is an initial scan, used only for events
@@ -291,7 +307,7 @@ mod data {
             // so we can use single logic to do the both file & dir's jobs.
             //
             // See: https://docs.rs/walkdir/2.0.1/walkdir/struct.WalkDir.html#method.new
-            WalkDir::new(root)
+            WalkDir::new(root.clone())
                 .follow_links(follow_symlinks)
                 .max_depth(Self::dir_scan_depth(is_recursive))
                 .into_iter()
@@ -318,7 +334,11 @@ mod data {
                         if is_initial {
                             // emit initial scans
                             if let Some(ref emitter) = data_builder.scan_emitter {
-                                emitter.borrow_mut().handle_event(Ok(path.clone()));
+                                emitter.borrow_mut().handle_event(Ok(reported_path(
+                                    &root,
+                                    &requested_root,
+                                    &path,
+                                )));
                             }
                         }
                         let meta_path = MetaPath::from_parts_unchecked(path, metadata);
@@ -350,6 +370,10 @@ mod data {
             } else {
                 RecursiveMode::NonRecursive
             }
+        }
+
+        pub(super) fn requested_root(&self) -> &Path {
+            &self.requested_root
         }
     }
 
@@ -674,7 +698,9 @@ impl PollWatcher {
     ///
     /// QUESTION: this function never return an Error, is it as intend?
     /// Please also consider the IO Error event problem.
-    fn watch_inner(&mut self, path: &Path, recursive_mode: RecursiveMode) {
+    fn watch_inner(&mut self, path: &Path, recursive_mode: RecursiveMode) -> crate::Result<()> {
+        let watch_path = WatchPath::new(path)?;
+
         // HINT: Make sure always lock in the same order to avoid deadlock.
         //
         // FIXME: inconsistent: some place mutex poison cause panic, some place just ignore.
@@ -684,26 +710,30 @@ impl PollWatcher {
         data_builder.update_timestamp();
 
         let watch_data = data_builder.build_watch_data(
-            path.to_path_buf(),
+            watch_path.clone(),
             recursive_mode.is_recursive(),
             self.follow_sylinks,
         );
 
         // if create watch_data successful, add it to watching list.
         if let Some(watch_data) = watch_data {
-            watches.insert(path.to_path_buf(), watch_data);
+            watches.insert(watch_path.absolute, watch_data);
         }
+
+        Ok(())
     }
 
     /// Unwatch a path.
     ///
     /// Return `Err(_)` if given path has't be monitored.
     fn unwatch_inner(&mut self, path: &Path) -> crate::Result<()> {
+        let path = absolute_path(path)?;
+
         // FIXME: inconsistent: some place mutex poison cause panic, some place just ignore.
         self.watches
             .lock()
             .unwrap_or_else(|e| e.into_inner())
-            .remove(path)
+            .remove(&path)
             .map(|_| ())
             .ok_or_else(crate::Error::watch_not_found)
     }
@@ -716,9 +746,7 @@ impl Watcher for PollWatcher {
     }
 
     fn watch(&mut self, path: &Path, recursive_mode: RecursiveMode) -> crate::Result<()> {
-        self.watch_inner(path, recursive_mode);
-
-        Ok(())
+        self.watch_inner(path, recursive_mode)
     }
 
     fn unwatch(&mut self, path: &Path) -> crate::Result<()> {
@@ -728,8 +756,8 @@ impl Watcher for PollWatcher {
     fn watched_paths(&self) -> crate::Result<Vec<(PathBuf, RecursiveMode)>> {
         let watches = self.watches.lock().map_err(crate::Error::from)?;
         Ok(watches
-            .iter()
-            .map(|(path, watch)| (path.clone(), watch.recursive_mode()))
+            .values()
+            .map(|watch| (watch.requested_root().to_path_buf(), watch.recursive_mode()))
             .collect())
     }
 

--- a/notify/src/windows.rs
+++ b/notify/src/windows.rs
@@ -5,12 +5,12 @@
 //!
 //! [ref]: https://msdn.microsoft.com/en-us/library/windows/desktop/aa363950(v=vs.85).aspx
 
+use crate::paths::{absolute_path, WatchPath};
 use crate::{bounded, unbounded, BoundSender, Config, Receiver, Sender};
 use crate::{event::*, WatcherKind};
 use crate::{Error, EventHandler, RecursiveMode, Result, Watcher, WindowsPathSeparatorStyle};
 use std::alloc;
 use std::collections::HashMap;
-use std::env;
 use std::ffi::OsString;
 use std::os::raw::c_void;
 use std::os::windows::ffi::{OsStrExt, OsStringExt};
@@ -125,7 +125,8 @@ fn normalize_path_separators(path: PathBuf, separator_style: SeparatorStyle) -> 
 #[derive(Clone)]
 struct ReadData {
     dir: PathBuf,          // directory that is being watched
-    file: Option<PathBuf>, // if a file is being watched, this is its full path
+    reported_dir: PathBuf, // directory prefix used in emitted event paths
+    file: Option<PathBuf>, // if a file is being watched, this is its reported path
     complete_sem: HANDLE,
     is_recursive: bool,
     separator_style: SeparatorStyle,
@@ -147,7 +148,7 @@ impl ReadDirectoryRequest {
 }
 
 enum Action {
-    Watch(PathBuf, RecursiveMode, SeparatorStyle),
+    Watch(WatchPath, RecursiveMode, SeparatorStyle),
     // Internal self-unwatch from the completion callback.
     Unwatch(PathBuf),
     // Public `Watcher::unwatch` path. This variant must ack only after `remove_watch` finishes so
@@ -168,6 +169,7 @@ struct WatchState {
     dir_handle: HANDLE,
     complete_sem: HANDLE,
     recursive_mode: RecursiveMode,
+    reported_path: PathBuf,
 }
 
 struct ReadDirectoryChangesServer {
@@ -235,7 +237,9 @@ impl ReadDirectoryChangesServer {
                         let _ = tx.send(
                             self.watches
                                 .iter()
-                                .map(|(path, state)| (path.clone(), state.recursive_mode))
+                                .map(|(_path, state)| {
+                                    (state.reported_path.clone(), state.recursive_mode)
+                                })
                                 .collect(),
                         );
                     }
@@ -273,25 +277,32 @@ impl ReadDirectoryChangesServer {
 
     fn add_watch(
         &mut self,
-        path: PathBuf,
+        path: WatchPath,
         is_recursive: bool,
         separator_style: SeparatorStyle,
     ) -> Result<PathBuf> {
         // path must exist and be either a file or directory
-        if !path.is_dir() && !path.is_file() {
+        if !path.absolute.is_dir() && !path.absolute.is_file() {
             return Err(
                 Error::generic("Input watch path is neither a file nor a directory.")
-                    .add_path(path),
+                    .add_path(path.requested),
             );
         }
 
         let (watching_file, dir_target) = {
-            if path.is_dir() {
-                (false, path.clone())
+            if path.absolute.is_dir() {
+                (false, path.absolute.clone())
             } else {
                 // emulate file watching by watching the parent directory
-                (true, path.parent().unwrap().to_path_buf())
+                (true, path.absolute.parent().unwrap().to_path_buf())
             }
+        };
+        let reported_dir = if watching_file {
+            path.requested
+                .parent()
+                .map_or_else(PathBuf::new, Path::to_path_buf)
+        } else {
+            path.requested.clone()
         };
 
         let encoded_path: Vec<u16> = dir_target
@@ -317,15 +328,18 @@ impl ReadDirectoryChangesServer {
                         "You attempted to watch a single file, but parent \
                          directory could not be opened.",
                     )
-                    .add_path(path)
+                    .add_path(path.requested)
                 } else {
                     // TODO: Call GetLastError for better error info?
-                    Error::path_not_found().add_path(path)
+                    Error::path_not_found().add_path(path.requested)
                 });
             }
         }
         let wf = if watching_file {
-            Some(normalize_path_separators(path.clone(), separator_style))
+            Some(normalize_path_separators(
+                path.requested.clone(),
+                separator_style,
+            ))
         } else {
             None
         };
@@ -335,10 +349,13 @@ impl ReadDirectoryChangesServer {
             unsafe {
                 CloseHandle(handle);
             }
-            return Err(Error::generic("Failed to create semaphore for watch.").add_path(path));
+            return Err(
+                Error::generic("Failed to create semaphore for watch.").add_path(path.requested)
+            );
         }
         let rd = ReadData {
             dir: dir_target,
+            reported_dir,
             file: wf,
             complete_sem: semaphore,
             is_recursive,
@@ -352,8 +369,10 @@ impl ReadDirectoryChangesServer {
             } else {
                 RecursiveMode::NonRecursive
             },
+            reported_path: path.requested,
         };
-        self.watches.insert(path.clone(), ws);
+        let watched_path = path.absolute;
+        self.watches.insert(watched_path.clone(), ws);
         start_read(
             &rd,
             self.event_handler.clone(),
@@ -361,7 +380,7 @@ impl ReadDirectoryChangesServer {
             handle,
             self.tx.clone(),
         );
-        Ok(path)
+        Ok(watched_path)
     }
 
     fn remove_watch(&mut self, path: PathBuf) {
@@ -522,7 +541,7 @@ unsafe extern "system" fn handle_event(
         let relative_path =
             PathBuf::from(OsString::from_wide(trim_leading_separators(encoded_path)));
         let path = normalize_path_separators(
-            request.data.dir.join(relative_path),
+            request.data.reported_dir.join(relative_path),
             request.data.separator_style,
         );
 
@@ -693,31 +712,21 @@ impl ReadDirectoryChangesWatcher {
 
     fn watch_inner(&mut self, path: &Path, recursive_mode: RecursiveMode) -> Result<()> {
         let separator_style = SeparatorStyle::resolve(self.windows_path_separator_style, path);
-        let pb = if path.is_absolute() {
-            path.to_owned()
-        } else {
-            let p = env::current_dir().map_err(Error::io)?;
-            p.join(path)
-        };
+        let pb = WatchPath::new(path)?;
         // path must exist and be either a file or directory
-        if !pb.is_dir() && !pb.is_file() {
+        if !pb.absolute.is_dir() && !pb.absolute.is_file() {
             return Err(Error::generic(
                 "Input watch path is neither a file nor a directory.",
             ));
         }
         self.send_action_require_ack(
             Action::Watch(pb.clone(), recursive_mode, separator_style),
-            &pb,
+            &pb.absolute,
         )
     }
 
     fn unwatch_inner(&mut self, path: &Path) -> Result<()> {
-        let pb = if path.is_absolute() {
-            path.to_owned()
-        } else {
-            let p = env::current_dir().map_err(Error::io)?;
-            p.join(path)
-        };
+        let pb = absolute_path(path)?;
         self.send_action_require_ack(Action::UnwatchAck(pb.clone()), &pb)
     }
 
@@ -914,7 +923,8 @@ pub mod tests {
 
         std::fs::File::create_new(&watched_file)?;
 
-        let expected_path = normalize_path_separators(watched_file, SeparatorStyle::Slash);
+        let expected_path =
+            normalize_path_separators(slash_watch_path.join("entry"), SeparatorStyle::Slash);
         rx.wait_unordered([expected(&expected_path).create_any()]);
 
         Ok(())
@@ -939,6 +949,28 @@ pub mod tests {
 
         assert_eq!(normalized_watch_path, normalized_event_path);
         assert_eq!(normalized_event_path, PathBuf::from("G:/Feature/a.txt"));
+    }
+
+    #[test]
+    fn single_file_filter_matches_bare_relative_file() {
+        let watched_file = PathBuf::from("a.txt");
+        let reported_dir = watched_file
+            .parent()
+            .map_or_else(PathBuf::new, Path::to_path_buf);
+        let separator_style =
+            SeparatorStyle::resolve(WindowsPathSeparatorStyle::Auto, &watched_file);
+        let normalized_watch_path =
+            normalize_path_separators(watched_file.clone(), separator_style);
+
+        let raw_event_name: Vec<u16> = "a.txt".encode_utf16().collect();
+        let relative_path = PathBuf::from(OsString::from_wide(trim_leading_separators(
+            &raw_event_name,
+        )));
+        let normalized_event_path =
+            normalize_path_separators(reported_dir.join(relative_path), separator_style);
+
+        assert_eq!(normalized_watch_path, normalized_event_path);
+        assert_eq!(normalized_event_path, watched_file);
     }
 
     #[test]


### PR DESCRIPTION
<!-- 
## Contribution Agreement
By contributing, you agree to the license terms (CC Zero 1.0 for notify crate, MIT/Apache 2.0 for the rest) and the code of conduct in CODE_OF_CONDUCT.md.

## Changelog
Add an entry to CHANGELOG.md if applicable. Create a new section `## notify (unreleased)` if not already present.

## Testing
The test suite will run after creating this PR. If builds fail, you must either fix the errors, ask for help, or provide a detailed explanation of why failures are expected. If you don't, a maintainer may prompt you, but it will take longer for your contribution to be reviewed.

## Code Quality
Running `cargo fmt` and `cargo clippy` is appreciated but not required.

You can delete this comment after reading.
-->

## Description
<!-- Describe your changes here -->

Fix #453, fix #740

If a caller watches a relative path, emitted event paths and `watched_paths()` now keep that relative root representation.
And if a caller watches an absolute path, the reported paths remain absolute.

The implementation still uses absolute paths internally where backends need them, but stores the user-requested path alongside that internal path and rewrites backend event paths before exposing them. The behavior is applied across the platform backends.

I'm not sure if the current is the best approach, let'd try it out during this RC periods.

## Related Issues
<!-- Link any related issues -->
