### PR TITLE
Add freebsd_inotify feature to use inotify on FreeBSD 14.4+

### DIFF
--- a/notify/Cargo.toml
+++ b/notify/Cargo.toml
@@ -22,6 +22,11 @@ default = ["macos_fsevent"]
 serde = ["notify-types/serde"]
 macos_kqueue = ["kqueue", "mio"]
 macos_fsevent = ["objc2-core-foundation", "objc2-core-services"]
+# Use inotify (instead of kqueue) as the FreeBSD backend. Requires FreeBSD
+# 14.4+, which provides inotify(2) and libc wrappers in the base system.
+# Forwards `freebsd-native` to `inotify-sys` so it resolves the inotify
+# symbols against libc rather than the userspace `libinotify` shim.
+freebsd_inotify = ["inotify", "inotify/freebsd-native"]
 serialization-compat-6 = ["notify-types/serialization-compat-6"]
 tokio = ["dep:tokio"]
 futures = ["dep:futures"]
@@ -70,7 +75,12 @@ windows-sys = { workspace = true, features = [
   "Win32_System_IO",
 ] }
 
-[target.'cfg(any(target_os="freebsd", target_os="openbsd", target_os = "netbsd", target_os = "dragonfly", target_os = "ios"))'.dependencies]
+[target.'cfg(target_os="freebsd")'.dependencies]
+kqueue.workspace = true
+mio.workspace = true
+inotify = { workspace = true, default-features = false, optional = true }
+
+[target.'cfg(any(target_os="openbsd", target_os = "netbsd", target_os = "dragonfly", target_os = "ios"))'.dependencies]
 kqueue.workspace = true
 mio.workspace = true
 

--- a/notify/src/inotify.rs
+++ b/notify/src/inotify.rs
@@ -1672,7 +1672,10 @@ mod tests {
                 break event;
             }
         };
-        assert_eq!(event, expected(&path).modify_data_any());
+        // Linux's inotify reports utimensat as IN_MODIFY (Data); FreeBSD's
+        // reports it as IN_ATTRIB (Metadata), per inotify(7)'s own description.
+        // Accept either to test the portable contract.
+        assert_eq!(event, expected(&path).modify());
     }
 
     #[test]
@@ -1758,8 +1761,14 @@ mod tests {
         ]);
     }
 
+    // Linux-only: Linux's inotify is dirent-centric (events fire on the
+    // pathname used for the write), so writes through an external hardlink
+    // are invisible on the watched name. FreeBSD's inotify is inode-centric
+    // and surfaces events on every name pointing to the modified inode.
     #[test]
-    fn write_to_a_hardlink_pointed_to_the_file_in_the_watched_dir_doesnt_trigger_an_event() {
+    #[cfg(target_os = "linux")]
+    fn write_to_a_hardlink_pointed_to_the_file_in_the_watched_dir_doesnt_trigger_an_event_on_linux()
+    {
         let tmpdir = testdir();
         let (mut watcher, mut rx) = watcher();
 

--- a/notify/src/lib.rs
+++ b/notify/src/lib.rs
@@ -181,7 +181,12 @@ use std::path::{Path, PathBuf};
 pub(crate) type StdResult<T, E> = std::result::Result<T, E>;
 pub(crate) type Receiver<T> = std::sync::mpsc::Receiver<T>;
 pub(crate) type Sender<T> = std::sync::mpsc::Sender<T>;
-#[cfg(any(target_os = "linux", target_os = "android", target_os = "windows"))]
+#[cfg(any(
+    target_os = "linux",
+    target_os = "android",
+    target_os = "windows",
+    all(target_os = "freebsd", feature = "freebsd_inotify"),
+))]
 pub(crate) type BoundSender<T> = std::sync::mpsc::SyncSender<T>;
 
 #[inline]
@@ -189,7 +194,12 @@ pub(crate) fn unbounded<T>() -> (Sender<T>, Receiver<T>) {
     std::sync::mpsc::channel()
 }
 
-#[cfg(any(target_os = "linux", target_os = "android", target_os = "windows"))]
+#[cfg(any(
+    target_os = "linux",
+    target_os = "android",
+    target_os = "windows",
+    all(target_os = "freebsd", feature = "freebsd_inotify"),
+))]
 #[inline]
 pub(crate) fn bounded<T>(cap: usize) -> (BoundSender<T>, Receiver<T>) {
     std::sync::mpsc::sync_channel(cap)
@@ -197,10 +207,14 @@ pub(crate) fn bounded<T>(cap: usize) -> (BoundSender<T>, Receiver<T>) {
 
 #[cfg(all(target_os = "macos", not(feature = "macos_kqueue")))]
 pub use crate::fsevent::FsEventWatcher;
-#[cfg(any(target_os = "linux", target_os = "android"))]
+#[cfg(any(
+    target_os = "linux",
+    target_os = "android",
+    all(target_os = "freebsd", feature = "freebsd_inotify"),
+))]
 pub use crate::inotify::INotifyWatcher;
 #[cfg(any(
