### PR TITLE
perf(notify): speed up recursive inotify watch setup

### DIFF
--- a/notify/src/inotify.rs
+++ b/notify/src/inotify.rs
@@ -658,15 +658,24 @@ impl EventLoop {
                             return Err(Error::io_watch(e).add_path(path.requested));
                         }
                     };
-                    let metadata = WatchMetadata::new(
-                        &path,
-                        is_recursive,
-                        watch_self,
-                        existing_watch.map(|watch| &watch.metadata),
-                        self.watches
-                            .iter()
-                            .map(|(path, watch)| (path, &watch.metadata)),
-                    );
+                    let metadata = if let Some(existing_watch) = existing_watch {
+                        WatchMetadata::new(
+                            &path,
+                            is_recursive,
+                            watch_self,
+                            Some(&existing_watch.metadata),
+                            self.watches
+                                .iter()
+                                .map(|(path, watch)| (path, &watch.metadata)),
+                        )
+                    } else {
+                        WatchMetadata {
+                            is_recursive,
+                            reported_path: path.requested.clone(),
+                            is_user_watch: watch_self,
+                            user_is_recursive: watch_self && is_recursive,
+                        }
+                    };
 
                     self.watches.insert(
                         path.absolute.clone(),
@@ -842,10 +851,8 @@ impl EventLoop {
 /// return `DirEntry` when it is a directory
 fn filter_dir(e: walkdir::Result<walkdir::DirEntry>) -> Option<walkdir::DirEntry> {
     if let Ok(e) = e {
-        if let Ok(metadata) = e.metadata() {
-            if metadata.is_dir() {
-                return Some(e);
-            }
+        if e.file_type().is_dir() {
+            return Some(e);
         }
     }
     None


### PR DESCRIPTION
<!-- 
## Contribution Agreement
By contributing, you agree to the license terms (CC Zero 1.0 for notify crate, MIT/Apache 2.0 for the rest) and the code of conduct in CODE_OF_CONDUCT.md.

## Changelog
Add an entry to CHANGELOG.md if applicable. Create a new section `## notify (unreleased)` if not already present.

## Testing
The test suite will run after creating this PR. If builds fail, you must either fix the errors, ask for help, or provide a detailed explanation of why failures are expected. If you don't, a maintainer may prompt you, but it will take longer for your contribution to be reviewed.

## Code Quality
Running `cargo fmt` and `cargo clippy` is appreciated but not required.

You can delete this comment after reading.
-->

## Description
<!-- Describe your changes here -->

Avoid recomputing watch metadata through `WatchMetadata::new` when adding brand-new inotify watches with known reported paths. Also use walkdir's cached file type when filtering directories.

As reference, local run for recursive watch installation for 10k dirs:
- old: ~173-230 ms
- new: ~55-59 ms

## Related Issues
<!-- Link any related issues -->
