### PR TITLE
feat(notify): make FSEvents stream latency configurable

### DIFF
--- a/notify/CHANGELOG.md
+++ b/notify/CHANGELOG.md
@@ -2,9 +2,12 @@
 
 ## unreleased
 
+- FEATURE: [macOS] add `Config::with_fsevent_latency` to configure FSEvents stream latency [#930]
 - FIX: [windows] emit a Remove event when a watched directory is deleted, matching inotify and FSEvents
 - CHANGE: [macOS] improve FSEvents callback performance by avoiding unnecessary allocations and repeated handler locking
 - PERF: [kqueue] avoid filesystem walks for recursive kqueue unwatch
+
+[#930]: https://github.com/notify-rs/notify/pull/930
 
 ## notify 9.0.0-rc.4 (2026-05-02)
 

--- a/notify/src/config.rs
+++ b/notify/src/config.rs
@@ -73,6 +73,9 @@ pub struct Config {
 
     /// See [Config::with_windows_path_separator_style]
     windows_path_separator_style: WindowsPathSeparatorStyle,
+
+    /// See [Config::with_fsevent_latency]
+    fsevent_latency: Duration,
 }
 
 impl Config {
@@ -206,6 +209,32 @@ impl Config {
     pub fn windows_path_separator_style(&self) -> WindowsPathSeparatorStyle {
         self.windows_path_separator_style
     }
+
+    /// For the [`FsEventWatcher`](crate::FsEventWatcher) backend.
+    ///
+    /// The latency passed to `FSEventStreamCreate`: how long the FSEvents service waits
+    /// after hearing about an event from the kernel before invoking the callback. A larger
+    /// value lets the system coalesce bursts of changes into fewer callbacks at the cost of
+    /// higher delivery latency.
+    ///
+    /// This watcher is created with `kFSEventStreamCreateFlagNoDefer`, so the first event in
+    /// an idle period is delivered immediately; only subsequent events get coalesced within
+    /// the latency window.
+    ///
+    /// The default is [`Duration::ZERO`].
+    ///
+    /// This can't be changed during runtime.
+    #[must_use]
+    pub fn with_fsevent_latency(mut self, latency: Duration) -> Self {
+        self.fsevent_latency = latency;
+        self
+    }
+
+    /// Returns current setting
+    #[must_use]
+    pub fn fsevent_latency(&self) -> Duration {
+        self.fsevent_latency
+    }
 }
 
 impl Default for Config {
@@ -216,6 +245,7 @@ impl Default for Config {
             follow_symlinks: true,
             event_kinds: EventKindMask::ALL,
             windows_path_separator_style: WindowsPathSeparatorStyle::Auto,
+            fsevent_latency: Duration::ZERO,
         }
     }
 }
@@ -357,5 +387,17 @@ mod tests {
             config.windows_path_separator_style(),
             WindowsPathSeparatorStyle::Slash
         );
+    }
+
+    #[test]
+    fn config_default_fsevent_latency_is_zero() {
+        assert_eq!(Config::default().fsevent_latency(), Duration::ZERO);
+    }
+
+    #[test]
+    fn config_with_fsevent_latency() {
+        let latency = Duration::from_millis(250);
+        let config = Config::default().with_fsevent_latency(latency);
+        assert_eq!(config.fsevent_latency(), latency);
     }
 }

--- a/notify/src/fsevent.rs
+++ b/notify/src/fsevent.rs
@@ -339,11 +339,12 @@ impl FsEventWatcher {
     fn from_event_handler(
         event_handler: Arc<Mutex<dyn EventHandler>>,
         event_kinds: EventKindMask,
+        latency: cf::CFTimeInterval,
     ) -> Result<Self> {
         Ok(FsEventWatcher {
             paths: cf::CFMutableArray::empty(),
             since_when: fs::kFSEventStreamEventIdSinceNow,
-            latency: 0.0,
+            latency,
             flags: fs::kFSEventStreamCreateFlagFileEvents
                 | fs::kFSEventStreamCreateFlagNoDefer
                 | fs::kFSEventStreamCreateFlagWatchRoot,
@@ -768,7 +769,11 @@ unsafe fn callback_impl(
 impl Watcher for FsEventWatcher {
     /// Create a new watcher.
     fn new<F: EventHandler>(event_handler: F, config: Config) -> Result<Self> {
-        Self::from_event_handler(Arc::new(Mutex::new(event_handler)), config.event_kinds())
+        Self::from_event_handler(
+            Arc::new(Mutex::new(event_handler)),
+            config.event_kinds(),
+            config.fsevent_latency().as_secs_f64(),
+        )
     }
 
     fn watch(&mut self, path: &Path, recursive_mode: RecursiveMode) -> Result<()> {


### PR DESCRIPTION
Adds Config::with_fsevent_latency to control the latency passed to FSEventStreamCreate. Defaults to Duration::ZERO, preserving current behavior. Set at construction time only.