-    target_os = "freebsd",
+    all(target_os = "freebsd", not(feature = "freebsd_inotify")),
     target_os = "openbsd",
     target_os = "netbsd",
     target_os = "dragonfly",
@@ -215,10 +229,14 @@ pub use windows::ReadDirectoryChangesWatcher;
 
 #[cfg(all(target_os = "macos", not(feature = "macos_kqueue")))]
 pub mod fsevent;
-#[cfg(any(target_os = "linux", target_os = "android"))]
+#[cfg(any(
+    target_os = "linux",
+    target_os = "android",
+    all(target_os = "freebsd", feature = "freebsd_inotify"),
+))]
 pub mod inotify;
 #[cfg(any(
-    target_os = "freebsd",
+    all(target_os = "freebsd", not(feature = "freebsd_inotify")),
     target_os = "openbsd",
     target_os = "dragonfly",
     target_os = "netbsd",
@@ -465,7 +483,11 @@ pub trait Watcher {
 }
 
 /// The recommended [`Watcher`] implementation for the current platform
-#[cfg(any(target_os = "linux", target_os = "android"))]
+#[cfg(any(
+    target_os = "linux",
+    target_os = "android",
+    all(target_os = "freebsd", feature = "freebsd_inotify"),
+))]
 pub type RecommendedWatcher = INotifyWatcher;
 /// The recommended [`Watcher`] implementation for the current platform
 #[cfg(all(target_os = "macos", not(feature = "macos_kqueue")))]
@@ -475,7 +497,7 @@ pub type RecommendedWatcher = FsEventWatcher;
 pub type RecommendedWatcher = ReadDirectoryChangesWatcher;
 /// The recommended [`Watcher`] implementation for the current platform
 #[cfg(any(
-    target_os = "freebsd",
+    all(target_os = "freebsd", not(feature = "freebsd_inotify")),
     target_os = "openbsd",
     target_os = "netbsd",
     target_os = "dragonfly",


### PR DESCRIPTION
## Description
FreeBSD 14.4+ provides an in-kernel inotify(2) implementation and libc wrappers in libc.so.7. Switching FreeBSD's notify backend from kqueue to inotify is a large win on big trees because kqueue requires one open file descriptor per watched directory (or file) while inotify uses a single fd with watch descriptors, scaling to large repositories without hitting RLIMIT_NOFILE / kern.maxfiles_per_proc.

Add a `freebsd_inotify` cargo feature (default off). When enabled:

  * `RecommendedWatcher` resolves to `INotifyWatcher` on FreeBSD.
  * The `inotify` module compiles in (it uses only std::os::unix + libc fcntl flags, no Linux-specific syscalls).
  * The `inotify` crate is pulled in via an optional FreeBSD target dep, and `inotify-sys/freebsd-native` is forwarded to skip linking the userspace libinotify shim.
  * The `BoundSender` / `bounded` helpers used by the inotify backend are extended to compile under this cfg path.

When the feature is off, FreeBSD continues to use the kqueue backend, so this is a strict opt-in and pre-14.4 FreeBSD remains buildable.

Two existing inotify-backend tests encoded Linux-specific event semantics; both are adjusted here so the test suite is green on FreeBSD:

  * `set_file_mtime` widened from `modify_data_any()` to `modify()`. Linux's inotify reports utimensat(2) as IN_MODIFY (Data); FreeBSD's reports it as IN_ATTRIB (Metadata), matching inotify(7)'s own description (which lists timestamps under IN_ATTRIB). Both still satisfy the portable contract "mtime change fires a Modify event".

  * `write_to_a_hardlink_…doesnt_trigger…` gated to #[cfg(target_os = "linux")] and renamed with an `_on_linux` suffix. Linux's inotify is dirent-centric (events fire on the pathname used for the write); FreeBSD's is inode-centric (events fire on every pathname pointing to the modified inode). The test as written encodes Linux's behavior; a comment documents the underlying architectural difference.

Tested on FreeBSD: cargo test --workspace --features notify/freebsd_inotify reports 74 passed, 0 failed, 2 ignored in `notify` lib unittests, with all other workspace crates fully green. Linux behavior is unchanged.

## Related Issues
<!-- Link any related issues -->
