### PR TITLE
fix(kqueue): do not infer file paths on non-recursive watcher

### DIFF
--- a/notify/CHANGELOG.md
+++ b/notify/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## unreleased
 
 - CHANGE: preserve watched path representation in `Event.paths` and `Watcher::watched_paths`; relative watch paths now produce relative event paths consistently across backends [#453] [#740]
+- FIX: [kqueue] stop reporting arbitrary existing child paths for non-recursive directory write events [#644]
 
 ## notify 9.0.0-rc.3 (2026-04-16)
 
@@ -20,6 +21,7 @@
 [#739]: https://github.com/notify-rs/notify/issues/739
 [#453]: https://github.com/notify-rs/notify/issues/453
 [#740]: https://github.com/notify-rs/notify/issues/740
+[#644]: https://github.com/notify-rs/notify/issues/644
 
 ## notify 9.0.0-rc.2 (2026-02-14)
 

--- a/notify/src/kqueue.rs
+++ b/notify/src/kqueue.rs
@@ -200,9 +200,20 @@ impl EventLoop {
                             Ok(Event::new(EventKind::Remove(RemoveKind::Any)).add_path(event_path))
                         }
 
-                        // a write to a directory means that a new file was created in it, let's
-                        // figure out which file this was
-                        kqueue::Vnode::Write if path.is_dir() => {
+                        // A write to a recursively watched directory may mean that a new file
+                        // was created in it. Non-recursive directory watches do not track
+                        // children, so guessing from read_dir would be unreliable.
+                        // FIXME: harden guessing for non-recursive watches.
+                        // Context: https://github.com/notify-rs/notify/issues/644
+                        kqueue::Vnode::Write
+                            if watch.is_some_and(|watch| watch.is_recursive)
+                                && if self.follow_symlinks {
+                                    path.is_dir()
+                                } else {
+                                    std::fs::symlink_metadata(&path)
+                                        .is_ok_and(|metadata| metadata.is_dir())
+                                } =>
+                        {
                             // find which file is new in the directory by comparing it with our
                             // list of known watches
                             std::fs::read_dir(&path)
@@ -690,6 +701,23 @@ mod tests {
         std::fs::remove_file(&file).expect("remove");
 
         // kqueue reports a write event on the directory when a file is deleted
+        rx.wait_unordered([expected(tmpdir.path()).modify_data_any()]);
+    }
+
+    #[test]
+    fn create_file_in_non_recursive_directory_with_existing_child() {
+        let tmpdir = testdir();
+        let (mut watcher, mut rx) = watcher();
+        let existing = tmpdir.path().join("existing");
+        let created = tmpdir.path().join("created");
+        std::fs::write(&existing, "").expect("write");
+
+        watcher.watch_nonrecursively(&tmpdir);
+
+        std::fs::write(&created, "").expect("write");
+
+        // kqueue does not report which directory entry changed, so the backend
+        // must not guess an arbitrary pre-existing child as the created path.
         rx.wait_unordered([expected(tmpdir.path()).modify_data_any()]);
     }
 


### PR DESCRIPTION
<!-- 
## Contribution Agreement
By contributing, you agree to the license terms (CC Zero 1.0 for notify crate, MIT/Apache 2.0 for the rest) and the code of conduct in CODE_OF_CONDUCT.md.

## Changelog
Add an entry to CHANGELOG.md if applicable. Create a new section `## notify (unreleased)` if not already present.

## Testing
The test suite will run after creating this PR. If builds fail, you must either fix the errors, ask for help, or provide a detailed explanation of why failures are expected. If you don't, a maintainer may prompt you, but it will take longer for your contribution to be reviewed.

## Code Quality
Running `cargo fmt` and `cargo clippy` is appreciated but not required.

You can delete this comment after reading.
-->

## Description
<!-- Describe your changes here -->

Fix #644

As far as I could tell, and as stated in the issue, there's no accurate information to infer the newly created paths perfectly, it'd be better to tell ambiguious event not to make confusion.

## Related Issues
<!-- Link any related issues -->
