### PR TITLE
perf(notify): avoid filesystem walks for recursive kqueue unwatch

### DIFF
--- a/notify/CHANGELOG.md
+++ b/notify/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - FIX: [windows] emit a Remove event when a watched directory is deleted, matching inotify and FSEvents
 - CHANGE: [macOS] improve FSEvents callback performance by avoiding unnecessary allocations and repeated handler locking
+- PERF: [kqueue] avoid filesystem walks for recursive kqueue unwatch
 
 ## notify 9.0.0-rc.4 (2026-05-02)
 
@@ -11,7 +12,6 @@
 - FIX: [kqueue] stop reporting arbitrary existing child paths for non-recursive directory write events [#644]
 - FIX: replace an existing watch when `watch` is called again for the same path, avoiding duplicate FSEvent paths and leaked Windows watch handles [#708]
 - DOCS: define `Watcher::watch` replacement behavior for an existing backend-resolved path [#708]
-- PERF: [kqueue] avoid filesystem walks for recursive kqueue unwatch
 
 ## notify 9.0.0-rc.3 (2026-04-16)
 

--- a/notify/CHANGELOG.md
+++ b/notify/CHANGELOG.md
@@ -11,6 +11,7 @@
 - FIX: [kqueue] stop reporting arbitrary existing child paths for non-recursive directory write events [#644]
 - FIX: replace an existing watch when `watch` is called again for the same path, avoiding duplicate FSEvent paths and leaked Windows watch handles [#708]
 - DOCS: define `Watcher::watch` replacement behavior for an existing backend-resolved path [#708]
+- PERF: [kqueue] avoid filesystem walks for recursive kqueue unwatch
 
 ## notify 9.0.0-rc.3 (2026-04-16)
 

--- a/notify/src/kqueue.rs
+++ b/notify/src/kqueue.rs
@@ -489,26 +489,30 @@ impl EventLoop {
             None => return Err(Error::watch_not_found()),
             Some(watch) => {
                 if watch.is_recursive || remove_recursive {
+                    self.kqueue
+                        .remove_filename(&path, EventFilter::EVFILT_VNODE)
+                        .map_err(|e| Error::io(e).add_path(path.clone()))?;
+
+                    let mut remove_list = Vec::new();
                     let mut reset_list = Vec::new();
-                    for entry in WalkDir::new(path.clone())
-                        .follow_links(self.follow_symlinks)
-                        .into_iter()
-                    {
-                        let p = entry.map_err(map_walkdir_error)?.into_path();
-                        if let Some(user_is_recursive) = preserved_watch_mode(&p, &preserved_roots)
-                        {
-                            if !user_is_recursive || is_preserved_watch_root(&p, &preserved_roots) {
-                                reset_list.push(p);
+                    for p in self.watches.keys().filter(|p| p.starts_with(&path)) {
+                        if let Some(user_is_recursive) = preserved_watch_mode(p, &preserved_roots) {
+                            if !user_is_recursive || is_preserved_watch_root(p, &preserved_roots) {
+                                reset_list.push(p.clone());
                             }
                             continue;
                         }
 
+                        remove_list.push(p.clone());
+                    }
+
+                    for p in &remove_list {
                         self.kqueue
-                            .remove_filename(&p, EventFilter::EVFILT_VNODE)
+                            .remove_filename(p, EventFilter::EVFILT_VNODE)
                             .map_err(|e| Error::io(e).add_path(p.clone()))?;
-                        if p != path {
-                            self.watches.remove(&p);
-                        }
+                    }
+                    for p in remove_list {
+                        self.watches.remove(&p);
                     }
                     for p in reset_list {
                         if let Some(watch) = self.watches.get_mut(&p) {
@@ -694,6 +698,27 @@ mod tests {
             .collect();
         assert_eq!(watched.get(dir.path()), Some(&true));
         assert_eq!(watched.get(&child), Some(&false));
+
+        Ok(())
+    }
+
+    #[test]
+    fn recursive_remove_uses_tracked_watches() -> std::result::Result<(), Box<dyn std::error::Error>>
+    {
+        let dir = tempfile::tempdir()?;
+        let child = dir.path().join("child");
+        std::fs::write(&child, "")?;
+
+        let kqueue = kqueue::Watcher::new()?;
+        let mut event_loop = EventLoop::new(kqueue, Box::new(|_| {}), false, EventKindMask::ALL)?;
+
+        event_loop.add_watch(WatchPath::new(dir.path())?, true, true)?;
+        assert!(event_loop.watches.contains_key(&child));
+
+        std::fs::remove_file(&child)?;
+        event_loop.remove_watch(dir.path().to_path_buf(), false)?;
+
+        assert!(!event_loop.watches.contains_key(&child));
 
         Ok(())
     }


### PR DESCRIPTION
<!-- 
## Contribution Agreement
By contributing, you agree to the license terms (CC Zero 1.0 for notify crate, MIT/Apache 2.0 for the rest) and the code of conduct in CODE_OF_CONDUCT.md.

## Changelog
Add an entry to CHANGELOG.md if applicable. Create a new section `## notify (unreleased)` if not already present.

## Testing
The test suite will run after creating this PR. If builds fail, you must either fix the errors, ask for help, or provide a detailed explanation of why failures are expected. If you don't, a maintainer may prompt you, but it will take longer for your contribution to be reviewed.

## Code Quality
Running `cargo fmt` and `cargo clippy` is appreciated but not required.

You can delete this comment after reading.
-->

## Description
<!-- Describe your changes here -->

This avoids extra filesystem traversal during recursive unwatch and also handles stale tracked descendants when files were already deleted before the root is unwatched.

simple benchmarks:

- Flat files: `1.94-1.98ms` -> `1.73-1.76ms` median, about `10-13%` faster
- Flat dirs: `11.99-13.84ms` -> `1.65-1.68ms` median, about `7.1-8.4x` faster

## Related Issues
<!-- Link any related issues -->
