### PR TITLE
fix(windows): emit Remove event when watched directory is deleted

### DIFF
--- a/notify/CHANGELOG.md
+++ b/notify/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## unreleased
 
+- FIX: [windows] emit a Remove event when a watched directory is deleted, matching inotify and FSEvents
+
 ## notify 9.0.0-rc.4 (2026-05-02)
 
 - CHANGE: preserve watched path representation in `Event.paths` and `Watcher::watched_paths`; relative watch paths now produce relative event paths consistently across backends [#453] [#740]

--- a/notify/src/fsevent.rs
+++ b/notify/src/fsevent.rs
@@ -1283,6 +1283,20 @@ mod tests {
     }
 
     #[test]
+    fn delete_self_dir() {
+        let tmpdir = testdir();
+        let dir = tmpdir.path().join("dir");
+        std::fs::create_dir(&dir).expect("create");
+
+        let (mut watcher, mut rx) = watcher();
+        watcher.watch_nonrecursively(&dir);
+
+        std::fs::remove_dir(&dir).expect("remove");
+
+        rx.wait_unordered([expected(&dir).remove_folder()]);
+    }
+
+    #[test]
     fn create_write_overwrite() {
         let tmpdir = testdir();
         let (mut watcher, mut rx) = watcher();

--- a/notify/src/inotify.rs
+++ b/notify/src/inotify.rs
@@ -1414,6 +1414,20 @@ mod tests {
     }
 
     #[test]
+    fn delete_self_dir() {
+        let tmpdir = testdir();
+        let dir = tmpdir.path().join("dir");
+        std::fs::create_dir(&dir).expect("create");
+
+        let (mut watcher, mut rx) = watcher();
+        watcher.watch_nonrecursively(&dir);
+
+        std::fs::remove_dir(&dir).expect("remove");
+
+        rx.wait_unordered([expected(&dir).remove_folder()]);
+    }
+
+    #[test]
     fn create_write_overwrite() {
         let tmpdir = testdir();
         let (mut watcher, mut rx) = watcher_with_all_events();

--- a/notify/src/kqueue.rs
+++ b/notify/src/kqueue.rs
@@ -894,6 +894,20 @@ mod tests {
     }
 
     #[test]
+    fn delete_self_dir() {
+        let tmpdir = testdir();
+        let dir = tmpdir.path().join("dir");
+        std::fs::create_dir(&dir).expect("create");
+
+        let (mut watcher, mut rx) = watcher();
+        watcher.watch_nonrecursively(&dir);
+
+        std::fs::remove_dir(&dir).expect("remove");
+
+        rx.wait_unordered([expected(&dir).remove_any()]);
+    }
+
+    #[test]
     #[ignore = "FIXME"]
     fn create_write_overwrite() {
         let tmpdir = testdir();

--- a/notify/src/windows.rs
+++ b/notify/src/windows.rs
@@ -491,9 +491,28 @@ unsafe extern "system" fn handle_event(
             return;
         }
         ERROR_ACCESS_DENIED => {
-            // This could happen when the watched directory is deleted or trashed, first check if it's the case.
-            // If so, unwatch the directory and return, otherwise, continue to handle the event.
+            // ReadDirectoryChangesW returns ERROR_ACCESS_DENIED both when the handle
+            // has been invalidated (usually because the watched dir was deleted) and
+            // when access has been revoked; use dir existence to tell which. For
+            // directory watches, emit a Remove event so consumers learn the watched
+            // path is gone, matching inotify IN_DELETE_SELF (#540) and FSEvents
+            // ROOT_CHANGED+ITEM_REMOVED. File watches are excluded because
+            // FILE_ACTION_REMOVED already fires for the file's parent.
             if !request.data.dir.exists() {
+                if request.data.file.is_none() {
+                    const KIND: EventKind = EventKind::Remove(RemoveKind::Folder);
+                    if request.event_kinds.matches(&KIND) {
+                        let path = normalize_path_separators(
+                            request.data.reported_dir.clone(),
+                            request.data.separator_style,
+                        );
+                        let event = Event::new(KIND).add_path(path);
+                        if let Ok(mut guard) = request.event_handler.lock() {
+                            let f: &mut dyn EventHandler = &mut *guard;
+                            f.handle_event(Ok(event));
+                        }
+                    }
+                }
                 request.unwatch();
                 ReleaseSemaphore(request.data.complete_sem, 1, ptr::null_mut());
                 return;
@@ -1068,6 +1087,20 @@ pub mod tests {
         std::fs::remove_file(&file).expect("remove");
 
         rx.wait_ordered_exact([expected(&file).remove_any()]);
+    }
+
+    #[test]
+    fn delete_self_dir() {
+        let tmpdir = testdir();
+        let dir = tmpdir.path().join("dir");
+        std::fs::create_dir(&dir).expect("create");
+
+        let (mut watcher, mut rx) = watcher();
+        watcher.watch_nonrecursively(&dir);
+
+        std::fs::remove_dir(&dir).expect("remove");
+
+        rx.wait_unordered([expected(&dir).remove_folder()]);
     }
 
     #[test]

--- a/notify/src/windows.rs
+++ b/notify/src/windows.rs
@@ -493,12 +493,12 @@ unsafe extern "system" fn handle_event(
         ERROR_ACCESS_DENIED => {
             // ReadDirectoryChangesW returns ERROR_ACCESS_DENIED both when the handle
             // has been invalidated (usually because the watched dir was deleted) and
-            // when access has been revoked; use dir existence to tell which. For
-            // directory watches, emit a Remove event so consumers learn the watched
-            // path is gone, matching inotify IN_DELETE_SELF (#540) and FSEvents
-            // ROOT_CHANGED+ITEM_REMOVED. File watches are excluded because
+            // when access has been revoked; use successful dir absence to tell which.
+            // For directory watches, emit a Remove event so consumers learn the
+            // watched path is gone, matching inotify IN_DELETE_SELF (#540) and
+            // FSEvents ROOT_CHANGED+ITEM_REMOVED. File watches are excluded because
             // FILE_ACTION_REMOVED already fires for the file's parent.
-            if !request.data.dir.exists() {
+            if matches!(request.data.dir.try_exists(), Ok(false)) {
                 if request.data.file.is_none() {
                     const KIND: EventKind = EventKind::Remove(RemoveKind::Folder);
                     if request.event_kinds.matches(&KIND) {
@@ -820,7 +820,7 @@ pub mod tests {
     use std::os::windows::ffi::OsStringExt;
     use std::path::{Path, PathBuf};
     use std::sync::atomic::{AtomicBool, Ordering};
-    use std::sync::{mpsc, Arc};
+    use std::sync::{mpsc, Arc, Mutex};
     use std::thread;
     use tempfile::{tempdir, tempdir_in};
 
@@ -921,6 +921,52 @@ pub mod tests {
         let path = PathBuf::from(r"\\?\C:\very\long\file");
         let normalized = normalize_path_separators(path, SeparatorStyle::Slash);
         assert_eq!(normalized, PathBuf::from(r"\\?\C:/very/long/file"));
+    }
+
+    #[test]
+    fn access_denied_existence_error_does_not_emit_remove() {
+        use std::ptr;
+        use windows_sys::Win32::Foundation::{
+            CloseHandle, ERROR_ACCESS_DENIED, INVALID_HANDLE_VALUE,
+        };
+        use windows_sys::Win32::System::Threading::CreateSemaphoreW;
+        use windows_sys::Win32::System::IO::OVERLAPPED;
+
+        let invalid_path = PathBuf::from(OsString::from_wide(&[0]));
+        assert!(invalid_path.try_exists().is_err());
+
+        let complete_sem = unsafe { CreateSemaphoreW(ptr::null_mut(), 0, 1, ptr::null_mut()) };
+        assert!(!complete_sem.is_null());
+        assert_ne!(complete_sem, INVALID_HANDLE_VALUE);
+
+        let (event_tx, event_rx) = mpsc::channel();
+        let (action_tx, action_rx) = crate::unbounded();
+        let event_handler: Arc<Mutex<dyn crate::EventHandler>> = Arc::new(Mutex::new(event_tx));
+        let request = Box::new(super::ReadDirectoryRequest {
+            event_handler,
+            event_kinds: crate::EventKindMask::ALL,
+            buffer: [0u8; super::BUF_SIZE as usize],
+            handle: INVALID_HANDLE_VALUE,
+            data: super::ReadData {
+                dir: invalid_path.clone(),
+                reported_dir: invalid_path,
+                file: None,
+                complete_sem,
+                is_recursive: false,
+                separator_style: SeparatorStyle::Backslash,
+            },
+            action_tx,
+        });
+        let mut overlapped = Box::new(unsafe { std::mem::zeroed::<OVERLAPPED>() });
+        overlapped.hEvent = Box::into_raw(request) as _;
+
+        unsafe {
+            super::handle_event(ERROR_ACCESS_DENIED, 0, Box::into_raw(overlapped));
+            CloseHandle(complete_sem);
+        }
+
+        assert!(event_rx.try_recv().is_err());
+        assert!(action_rx.try_recv().is_err());
     }
 
     #[test]


### PR DESCRIPTION
## Description

When a watched directory is deleted on Windows, no `Remove` event is currently emitted even though it would be on macOS and Linux. This is because [`ReadDirectoryChangesW`](https://learn.microsoft.com/en-us/windows/win32/api/winbase/nf-winbase-readdirectorychangesw) returns `ERROR_ACCESS_DENIED` when a watched directory is deleted, and the existing handler (PR #674) silently unwatches (without emitting any event to the consumer).

This PR makes the Windows backend match the behavior of inotify (`IN_DELETE_SELF` from PR #540) and FSEvents (`ROOT_CHANGED` + `ITEM_REMOVED`), which both emit a `Remove` event when their watched root disappears. The new Windows event is only emitted for directory watches the user explicitly asked for; it excludes file watches because `FILE_ACTION_REMOVED` already fires when a non-directory file is deleted. This also adds a new `delete_self_dir` test for each backend's test module.

## Related Issues

None, but I can open an issue to report the current discrepancy if it would help!