### PR TITLE
Emit `remove` events even if a file was created and then removed

### DIFF
--- a/notify-debouncer-full/CHANGELOG.md
+++ b/notify-debouncer-full/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
+
 ## unreleased
+
+- CHANGE: emit `remove` events event if a file was created and then removed (because macOS repeats the "create" event) [#900] **breaking**
+
+[#900]: https://github.com/notify-rs/notify/issues/900
 
 ## debouncer-full 0.8.0-rc.1 (2026-04-16)
 

--- a/notify-debouncer-full/CHANGELOG.md
+++ b/notify-debouncer-full/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## unreleased
 
-- CHANGE: emit `remove` events event if a file was created and then removed (because macOS repeats the "create" event) [#900] **breaking**
+- CHANGE: emit `remove` events even if a file was created and then removed (because macOS repeats the "create" event) [#900] **breaking**
 
 [#900]: https://github.com/notify-rs/notify/issues/900
 

--- a/notify-debouncer-full/src/lib.rs
+++ b/notify-debouncer-full/src/lib.rs
@@ -509,9 +509,6 @@ impl<T: FileIdCache> DebounceDataInner<T> {
         self.cache.remove_path(path);
 
         match self.queues.get_mut(path) {
-            Some(queue) if queue.was_created() => {
-                self.queues.remove(path);
-            }
             Some(queue) => {
                 queue.events = [DebouncedEvent::new(event, time)].into();
             }
@@ -963,6 +960,7 @@ mod tests {
     #[rstest]
     fn state(
         #[values(
+            "add_create_and_remove_event",
             "add_create_event",
             "add_create_event_after_remove_event",
             "add_create_dir_event_twice",

--- a/notify-debouncer-full/test_cases/add_create_and_remove_event.hjson
+++ b/notify-debouncer-full/test_cases/add_create_and_remove_event.hjson
@@ -8,12 +8,12 @@
             /watch/file: {
                 events: [
                     { kind: "create-any", paths: ["*"] }
-                    { kind: "modify-data-any", paths: ["*"] }
                 ]
             }
         }
     }
     events: [
+        { kind: "create-any", paths: ["/watch/file"] }
         { kind: "remove-any", paths: ["/watch/file"] }
     ]
     expected: {

--- a/notify-debouncer-full/test_cases/add_remove_event_after_create_event.hjson
+++ b/notify-debouncer-full/test_cases/add_remove_event_after_create_event.hjson
@@ -1,3 +1,7 @@
+// https://github.com/notify-rs/notify/issues/900
+//
+// macOS repeats the "create" event when a file is created and then removed.
+// The "remove" event must not be swallowed.
 {
     state: {
         queues: {
@@ -11,5 +15,13 @@
     events: [
         { kind: "remove-any", paths: ["/watch/file"] }
     ]
-    expected: {}
+    expected: {
+        queues: {
+            /watch/file: {
+                events: [
+                    { kind: "remove-any", paths: ["*"] }
+                ]
+            }
+        }
+    }
 }


### PR DESCRIPTION
Always emit `remove` events, regardless if files were just created.

## Description
Currently debouncer-full ignores `create` + `remove` events for a file. But @dmtrKovalenko reports that fsevents emits `create` + `remove` for remove events. So this PR changes the behavior to always emit `remove` events, regardless if the files were just created. (the `create` event is still not emitted in such a case)

I don't have macOS, so I can't test this. We could add a CI test, but I'm not sure if that is worth it.

@JohnTitor  This is a breaking change, so you may want to release debouncer-full 0.8.0 before merging.

## Related Issues
Fix https://github.com/notify-rs/notify/issues/900
