### PR TITLE
fix: replace watcher when rewatching

### DIFF
--- a/docs/UPGRADING_V8_TO_V9.md
+++ b/docs/UPGRADING_V8_TO_V9.md
@@ -76,6 +76,34 @@ let path = std::env::current_dir()?.join("src");
 watcher.watch(&path, notify::RecursiveMode::Recursive)?;
 ```
 
+### 4) Rewatching the same path replaces the existing watch
+
+Calling `Watcher::watch` again for the same backend-resolved path now replaces the existing watch
+on success. The recursive mode and reported path are updated to the new request, a second
+independent watch is not added, and one `Watcher::unwatch` call removes the path.
+
+In v8 this behavior varied by backend. Some backends effectively merged repeated watches, while
+others could keep duplicate backend entries or resources. If your code depended on repeated
+`watch` calls acting like independent watches for the same path, use separate watcher instances or
+manage parent/child watches explicitly.
+
+Before (v8 behavior varied by backend):
+
+```rust
+watcher.watch(path, notify::RecursiveMode::Recursive)?;
+watcher.watch(path, notify::RecursiveMode::NonRecursive)?;
+```
+
+After (v9):
+
+```rust
+watcher.watch(path, notify::RecursiveMode::Recursive)?;
+watcher.watch(path, notify::RecursiveMode::NonRecursive)?;
+
+// `path` is now watched non-recursively.
+watcher.unwatch(path)?;
+```
+
 ## Non-breaking changes but worth mentioning
 
 ### Event-kind filtering was added

--- a/notify/CHANGELOG.md
+++ b/notify/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 - CHANGE: preserve watched path representation in `Event.paths` and `Watcher::watched_paths`; relative watch paths now produce relative event paths consistently across backends [#453] [#740]
 - FIX: [kqueue] stop reporting arbitrary existing child paths for non-recursive directory write events [#644]
+- FIX: replace an existing watch when `watch` is called again for the same path, avoiding duplicate FSEvent paths and leaked Windows watch handles [#708]
+- DOCS: define `Watcher::watch` replacement behavior for an existing backend-resolved path [#708]
 
 ## notify 9.0.0-rc.3 (2026-04-16)
 
@@ -22,6 +24,7 @@
 [#453]: https://github.com/notify-rs/notify/issues/453
 [#740]: https://github.com/notify-rs/notify/issues/740
 [#644]: https://github.com/notify-rs/notify/issues/644
+[#708]: https://github.com/notify-rs/notify/issues/708
 
 ## notify 9.0.0-rc.2 (2026-02-14)
 

--- a/notify/src/fsevent.rs
+++ b/notify/src/fsevent.rs
@@ -408,8 +408,17 @@ impl FsEventWatcher {
             })
             .or_else(|| absolute_path(path).ok())
             .unwrap_or_else(|| path.to_owned());
+        self.remove_cf_path(&p)?;
+
+        match self.recursive_info.remove(&p) {
+            Some(_) => Ok(()),
+            None => Err(Error::watch_not_found()),
+        }
+    }
+
+    fn remove_cf_path(&mut self, path: &Path) -> Result<()> {
         let mut err: *mut cf::CFError = ptr::null_mut();
-        let Some(cf_path) = (unsafe { path_to_cfstring_ref(&p, &mut err) }) else {
+        let Some(cf_path) = (unsafe { path_to_cfstring_ref(path, &mut err) }) else {
             if let Some(err) = NonNull::new(err) {
                 let _ = unsafe { cf::CFRetained::from_raw(err) };
             }
@@ -432,11 +441,7 @@ impl FsEventWatcher {
                 cf::CFMutableArray::remove_value_at_index(Some(self.paths.as_opaque()), *idx)
             };
         }
-
-        match self.recursive_info.remove(&p) {
-            Some(_) => Ok(()),
-            None => Err(Error::watch_not_found()),
-        }
+        Ok(())
     }
 
     // https://github.com/thibaudgg/rb-fsevent/blob/master/ext/fsevent_watch/main.c
@@ -454,6 +459,9 @@ impl FsEventWatcher {
             // while the above code was running.
             return Err(Error::path_not_found().add_path(path.into()));
         };
+        if self.recursive_info.contains_key(&canonical_path) {
+            self.remove_cf_path(&canonical_path)?;
+        }
         self.paths.append(&cf_path);
 
         self.recursive_info.insert(
@@ -811,6 +819,26 @@ mod tests {
 
     fn watcher() -> (TestWatcher<FsEventWatcher>, Receiver) {
         channel()
+    }
+
+    #[test]
+    fn rewatching_same_path_replaces_recursive_info() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut watcher = FsEventWatcher::new(|_| {}, Config::default()).unwrap();
+
+        watcher
+            .append_path(dir.path(), RecursiveMode::Recursive)
+            .expect("watch recursively");
+        watcher
+            .append_path(dir.path(), RecursiveMode::NonRecursive)
+            .expect("rewatch non-recursively");
+
+        let watched = watcher.watched_paths().expect("watched paths");
+        assert_eq!(
+            watched,
+            vec![(dir.path().to_path_buf(), RecursiveMode::NonRecursive)]
+        );
+        assert_eq!(watcher.paths.iter().count(), 1);
     }
 
     #[test]

--- a/notify/src/inotify.rs
+++ b/notify/src/inotify.rs
@@ -8,7 +8,7 @@ use super::event::*;
 use super::{Config, Error, ErrorKind, EventHandler, RecursiveMode, Result, Watcher};
 use crate::paths::{
     absolute_path, is_preserved_watch_root, preserved_watch_mode, preserved_watch_roots,
-    reported_path, WatchMetadata, WatchPath,
+    recursive_user_watch_ancestor, reported_path, WatchMetadata, WatchPath,
 };
 use crate::{bounded, unbounded, BoundSender, Receiver, Sender};
 use inotify as inotify_sys;
@@ -522,9 +522,53 @@ impl EventLoop {
     }
 
     fn add_watch(&mut self, path: WatchPath, is_recursive: bool, watch_self: bool) -> Result<()> {
+        let path_is_dir = metadata(&path.absolute).map_err(Error::io_watch)?.is_dir();
+        let requested_is_recursive = is_recursive && path_is_dir;
+        if watch_self {
+            if let Some(watch) = self
+                .watches
+                .get(&path.absolute)
+                .filter(|watch| watch.metadata.is_user_watch)
+            {
+                if watch.metadata.user_is_recursive == requested_is_recursive
+                    && watch.metadata.reported_path == path.requested
+                {
+                    return Ok(());
+                }
+
+                let inherited_recursive_root =
+                    if !requested_is_recursive && path_is_dir && watch.metadata.is_recursive {
+                        recursive_user_watch_ancestor(
+                            &path.absolute,
+                            self.watches
+                                .iter()
+                                .map(|(path, watch)| (path, &watch.metadata)),
+                        )
+                    } else {
+                        None
+                    };
+                let replaced_path = path.absolute.clone();
+                self.remove_watch(replaced_path.clone(), false)?;
+
+                if let Some((ancestor_path, ancestor_reported_path)) = inherited_recursive_root {
+                    let entries = WalkDir::new(&replaced_path)
+                        .follow_links(self.follow_links)
+                        .into_iter()
+                        .filter_map(filter_dir)
+                        .map(|entry| {
+                            let absolute = entry.into_path();
+                            let requested =
+                                reported_path(&ancestor_path, &ancestor_reported_path, &absolute);
+                            WatchPath::from_parts(absolute, requested)
+                        });
+                    self.add_watches_for_paths(entries, true, false)?;
+                }
+            }
+        }
+
         // If the watch is not recursive, or if we determine (by stat'ing the path to get its
         // metadata) that the watched path is not a directory, add a single path watch.
-        if !is_recursive || !metadata(&path.absolute).map_err(Error::io_watch)?.is_dir() {
+        if !requested_is_recursive {
             return self.add_single_watch(path, false, true);
         }
 
@@ -959,6 +1003,113 @@ mod tests {
             result.is_ok(),
             "expected recursive watch to succeed, got: {result:?}"
         );
+    }
+
+    #[test]
+    fn rewatching_same_path_replaces_recursive_state() {
+        let tmpdir = tempfile::tempdir().unwrap();
+        let root = tmpdir.path().to_path_buf();
+        let child = root.join("child");
+        std::fs::create_dir(&child).unwrap();
+
+        let inotify = super::inotify_sys::Inotify::init().unwrap();
+        let mut event_loop = EventLoop::new(inotify, Box::new(|_| {}), &Config::default()).unwrap();
+
+        event_loop
+            .add_watch(WatchPath::new(&root).unwrap(), true, true)
+            .expect("watch recursively");
+        assert!(event_loop.watches.contains_key(&child));
+
+        event_loop
+            .add_watch(WatchPath::new(&root).unwrap(), false, true)
+            .expect("rewatch non-recursively");
+
+        let watch = event_loop.watches.get(&root).expect("root watch");
+        assert!(watch.metadata.is_user_watch);
+        assert!(!watch.metadata.user_is_recursive);
+        assert!(!watch.metadata.is_recursive);
+        assert!(!event_loop.watches.contains_key(&child));
+    }
+
+    #[test]
+    fn rewatching_child_preserves_recursive_parent_state() {
+        let tmpdir = tempfile::tempdir().unwrap();
+        let root = tmpdir.path().to_path_buf();
+        let child = root.join("child");
+        let grandchild = child.join("grandchild");
+        std::fs::create_dir_all(&grandchild).unwrap();
+
+        let inotify = super::inotify_sys::Inotify::init().unwrap();
+        let mut event_loop = EventLoop::new(inotify, Box::new(|_| {}), &Config::default()).unwrap();
+
+        event_loop
+            .add_watch(WatchPath::new(&root).unwrap(), true, true)
+            .expect("watch root recursively");
+        event_loop
+            .add_watch(WatchPath::new(&child).unwrap(), false, true)
+            .expect("watch child non-recursively");
+        event_loop
+            .add_watch(
+                WatchPath::from_parts(child.clone(), PathBuf::from("reported-child")),
+                false,
+                true,
+            )
+            .expect("rewatch child non-recursively");
+
+        let child_watch = event_loop.watches.get(&child).expect("child watch");
+        assert!(child_watch.metadata.is_user_watch);
+        assert!(!child_watch.metadata.user_is_recursive);
+        assert!(child_watch.metadata.is_recursive);
+        assert_eq!(
+            child_watch.metadata.reported_path,
+            PathBuf::from("reported-child")
+        );
+
+        let grandchild_watch = event_loop
+            .watches
+            .get(&grandchild)
+            .expect("grandchild still covered by recursive parent");
+        assert!(!grandchild_watch.metadata.is_user_watch);
+        assert!(grandchild_watch.metadata.is_recursive);
+    }
+
+    #[test]
+    fn rewatching_carved_out_child_does_not_restore_parent_recursive_state() {
+        let tmpdir = tempfile::tempdir().unwrap();
+        let root = tmpdir.path().to_path_buf();
+        let child = root.join("child");
+        let grandchild = child.join("grandchild");
+        std::fs::create_dir_all(&grandchild).unwrap();
+
+        let inotify = super::inotify_sys::Inotify::init().unwrap();
+        let mut event_loop = EventLoop::new(inotify, Box::new(|_| {}), &Config::default()).unwrap();
+
+        event_loop
+            .add_watch(WatchPath::new(&root).unwrap(), true, true)
+            .expect("watch root recursively");
+        event_loop
+            .remove_watch(child.clone(), false)
+            .expect("carve out child");
+        event_loop
+            .add_watch(WatchPath::new(&child).unwrap(), false, true)
+            .expect("watch child non-recursively");
+        event_loop
+            .add_watch(
+                WatchPath::from_parts(child.clone(), PathBuf::from("reported-child")),
+                false,
+                true,
+            )
+            .expect("rewatch child non-recursively");
+
+        let child_watch = event_loop.watches.get(&child).expect("child watch");
+        assert!(child_watch.metadata.is_user_watch);
+        assert!(!child_watch.metadata.user_is_recursive);
+        assert!(!child_watch.metadata.is_recursive);
+        assert_eq!(
+            child_watch.metadata.reported_path,
+            PathBuf::from("reported-child")
+        );
+        assert!(!event_loop.watches.contains_key(&grandchild));
     }
 
     /// Runs manually.

--- a/notify/src/inotify.rs
+++ b/notify/src/inotify.rs
@@ -536,6 +536,10 @@ impl EventLoop {
                     return Ok(());
                 }
 
+                // Rewatching an explicit user watch replaces its requested mode and reported path
+                // instead of merging with the previous metadata. If the current entry also carries
+                // recursive coverage from an ancestor, remember that ancestor before removal so we
+                // can rebuild that inherited coverage below.
                 let inherited_recursive_root =
                     if !requested_is_recursive && path_is_dir && watch.metadata.is_recursive {
                         recursive_user_watch_ancestor(
@@ -551,6 +555,9 @@ impl EventLoop {
                 self.remove_watch(replaced_path.clone(), false)?;
 
                 if let Some((ancestor_path, ancestor_reported_path)) = inherited_recursive_root {
+                    // Removing a directory watch removes its recursively inherited children too.
+                    // Re-add them as non-user watches so the ancestor recursive watch still covers
+                    // this subtree after the user watch is replaced.
                     let entries = WalkDir::new(&replaced_path)
                         .follow_links(self.follow_links)
                         .into_iter()

--- a/notify/src/kqueue.rs
+++ b/notify/src/kqueue.rs
@@ -373,6 +373,10 @@ impl EventLoop {
                     return Ok(());
                 }
 
+                // Rewatching an explicit user watch replaces its requested mode and reported path
+                // instead of merging with the previous metadata. If the current entry also carries
+                // recursive coverage from an ancestor, remember that ancestor before removal so we
+                // can rebuild that inherited coverage below.
                 let inherited_recursive_root =
                     if !requested_is_recursive && path_is_dir && watch.is_recursive {
                         recursive_user_watch_ancestor(&path.absolute, self.watches.iter())
@@ -383,6 +387,9 @@ impl EventLoop {
                 self.remove_watch(replaced_path.clone(), false)?;
 
                 if let Some((ancestor_path, ancestor_reported_path)) = inherited_recursive_root {
+                    // Removing a directory watch removes its recursively inherited children too.
+                    // Re-add them as non-user watches so the ancestor recursive watch still covers
+                    // this subtree after the user watch is replaced.
                     for entry in WalkDir::new(&replaced_path)
                         .follow_links(self.follow_symlinks)
                         .into_iter()

--- a/notify/src/kqueue.rs
+++ b/notify/src/kqueue.rs
@@ -5,10 +5,12 @@
 //! pieces of kernel code termed filters.
 
 use super::event::*;
-use super::{Config, Error, EventHandler, EventKindMask, RecursiveMode, Result, Watcher};
+use super::{
+    Config, Error, ErrorKind, EventHandler, EventKindMask, RecursiveMode, Result, Watcher,
+};
 use crate::paths::{
     absolute_path, is_preserved_watch_root, preserved_watch_mode, preserved_watch_roots,
-    reported_path, WatchMetadata as Watch, WatchPath,
+    recursive_user_watch_ancestor, reported_path, WatchMetadata as Watch, WatchPath,
 };
 use crate::{unbounded, Receiver, Sender};
 use kqueue::{EventData, EventFilter, FilterFlag, Ident};
@@ -357,9 +359,59 @@ impl EventLoop {
         is_recursive: bool,
         is_user_watch: bool,
     ) -> Result<()> {
+        let path_is_dir = metadata(&path.absolute).map_err(Error::io)?.is_dir();
+        let requested_is_recursive = is_recursive && path_is_dir;
+        if is_user_watch {
+            if let Some(watch) = self
+                .watches
+                .get(&path.absolute)
+                .filter(|watch| watch.is_user_watch)
+            {
+                if watch.user_is_recursive == requested_is_recursive
+                    && watch.reported_path == path.requested
+                {
+                    return Ok(());
+                }
+
+                let inherited_recursive_root =
+                    if !requested_is_recursive && path_is_dir && watch.is_recursive {
+                        recursive_user_watch_ancestor(&path.absolute, self.watches.iter())
+                    } else {
+                        None
+                    };
+                let replaced_path = path.absolute.clone();
+                self.remove_watch(replaced_path.clone(), false)?;
+
+                if let Some((ancestor_path, ancestor_reported_path)) = inherited_recursive_root {
+                    for entry in WalkDir::new(&replaced_path)
+                        .follow_links(self.follow_symlinks)
+                        .into_iter()
+                    {
+                        let absolute = match entry {
+                            Ok(entry) => entry.into_path(),
+                            Err(err) if walkdir_error_is_not_found(&err) => continue,
+                            Err(err) => return Err(map_walkdir_error(err)),
+                        };
+                        let requested =
+                            reported_path(&ancestor_path, &ancestor_reported_path, &absolute);
+                        let result = self.add_single_watch(
+                            WatchPath::from_parts(absolute, requested),
+                            true,
+                            false,
+                        );
+                        if let Err(err) = result {
+                            if !error_is_not_found(&err) {
+                                return Err(err);
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
         // If the watch is not recursive, or if we determine (by stat'ing the path to get its
         // metadata) that the watched path is not a directory, add a single path watch.
-        if !is_recursive || !metadata(&path.absolute).map_err(Error::io)?.is_dir() {
+        if !requested_is_recursive {
             self.add_single_watch(path, false, is_user_watch)?;
         } else {
             let root = path;
@@ -476,6 +528,16 @@ fn map_walkdir_error(e: walkdir::Error) -> Error {
     } else {
         Error::generic(&e.to_string())
     }
+}
+
+fn walkdir_error_is_not_found(e: &walkdir::Error) -> bool {
+    e.io_error()
+        .is_some_and(|e| e.kind() == std::io::ErrorKind::NotFound)
+}
+
+fn error_is_not_found(e: &Error) -> bool {
+    matches!(&e.kind, ErrorKind::PathNotFound)
+        || matches!(&e.kind, ErrorKind::Io(io_err) if io_err.kind() == std::io::ErrorKind::NotFound)
 }
 
 impl KqueueWatcher {
@@ -625,6 +687,95 @@ mod tests {
             .collect();
         assert_eq!(watched.get(dir.path()), Some(&true));
         assert_eq!(watched.get(&child), Some(&false));
+
+        Ok(())
+    }
+
+    #[test]
+    fn rewatching_same_path_replaces_recursive_state(
+    ) -> std::result::Result<(), Box<dyn std::error::Error>> {
+        let dir = tempfile::tempdir()?;
+        let child = dir.path().join("child");
+        std::fs::create_dir(&child)?;
+
+        let kqueue = kqueue::Watcher::new()?;
+        let mut event_loop = EventLoop::new(kqueue, Box::new(|_| {}), false, EventKindMask::ALL)?;
+
+        event_loop.add_watch(WatchPath::new(dir.path())?, true, true)?;
+        assert!(event_loop.watches.contains_key(&child));
+
+        event_loop.add_watch(WatchPath::new(dir.path())?, false, true)?;
+
+        let watch = event_loop.watches.get(dir.path()).expect("root watch");
+        assert!(watch.is_user_watch);
+        assert!(!watch.user_is_recursive);
+        assert!(!watch.is_recursive);
+        assert!(!event_loop.watches.contains_key(&child));
+
+        Ok(())
+    }
+
+    #[test]
+    fn rewatching_child_preserves_recursive_parent_state(
+    ) -> std::result::Result<(), Box<dyn std::error::Error>> {
+        let dir = tempfile::tempdir()?;
+        let child = dir.path().join("child");
+        let grandchild = child.join("grandchild");
+        std::fs::create_dir_all(&grandchild)?;
+
+        let kqueue = kqueue::Watcher::new()?;
+        let mut event_loop = EventLoop::new(kqueue, Box::new(|_| {}), false, EventKindMask::ALL)?;
+
+        event_loop.add_watch(WatchPath::new(dir.path())?, true, true)?;
+        event_loop.add_watch(WatchPath::new(&child)?, false, true)?;
+        event_loop.add_watch(
+            WatchPath::from_parts(child.clone(), PathBuf::from("reported-child")),
+            false,
+            true,
+        )?;
+
+        let child_watch = event_loop.watches.get(&child).expect("child watch");
+        assert!(child_watch.is_user_watch);
+        assert!(!child_watch.user_is_recursive);
+        assert!(child_watch.is_recursive);
+        assert_eq!(child_watch.reported_path, PathBuf::from("reported-child"));
+
+        let grandchild_watch = event_loop
+            .watches
+            .get(&grandchild)
+            .expect("grandchild still covered by recursive parent");
+        assert!(!grandchild_watch.is_user_watch);
+        assert!(grandchild_watch.is_recursive);
+
+        Ok(())
+    }
+
+    #[test]
+    fn rewatching_carved_out_child_does_not_restore_parent_recursive_state(
+    ) -> std::result::Result<(), Box<dyn std::error::Error>> {
+        let dir = tempfile::tempdir()?;
+        let child = dir.path().join("child");
+        let grandchild = child.join("grandchild");
+        std::fs::create_dir_all(&grandchild)?;
+
+        let kqueue = kqueue::Watcher::new()?;
+        let mut event_loop = EventLoop::new(kqueue, Box::new(|_| {}), false, EventKindMask::ALL)?;
+
+        event_loop.add_watch(WatchPath::new(dir.path())?, true, true)?;
+        event_loop.remove_watch(child.clone(), false)?;
+        event_loop.add_watch(WatchPath::new(&child)?, false, true)?;
+        event_loop.add_watch(
+            WatchPath::from_parts(child.clone(), PathBuf::from("reported-child")),
+            false,
+            true,
+        )?;
+
+        let child_watch = event_loop.watches.get(&child).expect("child watch");
+        assert!(child_watch.is_user_watch);
+        assert!(!child_watch.user_is_recursive);
+        assert!(!child_watch.is_recursive);
+        assert_eq!(child_watch.reported_path, PathBuf::from("reported-child"));
+        assert!(!event_loop.watches.contains_key(&grandchild));
 
         Ok(())
     }

--- a/notify/src/lib.rs
+++ b/notify/src/lib.rs
@@ -365,6 +365,11 @@ pub trait Watcher {
     /// method is called. If `path` is absolute, emitted event paths are absolute. Convert `path`
     /// before calling this method if your application needs a specific representation.
     ///
+    /// On success, calling this method again for the same backend-resolved path replaces the
+    /// existing watch for that path. The recursive mode is updated to the new value, a second
+    /// independent watch is not added, and a single call to [`Watcher::unwatch`] removes the
+    /// watched path.
+    ///
     /// On some platforms, if the `path` is renamed or removed while being watched, behaviour may
     /// be unexpected. See discussions in [#165] and [#166]. If less surprising behaviour is wanted
     /// one may non-recursively watch the _parent_ directory as well and manage related events.
@@ -826,6 +831,34 @@ mod tests {
         let watched = canonical_watch_set(watcher.watched_paths()?);
         assert!(!watched.contains(&(canonical_or_path(&dir_a), RecursiveMode::Recursive)));
         assert!(watched.contains(&(canonical_or_path(&dir_b), RecursiveMode::NonRecursive)));
+
+        Ok(())
+    }
+
+    #[test]
+    fn rewatching_same_path_replaces_recursive_mode(
+    ) -> std::result::Result<(), Box<dyn std::error::Error>> {
+        let dir = tempdir()?;
+        let root = canonical_or_path(dir.path());
+
+        let (tx, _rx) = std::sync::mpsc::channel();
+        let mut watcher = RecommendedWatcher::new(tx, Config::default())?;
+
+        watcher.watch(dir.path(), RecursiveMode::Recursive)?;
+        watcher.watch(dir.path(), RecursiveMode::NonRecursive)?;
+
+        let watched = canonical_watch_set(watcher.watched_paths()?);
+        assert!(watched.contains(&(root.clone(), RecursiveMode::NonRecursive)));
+        assert!(!watched.contains(&(root.clone(), RecursiveMode::Recursive)));
+        assert_eq!(
+            watched.iter().filter(|(path, _mode)| path == &root).count(),
+            1
+        );
+
+        watcher.unwatch(dir.path())?;
+
+        let watched = canonical_watch_set(watcher.watched_paths()?);
+        assert!(!watched.iter().any(|(path, _mode)| path == &root));
 
         Ok(())
     }

--- a/notify/src/paths.rs
+++ b/notify/src/paths.rs
@@ -146,3 +146,22 @@ where
 pub(crate) fn is_preserved_watch_root(path: &Path, preserved_roots: &[(PathBuf, bool)]) -> bool {
     preserved_roots.iter().any(|(root, _)| path == root)
 }
+
+pub(crate) fn recursive_user_watch_ancestor<'a, I>(
+    path: &Path,
+    watches: I,
+) -> Option<(PathBuf, PathBuf)>
+where
+    I: IntoIterator<Item = (&'a PathBuf, &'a WatchMetadata)>,
+{
+    watches
+        .into_iter()
+        .filter(|(candidate, watch)| {
+            *candidate != path
+                && path.starts_with(candidate)
+                && watch.is_user_watch
+                && watch.user_is_recursive
+        })
+        .max_by_key(|(candidate, _)| candidate.as_os_str().len())
+        .map(|(path, watch)| (path.clone(), watch.reported_path.clone()))
+}

--- a/notify/src/paths.rs
+++ b/notify/src/paths.rs
@@ -147,6 +147,11 @@ pub(crate) fn is_preserved_watch_root(path: &Path, preserved_roots: &[(PathBuf, 
     preserved_roots.iter().any(|(root, _)| path == root)
 }
 
+/// Finds the nearest recursive user watch that covers `path`.
+///
+/// Backends use this when replacing an explicit watch that also inherits recursive coverage from an
+/// ancestor. Returning the ancestor's reported path lets them rebuild the inherited subtree with the
+/// same path representation users expect from that ancestor watch.
 pub(crate) fn recursive_user_watch_ancestor<'a, I>(
     path: &Path,
     watches: I,

--- a/notify/src/poll.rs
+++ b/notify/src/poll.rs
@@ -840,6 +840,33 @@ mod tests {
     }
 
     #[test]
+    fn rewatching_same_path_replaces_recursive_mode() {
+        let tmpdir = testdir();
+        let root = tmpdir.path().canonicalize().expect("canonicalize root");
+
+        let mut watcher = PollWatcher::new(|_| {}, Config::default()).expect("create watcher");
+
+        watcher
+            .watch(tmpdir.path(), RecursiveMode::Recursive)
+            .expect("watch recursively");
+        watcher
+            .watch(tmpdir.path(), RecursiveMode::NonRecursive)
+            .expect("watch non-recursively");
+
+        let watched = watcher.watched_paths().expect("list watched paths");
+        assert!(watched.contains(&(root.clone(), RecursiveMode::NonRecursive)));
+        assert!(!watched.contains(&(root.clone(), RecursiveMode::Recursive)));
+        assert_eq!(
+            watched.iter().filter(|(path, _mode)| path == &root).count(),
+            1
+        );
+
+        watcher.unwatch(tmpdir.path()).expect("unwatch");
+        let watched = watcher.watched_paths().expect("list watched paths");
+        assert!(!watched.iter().any(|(path, _mode)| path == &root));
+    }
+
+    #[test]
     fn create_file() {
         let tmpdir = testdir();
         let (mut watcher, mut rx) = watcher();

--- a/notify/src/windows.rs
+++ b/notify/src/windows.rs
@@ -372,6 +372,9 @@ impl ReadDirectoryChangesServer {
             reported_path: path.requested,
         };
         let watched_path = path.absolute;
+        if let Some(ws) = self.watches.remove(&watched_path) {
+            stop_watch(&ws, &self.meta_tx);
+        }
         self.watches.insert(watched_path.clone(), ws);
         start_read(
             &rd,


### PR DESCRIPTION
<!-- 
## Contribution Agreement
By contributing, you agree to the license terms (CC Zero 1.0 for notify crate, MIT/Apache 2.0 for the rest) and the code of conduct in CODE_OF_CONDUCT.md.

## Changelog
Add an entry to CHANGELOG.md if applicable. Create a new section `## notify (unreleased)` if not already present.

## Testing
The test suite will run after creating this PR. If builds fail, you must either fix the errors, ask for help, or provide a detailed explanation of why failures are expected. If you don't, a maintainer may prompt you, but it will take longer for your contribution to be reviewed.

## Code Quality
Running `cargo fmt` and `cargo clippy` is appreciated but not required.

You can delete this comment after reading.
-->

## Description
<!-- Describe your changes here -->

Fix https://github.com/notify-rs/notify/issues/708

Currently, rewatching behavior varies by backend and brings some confusion like #708.
This makes it consistent over all the backend and documents its behavior.

## Related Issues
<!-- Link any related issues -->
