### PR TITLE
Add `watch_filtered`, filtering paths to watch

### DIFF
--- a/docs/UPGRADING_V8_TO_V9.md
+++ b/docs/UPGRADING_V8_TO_V9.md
@@ -104,6 +104,57 @@ watcher.watch(path, notify::RecursiveMode::NonRecursive)?;
 watcher.unwatch(path)?;
 ```
 
+### 5) `Watcher::watch_filtered` is the required trait method
+
+v9 adds `Watcher::watch_filtered(path, recursive_mode, watch_filter)`, which excludes
+directories rejected by a `WatchFilter` from the watch. It is now the required method of the
+`Watcher` trait; `Watcher::watch` is a provided method that forwards to it with
+`WatchFilter::accept_all()`.
+
+Users of `Watcher` are unaffected: `watch` keeps working unchanged. Implementors of the trait
+must rename their `watch` implementation to `watch_filtered` and accept the extra parameter.
+
+The filter gates directories only: watching a non-directory path must never be affected by
+it. Two restrictions keep the semantics simple, and implementations must enforce both by
+returning an error while leaving all watches unchanged:
+
+- Watching a directory the filter itself rejects returns `ErrorKind::PathExcluded`. A root
+  that is a symlink to a directory is checked against both the link path and its resolved
+  target. `WatchFilter::rejects_root` implements the basic root check for already-resolved
+  paths; backends that accept symlink paths must also check the resolved target.
+- A directory watch carrying a filter must not overlap another directory watch in either
+  direction (filters cannot be merged across watches). Watches whose filters are all
+  `WatchFilter::accept_all` may overlap as before, and file watches never conflict.
+
+Before (v8):
+
+```rust
+impl Watcher for MyWatcher {
+    fn watch(&mut self, path: &Path, recursive_mode: RecursiveMode) -> notify::Result<()> {
+        // ...
+    }
+    // ...
+}
+```
+
+After (v9):
+
+```rust
+impl Watcher for MyWatcher {
+    fn watch_filtered(
+        &mut self,
+        path: &Path,
+        recursive_mode: RecursiveMode,
+        watch_filter: notify::WatchFilter,
+    ) -> notify::Result<()> {
+        // Gate directories on the filter, e.g. via watch_filter.rejects_root(...) for the
+        // root and watch_filter.should_watch(...) for directories discovered while scanning.
+        // ...
+    }
+    // ...
+}
+```
+
 ## Non-breaking changes but worth mentioning
 
 ### Event-kind filtering was added

--- a/notify-debouncer-full/CHANGELOG.md
+++ b/notify-debouncer-full/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## unreleased
 
+- FEATURE: add `Debouncer::watch_filtered`, forwarding notify's new `WatchFilter` support; errors from the inner watcher (e.g. `PathExcluded` for a rejected root) propagate to the caller, and a failed `watch_filtered` or `unwatch` leaves the debouncer's bookkeeping untouched
+- CHANGE: `FileIdCache::add_path` and `FileIdCache::rescan` now receive the watch's `WatchFilter`, so caches do not walk or fingerprint excluded directories; custom `FileIdCache` implementations must be updated **breaking**
 - PERF: park the debouncer thread to avoid idle polling [#933]
 
 [#933]: https://github.com/notify-rs/notify/pull/933

--- a/notify-debouncer-full/src/cache.rs
+++ b/notify-debouncer-full/src/cache.rs
@@ -1,5 +1,5 @@
 use file_id::FileId;
-use notify::RecursiveMode;
+use notify::{RecursiveMode, WatchFilter};
 use std::path::{Path, PathBuf};
 
 /// The interface of a file ID cache.
@@ -14,7 +14,16 @@ pub trait FileIdCache {
     /// Add a new path to the cache or update its value.
     ///
     /// This will be called if a new file or directory is created or if an existing file is overridden.
-    fn add_path(&mut self, path: &Path, recursive_mode: RecursiveMode);
+    ///
+    /// `watch_filter` gates directories the same way it does for the watch itself:
+    /// implementations should not descend into directories the filter rejects, since events
+    /// beneath them are suppressed and cached entries could never be invalidated. A rejected
+    /// directory's own ID should still be cached: its own events are delivered by its watched
+    /// parent and rename stitching needs the ID. The documented `WatchFilter` contract passes
+    /// backend-resolved absolute paths, so implementations should evaluate the filter against
+    /// absolutized paths even when `path` is relative; absolutization only approximates the
+    /// canonical form the macOS backends resolve to (known limitation).
+    fn add_path(&mut self, path: &Path, recursive_mode: RecursiveMode, watch_filter: &WatchFilter);
 
     /// Remove a path from the cache.
     ///
@@ -25,11 +34,13 @@ pub trait FileIdCache {
     ///
     /// This will be called if the notification back-end has dropped events.
     /// The root paths are passed as argument, so the implementer doesn't have to store them.
+    /// Each root carries the `WatchFilter` it was watched with; implementations must honor it
+    /// the same way `add_path` does and not walk excluded directories.
     ///
     /// The default implementation calls `add_path` for each root path.
-    fn rescan(&mut self, root_paths: &[(PathBuf, RecursiveMode)]) {
-        for (path, recursive_mode) in root_paths {
-            self.add_path(path, *recursive_mode);
+    fn rescan(&mut self, root_paths: &[(PathBuf, RecursiveMode, WatchFilter)]) {
+        for (path, recursive_mode, watch_filter) in root_paths {
+            self.add_path(path, *recursive_mode, watch_filter);
         }
     }
 }
@@ -53,7 +64,13 @@ impl FileIdCache for NoCache {
         Option::<&FileId>::None
     }
 
-    fn add_path(&mut self, _path: &Path, _recursive_mode: RecursiveMode) {}
+    fn add_path(
+        &mut self,
+        _path: &Path,
+        _recursive_mode: RecursiveMode,
+        _watch_filter: &WatchFilter,
+    ) {
+    }
 
     fn remove_path(&mut self, _path: &Path) {}
 }

--- a/notify-debouncer-full/src/file_id_map.rs
+++ b/notify-debouncer-full/src/file_id_map.rs
@@ -1,6 +1,6 @@
 use crate::FileIdCache;
 use file_id::{get_file_id, FileId};
-use notify::RecursiveMode;
+use notify::{RecursiveMode, WatchFilter};
 use rustc_hash::FxHashMap as HashMap;
 use std::path::{Path, PathBuf};
 use walkdir::WalkDir;
@@ -35,24 +35,112 @@ impl FileIdCache for FileIdMap {
         self.paths.get(path)
     }
 
-    fn add_path(&mut self, path: &Path, recursive_mode: RecursiveMode) {
+    fn add_path(&mut self, path: &Path, recursive_mode: RecursiveMode, watch_filter: &WatchFilter) {
         let is_recursive = recursive_mode == RecursiveMode::Recursive;
 
-        for (path, file_id) in WalkDir::new(path)
+        // The filter receives backend-resolved absolute paths, so evaluate it on an
+        // absolutized mirror of each entry while keeping the cache keyed by the walked
+        // form: lookups use delivered event paths in that form. Absolutization only
+        // approximates the canonical form the macOS backends resolve to (known limitation).
+        let absolute_root = std::path::absolute(path).unwrap_or_else(|_| path.to_path_buf());
+
+        let mut it = WalkDir::new(path)
             .follow_links(true)
             .max_depth(Self::dir_scan_depth(is_recursive))
-            .into_iter()
-            .filter_map(|entry| {
-                let path = entry.ok()?.into_path();
-                let file_id = get_file_id(&path).ok()?;
-                Some((path, file_id))
-            })
-        {
-            self.paths.insert(path, file_id);
+            .into_iter();
+        while let Some(entry) = it.next() {
+            let Ok(entry) = entry else { continue };
+
+            if entry.file_type().is_dir() && !watch_filter.is_accept_all() {
+                let absolute =
+                    absolute_root.join(entry.path().strip_prefix(path).unwrap_or(entry.path()));
+                let mut allowed = watch_filter.should_watch(&absolute);
+                if allowed && entry.path_is_symlink() {
+                    // file_type() follows the link, but path() is the link side; check the
+                    // target too so name-based exclusions cannot be bypassed via symlinks.
+                    if let Ok(target) = std::fs::canonicalize(entry.path()) {
+                        allowed = watch_filter.should_watch(&target);
+                    }
+                }
+                if !allowed {
+                    // Cache the excluded directory's own ID (its own events are still
+                    // delivered by its watched parent, and rename stitching needs it)
+                    // but never descend: events beneath it are suppressed, so cached
+                    // entries there could never be invalidated.
+                    it.skip_current_dir();
+                }
+            }
+
+            if let Ok(file_id) = get_file_id(entry.path()) {
+                self.paths.insert(entry.into_path(), file_id);
+            }
         }
     }
 
     fn remove_path(&mut self, path: &Path) {
         self.paths.retain(|p, _| !p.starts_with(path));
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+
+    #[test]
+    fn add_path_caches_excluded_directory_own_id() {
+        let tempdir = tempfile::tempdir().unwrap();
+        let excluded = tempdir.path().join("excluded");
+        fs::create_dir(&excluded).unwrap();
+        let excluded_file = excluded.join("file.txt");
+        fs::write(&excluded_file, b"content").unwrap();
+
+        let watch_filter = WatchFilter::with_filter(|p: &Path| {
+            p.file_name() != Some(std::ffi::OsStr::new("excluded"))
+        });
+
+        let mut cache = FileIdMap::new();
+        cache.add_path(&excluded, RecursiveMode::Recursive, &watch_filter);
+
+        // The excluded directory's own events are still delivered by its watched parent
+        // and rename stitching needs its ID; nothing beneath it may be fingerprinted.
+        assert!(cache.cached_file_id(&excluded).is_some());
+        assert!(cache.cached_file_id(&excluded_file).is_none());
+    }
+
+    #[test]
+    fn add_path_evaluates_filter_on_absolutized_paths() {
+        // Use a tempdir inside the current directory so a genuinely relative path can be
+        // walked without touching the process-global working directory.
+        let cwd = std::env::current_dir().unwrap();
+        let tempdir = tempfile::tempdir_in(&cwd).unwrap();
+        let relative = PathBuf::from(tempdir.path().file_name().unwrap());
+
+        let excluded = tempdir.path().join("excluded");
+        fs::create_dir(&excluded).unwrap();
+        fs::write(excluded.join("file.txt"), b"content").unwrap();
+        fs::write(tempdir.path().join("visible.txt"), b"content").unwrap();
+
+        // The filter matches on the absolute form only; it must still prune the walk of
+        // the relative form.
+        let absolute_excluded = cwd.join(&relative).join("excluded");
+        let watch_filter =
+            WatchFilter::with_filter(move |p: &Path| !p.starts_with(&absolute_excluded));
+
+        let mut cache = FileIdMap::new();
+        cache.add_path(&relative, RecursiveMode::Recursive, &watch_filter);
+
+        // Cache keys keep the walked (relative) form, since lookups use delivered event
+        // paths in that form.
+        assert!(cache
+            .cached_file_id(&relative.join("visible.txt"))
+            .is_some());
+        assert!(cache
+            .cached_file_id(&tempdir.path().join("visible.txt"))
+            .is_none());
+        assert!(cache.cached_file_id(&relative.join("excluded")).is_some());
+        assert!(cache
+            .cached_file_id(&relative.join("excluded").join("file.txt"))
+            .is_none());
     }
 }

--- a/notify-debouncer-full/src/lib.rs
+++ b/notify-debouncer-full/src/lib.rs
@@ -97,7 +97,7 @@ use file_id::FileId;
 use notify::{
     event::{ModifyKind, RemoveKind, RenameMode},
     Error, ErrorKind, Event, EventKind, PathOp, RecommendedWatcher, RecursiveMode,
-    UpdatePathsError, Watcher, WatcherKind,
+    UpdatePathsError, WatchFilter, Watcher, WatcherKind,
 };
 
 /// The set of requirements for watcher debounce event handling functions.
@@ -214,7 +214,7 @@ pub(crate) struct DebounceDataInner<T> {
     queues: HashMap<PathBuf, Queue>,
     /// Registered watch roots, kept **sorted by path** so that `add_root`
     /// can dedupe via binary search in O(log N) and doesn't suffer from injection
-    roots: VecDeque<(PathBuf, RecursiveMode)>,
+    roots: VecDeque<(PathBuf, RecursiveMode, WatchFilter)>,
     cache: T,
     rename_event: Option<(DebouncedEvent, Option<FileId>)>,
     rescan_event: Option<DebouncedEvent>,
@@ -313,9 +313,9 @@ impl<T: FileIdCache> DebounceDataInner<T> {
 
         match &event.kind {
             EventKind::Create(_) => {
-                let recursive_mode = self.recursive_mode(path);
+                let (recursive_mode, watch_filter) = self.coverage_for(path);
 
-                self.cache.add_path(path, recursive_mode);
+                self.cache.add_path(path, recursive_mode, &watch_filter);
 
                 self.push_event(event, now());
             }
@@ -350,9 +350,9 @@ impl<T: FileIdCache> DebounceDataInner<T> {
             }
             _ => {
                 if self.cache.cached_file_id(path).is_none() {
-                    let recursive_mode = self.recursive_mode(path);
+                    let (recursive_mode, watch_filter) = self.coverage_for(path);
 
-                    self.cache.add_path(path, recursive_mode);
+                    self.cache.add_path(path, recursive_mode, &watch_filter);
                 }
 
                 self.push_event(event, now());
@@ -360,19 +360,49 @@ impl<T: FileIdCache> DebounceDataInner<T> {
         }
     }
 
-    fn recursive_mode(&self, path: &Path) -> RecursiveMode {
-        for ancestor in path.ancestors() {
+    /// The effective coverage of `path` across the registered roots: the recursive mode
+    /// and the filter of the covering watches, used when re-adding event paths to the file
+    /// ID cache. A recursive root covers its whole subtree; a non-recursive root covers
+    /// only itself and its direct children. The backends' overlap barrier guarantees at
+    /// most one covering root carries a real filter, so that root's filter is used as-is;
+    /// otherwise the result is accept-all. A third-party watcher without the barrier
+    /// degrades to whichever filtered covering root is found.
+    fn coverage_for(&self, path: &Path) -> (RecursiveMode, WatchFilter) {
+        let mut recursive = false;
+        let mut filter: Option<WatchFilter> = None;
+
+        for (depth, ancestor) in path.ancestors().enumerate() {
             if let Ok(index) = self
                 .roots
-                .binary_search_by(|(root, _)| root.as_path().cmp(ancestor))
+                .binary_search_by(|(root, _, _)| root.as_path().cmp(ancestor))
             {
-                if self.roots[index].1 == RecursiveMode::Recursive {
-                    return RecursiveMode::Recursive;
+                let (_, recursive_mode, watch_filter) = &self.roots[index];
+                let covers = match recursive_mode {
+                    RecursiveMode::Recursive => true,
+                    // A non-recursive root only spans itself (depth 0) and its direct
+                    // children (depth 1); deeper roots do not cover `path` at all.
+                    RecursiveMode::NonRecursive => depth <= 1,
+                };
+                if !covers {
+                    continue;
+                }
+                if *recursive_mode == RecursiveMode::Recursive {
+                    recursive = true;
+                }
+                if filter.is_none() && !watch_filter.is_accept_all() {
+                    filter = Some(watch_filter.clone());
                 }
             }
         }
 
-        RecursiveMode::NonRecursive
+        (
+            if recursive {
+                RecursiveMode::Recursive
+            } else {
+                RecursiveMode::NonRecursive
+            },
+            filter.unwrap_or_else(WatchFilter::accept_all),
+        )
     }
 
     fn handle_rename_from(&mut self, event: Event) {
@@ -389,9 +419,10 @@ impl<T: FileIdCache> DebounceDataInner<T> {
     }
 
     fn handle_rename_to(&mut self, event: Event) {
-        let recursive_mode = self.recursive_mode(&event.paths[0]);
+        let (recursive_mode, watch_filter) = self.coverage_for(&event.paths[0]);
 
-        self.cache.add_path(&event.paths[0], recursive_mode);
+        self.cache
+            .add_path(&event.paths[0], recursive_mode, &watch_filter);
 
         let trackers_match = self
             .rename_event
@@ -593,31 +624,59 @@ impl<T: Watcher, C: FileIdCache> Debouncer<T, C> {
     #[deprecated = "`Debouncer` now manages root paths automatically. Remove all calls to `add_root` and `remove_root`."]
     pub fn cache(&mut self) {}
 
-    fn add_root(&mut self, path: impl Into<PathBuf>, recursive_mode: RecursiveMode) {
+    fn add_root(
+        &mut self,
+        path: impl Into<PathBuf>,
+        recursive_mode: RecursiveMode,
+        watch_filter: WatchFilter,
+    ) {
         let path = path.into();
 
         let mut data = self.data.inner.lock().unwrap();
 
         match data
             .roots
-            .binary_search_by(|(p, _)| p.as_path().cmp(path.as_path()))
+            .binary_search_by(|(p, _, _)| p.as_path().cmp(path.as_path()))
         {
-            Ok(_) => return, // already registered
+            Ok(pos) => {
+                // Rewatching with an unchanged mode and filter leaves the backend's watch
+                // as-is, so skip the re-fingerprint: it's a full walk under the data mutex
+                // that would block event ingestion and delivery for nothing.
+                let (_, current_mode, current_filter) = &data.roots[pos];
+                if *current_mode == recursive_mode && current_filter.same_filter(&watch_filter) {
+                    return;
+                }
+                // Rewatch: the backend replaced the watch, so replace the recorded mode and
+                // filter too and refresh the cache under the new filter.
+                data.roots[pos] = (path.clone(), recursive_mode, watch_filter.clone());
+            }
             Err(pos) => {
                 // `VecDeque::insert` is O(min(pos, len - pos))
-                data.roots.insert(pos, (path.clone(), recursive_mode));
+                data.roots
+                    .insert(pos, (path.clone(), recursive_mode, watch_filter.clone()));
             }
         }
 
-        data.cache.add_path(&path, recursive_mode);
+        data.cache.add_path(&path, recursive_mode, &watch_filter);
     }
 
     fn remove_root(&mut self, path: impl AsRef<Path>) {
         let mut data = self.data.inner.lock().unwrap();
+        let path = path.as_ref();
 
-        data.roots.retain(|(root, _)| !root.starts_with(&path));
+        let surviving_nested_roots: Vec<_> = data
+            .roots
+            .iter()
+            .filter(|(root, _, _)| root.starts_with(path) && root.as_path() != path)
+            .cloned()
+            .collect();
 
-        data.cache.remove_path(path.as_ref());
+        data.roots.retain(|(root, _, _)| root.as_path() != path);
+
+        data.cache.remove_path(path);
+        for (root, recursive_mode, watch_filter) in surviving_nested_roots {
+            data.cache.add_path(&root, recursive_mode, &watch_filter);
+        }
     }
 
     pub fn watch(
@@ -625,8 +684,21 @@ impl<T: Watcher, C: FileIdCache> Debouncer<T, C> {
         path: impl AsRef<Path>,
         recursive_mode: RecursiveMode,
     ) -> notify::Result<()> {
-        self.watcher.watch(path.as_ref(), recursive_mode)?;
-        self.add_root(path.as_ref(), recursive_mode);
+        self.watch_filtered(path, recursive_mode, WatchFilter::accept_all())
+    }
+
+    /// Begin watching a new path, excluding directories rejected by `watch_filter`.
+    ///
+    /// See [`Watcher::watch_filtered`] for the filter semantics.
+    pub fn watch_filtered(
+        &mut self,
+        path: impl AsRef<Path>,
+        recursive_mode: RecursiveMode,
+        watch_filter: notify::WatchFilter,
+    ) -> notify::Result<()> {
+        self.watcher
+            .watch_filtered(path.as_ref(), recursive_mode, watch_filter.clone())?;
+        self.add_root(path.as_ref(), recursive_mode, watch_filter);
         Ok(())
     }
 
@@ -673,6 +745,9 @@ impl<T: Watcher, C: FileIdCache> Debouncer<T, C> {
     /// # Ok(())
     /// # }
     /// ```
+    // The error intentionally carries the failed and unapplied `PathOp`s back to the caller,
+    // which makes it larger than clippy's default threshold.
+    #[allow(clippy::result_large_err)]
     pub fn update_paths<Op: Into<PathOp>>(
         &mut self,
         ops: impl IntoIterator<Item = Op>,
@@ -685,7 +760,9 @@ impl<T: Watcher, C: FileIdCache> Debouncer<T, C> {
                 paths.push((
                     op.as_path().to_path_buf(),
                     match op {
-                        PathOp::Watch(_, config) => Some(config.recursive_mode()),
+                        PathOp::Watch(_, config) => {
+                            Some((config.recursive_mode(), config.watch_filter()))
+                        }
                         PathOp::Unwatch(_) => None,
                     },
                 ));
@@ -703,7 +780,9 @@ impl<T: Watcher, C: FileIdCache> Debouncer<T, C> {
         let updated_paths = &paths[..updated_len];
         for (path, watch_mode) in updated_paths {
             match watch_mode {
-                Some(recursive_mode) => self.add_root(path, *recursive_mode),
+                Some((recursive_mode, watch_filter)) => {
+                    self.add_root(path, *recursive_mode, watch_filter.clone());
+                }
                 None => self.remove_root(path),
             }
         }
@@ -924,7 +1003,12 @@ mod tests {
             })
         }
 
-        fn watch(&mut self, path: &Path, _recursive_mode: RecursiveMode) -> notify::Result<()> {
+        fn watch_filtered(
+            &mut self,
+            path: &Path,
+            _recursive_mode: RecursiveMode,
+            _watch_filter: notify::WatchFilter,
+        ) -> notify::Result<()> {
             if path == self.fail_path {
                 Err(Error::path_not_found())
             } else {
@@ -948,6 +1032,7 @@ mod tests {
     #[derive(Debug, Default)]
     struct TrackingWatcher {
         watched: Vec<(PathBuf, RecursiveMode)>,
+        last_filter: Option<notify::WatchFilter>,
     }
 
     impl Watcher for TrackingWatcher {
@@ -958,7 +1043,20 @@ mod tests {
             Ok(Self::default())
         }
 
-        fn watch(&mut self, path: &Path, recursive_mode: RecursiveMode) -> notify::Result<()> {
+        fn watch_filtered(
+            &mut self,
+            path: &Path,
+            recursive_mode: RecursiveMode,
+            watch_filter: notify::WatchFilter,
+        ) -> notify::Result<()> {
+            // Mirror the real backends' contract: watching a directory root the filter
+            // rejects fails with `PathExcluded` and changes nothing.
+            let absolute = std::path::absolute(path).unwrap_or_else(|_| path.to_path_buf());
+            if watch_filter.rejects_root(&absolute, path.is_dir()) {
+                return Err(Error::path_excluded());
+            }
+            self.last_filter = Some(watch_filter);
+            self.watched.retain(|(watched, _)| watched != path);
             self.watched.push((path.to_path_buf(), recursive_mode));
             Ok(())
         }
@@ -1039,7 +1137,11 @@ mod tests {
         MockTime::set_time(time);
 
         let mut state = test_case.state.into_debounce_data_inner(time);
-        state.roots = VecDeque::from([(PathBuf::from("/"), RecursiveMode::Recursive)]);
+        state.roots = VecDeque::from([(
+            PathBuf::from("/"),
+            RecursiveMode::Recursive,
+            WatchFilter::accept_all(),
+        )]);
 
         let mut prev_event_time = Duration::default();
 
@@ -1121,12 +1223,20 @@ mod tests {
     }
 
     #[test]
-    fn recursive_mode_uses_recursive_root_for_overlapping_watches() {
+    fn coverage_for_uses_recursive_root_for_overlapping_watches() {
         let state = DebounceDataInner {
             queues: HashMap::default(),
             roots: VecDeque::from([
-                (PathBuf::from("root"), RecursiveMode::NonRecursive),
-                (PathBuf::from("root/nested"), RecursiveMode::Recursive),
+                (
+                    PathBuf::from("root"),
+                    RecursiveMode::NonRecursive,
+                    WatchFilter::accept_all(),
+                ),
+                (
+                    PathBuf::from("root/nested"),
+                    RecursiveMode::Recursive,
+                    WatchFilter::accept_all(),
+                ),
             ]),
             cache: NoCache,
             rename_event: None,
@@ -1136,13 +1246,46 @@ mod tests {
         };
 
         assert_eq!(
-            state.recursive_mode(Path::new("root/nested/child")),
+            state.coverage_for(Path::new("root/nested/child")).0,
             RecursiveMode::Recursive
         );
         assert_eq!(
-            state.recursive_mode(Path::new("root/other")),
+            state.coverage_for(Path::new("root/other")).0,
             RecursiveMode::NonRecursive
         );
+    }
+
+    #[test]
+    fn coverage_for_preserves_recursive_filter_under_non_recursive_root() {
+        let state = DebounceDataInner {
+            queues: HashMap::default(),
+            roots: VecDeque::from([
+                (
+                    PathBuf::from("root"),
+                    RecursiveMode::Recursive,
+                    WatchFilter::with_filter(|p: &Path| {
+                        p.file_name() != Some(std::ffi::OsStr::new("skip"))
+                    }),
+                ),
+                (
+                    PathBuf::from("root/a"),
+                    RecursiveMode::NonRecursive,
+                    WatchFilter::accept_all(),
+                ),
+            ]),
+            cache: NoCache,
+            rename_event: None,
+            rescan_event: None,
+            errors: Vec::new(),
+            timeout: Duration::from_millis(50),
+        };
+
+        // The outer recursive root is the unique covering root with a real filter, so
+        // `coverage_for` must use it; the accept-all inner root contributes nothing.
+        let (recursive_mode, watch_filter) = state.coverage_for(Path::new("root/a/b"));
+        assert_eq!(recursive_mode, RecursiveMode::Recursive);
+        assert!(!watch_filter.should_watch(Path::new("root/a/b/skip")));
+        assert!(watch_filter.should_watch(Path::new("root/a/b/keep")));
     }
 
     #[test]
@@ -1453,11 +1596,97 @@ mod tests {
         assert!(err.origin.is_some());
         assert_eq!(err.remaining.len(), 1);
 
-        let roots = debouncer.data.inner.lock().unwrap().roots.clone();
+        let roots: Vec<_> = debouncer
+            .data
+            .inner
+            .lock()
+            .unwrap()
+            .roots
+            .iter()
+            .map(|(path, mode, _)| (path.clone(), *mode))
+            .collect();
         assert_eq!(
             roots,
-            VecDeque::from([(PathBuf::from("ok1"), RecursiveMode::Recursive)])
+            vec![(PathBuf::from("ok1"), RecursiveMode::Recursive)]
         );
+
+        Ok(())
+    }
+
+    #[test]
+    fn rejected_root_propagates_error_and_registers_nothing(
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        let mut debouncer = new_debouncer_opt::<_, TrackingWatcher, testing::TestCache>(
+            Duration::from_millis(20),
+            Some(Duration::from_millis(5)),
+            |_| {},
+            testing::TestCache::new(Default::default(), Default::default()),
+            notify::Config::default(),
+        )?;
+
+        // Use a real directory so the directory-gating check applies.
+        let tmpdir = tempdir()?;
+        let root = tmpdir.path().to_path_buf();
+        let rejecting = std::path::absolute(&root)?;
+        let result = debouncer.watch_filtered(
+            &root,
+            RecursiveMode::Recursive,
+            notify::WatchFilter::with_filter(move |p: &Path| p != rejecting),
+        );
+
+        // Watching a rejected directory root fails and changes nothing.
+        assert!(
+            matches!(&result, Err(error) if matches!(error.kind, ErrorKind::PathExcluded)),
+            "watching a rejected root must fail with PathExcluded, got {result:?}"
+        );
+        assert!(debouncer.watched_paths()?.is_empty());
+
+        let data = debouncer.data.inner.lock().unwrap();
+        assert!(
+            data.roots.is_empty(),
+            "a rejected root must not be registered in the debouncer's bookkeeping"
+        );
+        assert_eq!(
+            data.cache.add_path_calls, 0,
+            "a rejected root must not touch the cache"
+        );
+        drop(data);
+
+        Ok(())
+    }
+
+    #[test]
+    fn watch_filtered_forwards_filter_and_registers_root() -> Result<(), Box<dyn std::error::Error>>
+    {
+        let mut debouncer = new_debouncer_opt::<_, TrackingWatcher, NoCache>(
+            Duration::from_millis(20),
+            Some(Duration::from_millis(5)),
+            |_| {},
+            NoCache::new(),
+            notify::Config::default(),
+        )?;
+
+        let path = PathBuf::from("root");
+        debouncer.watch_filtered(
+            &path,
+            RecursiveMode::Recursive,
+            notify::WatchFilter::with_filter(|p: &Path| {
+                p.file_name() != Some(std::ffi::OsStr::new("excluded"))
+            }),
+        )?;
+
+        assert_eq!(
+            debouncer.watched_paths()?,
+            vec![(path.clone(), RecursiveMode::Recursive)]
+        );
+
+        let filter = debouncer
+            .watcher
+            .last_filter
+            .clone()
+            .expect("the filter must be forwarded to the inner watcher");
+        assert!(!filter.should_watch(Path::new("root/excluded")));
+        assert!(filter.should_watch(Path::new("root/other")));
 
         Ok(())
     }
@@ -1503,6 +1732,111 @@ mod tests {
             debouncer.watched_paths()?,
             vec![(path3, RecursiveMode::Recursive)]
         );
+
+        Ok(())
+    }
+
+    #[test]
+    fn unwatch_parent_preserves_nested_root() -> Result<(), Box<dyn std::error::Error>> {
+        let mut debouncer = new_debouncer_opt::<_, TrackingWatcher, FileIdMap>(
+            Duration::from_millis(20),
+            Some(Duration::from_millis(5)),
+            |_| {},
+            FileIdMap::new(),
+            notify::Config::default(),
+        )?;
+
+        let tmpdir = tempdir()?;
+        let nested = tmpdir.path().join("nested");
+        fs::create_dir(&nested)?;
+        let nested_file = nested.join("file.txt");
+        fs::write(&nested_file, b"content")?;
+
+        debouncer.watch(tmpdir.path(), RecursiveMode::Recursive)?;
+        debouncer.watch(&nested, RecursiveMode::Recursive)?;
+        debouncer.unwatch(tmpdir.path())?;
+
+        let data = debouncer.data.inner.lock().unwrap();
+        assert_eq!(
+            data.roots
+                .iter()
+                .map(|(path, _, _)| path.clone())
+                .collect::<Vec<_>>(),
+            vec![nested.clone()]
+        );
+        assert!(
+            data.cache.cached_file_id(&nested_file).is_some(),
+            "removing the parent must rebuild cache coverage for the surviving nested root"
+        );
+
+        Ok(())
+    }
+
+    #[test]
+    fn unwatch_not_found_preserves_nested_roots() -> Result<(), Box<dyn std::error::Error>> {
+        let mut debouncer = new_debouncer_opt::<_, TrackingWatcher, FileIdMap>(
+            Duration::from_millis(20),
+            Some(Duration::from_millis(5)),
+            |_| {},
+            FileIdMap::new(),
+            notify::Config::default(),
+        )?;
+
+        let tmpdir = tempdir()?;
+        let nested = tmpdir.path().join("nested");
+        fs::create_dir(&nested)?;
+        let nested_file = nested.join("file.txt");
+        fs::write(&nested_file, b"content")?;
+
+        debouncer.watch(&nested, RecursiveMode::Recursive)?;
+
+        // The parent was never watched: the backend reports WatchNotFound and changes
+        // nothing, so the error propagates and the nested root's bookkeeping and cached
+        // IDs must stay untouched.
+        let result = debouncer.unwatch(tmpdir.path());
+        assert!(matches!(&result, Err(error) if matches!(error.kind, ErrorKind::WatchNotFound)));
+
+        let data = debouncer.data.inner.lock().unwrap();
+        assert_eq!(
+            data.roots
+                .iter()
+                .map(|(path, _, _)| path.clone())
+                .collect::<Vec<_>>(),
+            vec![nested.clone()]
+        );
+        assert!(data.cache.cached_file_id(&nested_file).is_some());
+        drop(data);
+
+        Ok(())
+    }
+
+    #[test]
+    fn rewatch_with_same_filter_skips_refingerprint() -> Result<(), Box<dyn std::error::Error>> {
+        let mut debouncer = new_debouncer_opt::<_, TrackingWatcher, testing::TestCache>(
+            Duration::from_millis(20),
+            Some(Duration::from_millis(5)),
+            |_| {},
+            testing::TestCache::new(Default::default(), Default::default()),
+            notify::Config::default(),
+        )?;
+
+        let path = PathBuf::from("root");
+        let filter = notify::WatchFilter::with_filter(|_: &Path| true);
+
+        debouncer.watch_filtered(&path, RecursiveMode::Recursive, filter.clone())?;
+        debouncer.watch_filtered(&path, RecursiveMode::Recursive, filter.clone())?;
+        assert_eq!(
+            debouncer.data.inner.lock().unwrap().cache.add_path_calls,
+            1,
+            "rewatching with the same mode and filter must not re-fingerprint"
+        );
+
+        debouncer.watch_filtered(
+            &path,
+            RecursiveMode::Recursive,
+            notify::WatchFilter::with_filter(|_: &Path| true),
+        )?;
+        assert_eq!(debouncer.data.inner.lock().unwrap().cache.add_path_calls, 2);
 
         Ok(())
     }

--- a/notify-debouncer-full/src/testing.rs
+++ b/notify-debouncer-full/src/testing.rs
@@ -281,11 +281,17 @@ impl schema::State {
 pub struct TestCache {
     pub paths: HashMap<PathBuf, FileId>,
     pub file_system: HashMap<PathBuf, FileId>,
+    /// Number of `add_path` calls, so tests can assert that re-fingerprints are skipped.
+    pub add_path_calls: usize,
 }
 
 impl TestCache {
     pub fn new(paths: HashMap<PathBuf, FileId>, file_system: HashMap<PathBuf, FileId>) -> Self {
-        Self { paths, file_system }
+        Self {
+            paths,
+            file_system,
+            add_path_calls: 0,
+        }
     }
 }
 
@@ -294,7 +300,13 @@ impl FileIdCache for TestCache {
         self.paths.get(path)
     }
 
-    fn add_path(&mut self, path: &Path, recursive_mode: RecursiveMode) {
+    fn add_path(
+        &mut self,
+        path: &Path,
+        recursive_mode: RecursiveMode,
+        _watch_filter: &notify::WatchFilter,
+    ) {
+        self.add_path_calls += 1;
         for (file_path, file_id) in &self.file_system {
             if file_path == path
                 || (file_path.starts_with(path) && recursive_mode == RecursiveMode::Recursive)

--- a/notify/CHANGELOG.md
+++ b/notify/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## unreleased
 
+- FEATURE: add `WatchFilter` and `Watcher::watch_filtered` to exclude directories from watches; walk-based backends prune excluded directories, FSEvents and Windows suppress matching events at delivery time, and filters propagate to directories discovered while watching. The filter gates directories only (file watches are never affected) and re-watching a path with a different filter rebuilds the watch. Two restrictions apply: watching a directory the filter itself rejects returns `ErrorKind::PathExcluded` **breaking**, and a filtered directory watch must not overlap another directory watch (overlap is refused with an error; accept-all watches may overlap as before) [#481]
+- FEATURE: add `WatchPathConfig::with_watch_filter` so `Watcher::update_paths` batches can carry a `WatchFilter` per watch
+- CHANGE: `Watcher::watch_filtered` is now the required `Watcher` trait method; `Watcher::watch` is a provided method that forwards to it with `WatchFilter::accept_all()`. Implementors of `Watcher` must implement `watch_filtered` instead of `watch` **breaking**
 - FEATURE: [macOS] add `Config::with_fsevent_latency` to configure FSEvents stream latency [#930]
 - FIX: [windows] emit a Remove event when a watched directory is deleted, matching inotify and FSEvents
 - FIX: [windows] surface `ReadDirectoryChangesW` read-start failures [#935]
@@ -10,6 +13,7 @@
 - CHANGE: [macOS] improve FSEvents callback performance by avoiding unnecessary allocations and repeated handler locking
 - PERF: [kqueue] avoid filesystem walks for recursive kqueue unwatch
 
+[#481]: https://github.com/notify-rs/notify/issues/481
 [#930]: https://github.com/notify-rs/notify/pull/930
 [#935]: https://github.com/notify-rs/notify/issues/935
 [#958]: https://github.com/notify-rs/notify/pull/958

--- a/notify/src/config.rs
+++ b/notify/src/config.rs
@@ -257,13 +257,17 @@ impl Default for Config {
 #[derive(Debug)]
 pub struct WatchPathConfig {
     recursive_mode: RecursiveMode,
+    watch_filter: crate::WatchFilter,
 }
 
 impl WatchPathConfig {
     /// Creates new instance with provided [`RecursiveMode`]
     #[must_use]
     pub fn new(recursive_mode: RecursiveMode) -> Self {
-        Self { recursive_mode }
+        Self {
+            recursive_mode,
+            watch_filter: crate::WatchFilter::accept_all(),
+        }
     }
 
     /// Set [`RecursiveMode`] for the watch
@@ -273,10 +277,25 @@ impl WatchPathConfig {
         self
     }
 
+    /// Set a [`WatchFilter`](crate::WatchFilter) for the watch.
+    ///
+    /// See [`Watcher::watch_filtered`](crate::Watcher::watch_filtered) for the filter semantics.
+    #[must_use]
+    pub fn with_watch_filter(mut self, watch_filter: crate::WatchFilter) -> Self {
+        self.watch_filter = watch_filter;
+        self
+    }
+
     /// Returns current setting
     #[must_use]
     pub fn recursive_mode(&self) -> RecursiveMode {
         self.recursive_mode
+    }
+
+    /// Returns the configured [`WatchFilter`](crate::WatchFilter)
+    #[must_use]
+    pub fn watch_filter(&self) -> crate::WatchFilter {
+        self.watch_filter.clone()
     }
 }
 

--- a/notify/src/error.rs
+++ b/notify/src/error.rs
@@ -33,6 +33,11 @@ pub enum ErrorKind {
 
     /// Can't watch (more) files, limit on the total number of inotify watches reached
     MaxFilesWatch,
+
+    /// The watched path is a directory rejected by the watch's own
+    /// [`WatchFilter`](crate::WatchFilter); nothing was watched and existing watches are
+    /// unchanged. See [`Watcher::watch_filtered`](crate::Watcher::watch_filtered).
+    PathExcluded,
 }
 
 /// Notify error type.
@@ -109,6 +114,12 @@ impl Error {
         Self::new(ErrorKind::WatchNotFound)
     }
 
+    /// Creates a new "path excluded" error.
+    #[must_use]
+    pub fn path_excluded() -> Self {
+        Self::new(ErrorKind::PathExcluded)
+    }
+
     /// Creates a new "invalid config" error from the given `Config`.
     #[must_use]
     pub fn invalid_config(config: &Config) -> Self {
@@ -125,6 +136,7 @@ impl fmt::Display for Error {
             ErrorKind::Generic(ref err) => err.clone(),
             ErrorKind::Io(ref err) => err.to_string(),
             ErrorKind::MaxFilesWatch => "OS file watch limit reached.".into(),
+            ErrorKind::PathExcluded => "The path is excluded by the watch filter.".into(),
         };
 
         if self.paths.is_empty() {

--- a/notify/src/fsevent.rs
+++ b/notify/src/fsevent.rs
@@ -17,7 +17,8 @@
 use crate::paths::{absolute_path, reported_path};
 use crate::{event::*, PathOp};
 use crate::{
-    unbounded, Config, Error, EventHandler, EventKindMask, RecursiveMode, Result, Sender, Watcher,
+    unbounded, Config, Error, EventHandler, EventKindMask, RecursiveMode, Result, Sender,
+    WatchFilter, Watcher,
 };
 use objc2_core_foundation as cf;
 use objc2_core_services as fs;
@@ -76,8 +77,10 @@ pub struct FsEventWatcher {
 
 #[derive(Clone, Debug)]
 struct WatchInfo {
+    is_dir: bool,
     is_recursive: bool,
     reported_path: PathBuf,
+    watch_filter: WatchFilter,
 }
 
 #[derive(Debug)]
@@ -355,9 +358,42 @@ impl FsEventWatcher {
         })
     }
 
-    fn watch_inner(&mut self, path: &Path, recursive_mode: RecursiveMode) -> Result<()> {
+    fn watch_inner(
+        &mut self,
+        path: &Path,
+        recursive_mode: RecursiveMode,
+        watch_filter: WatchFilter,
+    ) -> Result<()> {
+        // Validate before touching the running stream: bouncing it for a call that errors
+        // would lose events delivered in the stop/recreate window (streams start at
+        // `kFSEventStreamEventIdSinceNow`). With an accept-all filter and no existing
+        // filtered watches, rejection is impossible, so skip the extra validation syscalls;
+        // `append_path` re-validates either way and stays authoritative.
+        if !watch_filter.is_accept_all()
+            || self
+                .recursive_info
+                .values()
+                .any(|info| !info.watch_filter.is_accept_all())
+        {
+            if !path.exists() {
+                return Err(Error::path_not_found().add_path(path.into()));
+            }
+            let canonical_path = path.to_path_buf().canonicalize()?;
+            let path_is_dir = canonical_path.is_dir();
+            crate::paths::check_watch_barriers(
+                &canonical_path,
+                path,
+                path_is_dir,
+                recursive_mode.is_recursive() && path_is_dir,
+                &watch_filter,
+                self.recursive_info
+                    .iter()
+                    .map(|(path, info)| (path, info.is_dir, info.is_recursive, &info.watch_filter)),
+            )?;
+        }
+
         self.stop();
-        let result = self.append_path(path, recursive_mode);
+        let result = self.append_path(path, recursive_mode, watch_filter);
         self.run()?;
         result
     }
@@ -377,7 +413,7 @@ impl FsEventWatcher {
 
         let result = crate::update_paths(ops, |op| match op {
             crate::PathOp::Watch(path, config) => self
-                .append_path(&path, config.recursive_mode())
+                .append_path(&path, config.recursive_mode(), config.watch_filter())
                 .map_err(|e| (PathOp::Watch(path, config), e)),
             crate::PathOp::Unwatch(path) => self
                 .remove_path(&path)
@@ -477,11 +513,29 @@ impl FsEventWatcher {
     }
 
     // https://github.com/thibaudgg/rb-fsevent/blob/master/ext/fsevent_watch/main.c
-    fn append_path(&mut self, path: &Path, recursive_mode: RecursiveMode) -> Result<()> {
+    fn append_path(
+        &mut self,
+        path: &Path,
+        recursive_mode: RecursiveMode,
+        watch_filter: WatchFilter,
+    ) -> Result<()> {
         if !path.exists() {
             return Err(Error::path_not_found().add_path(path.into()));
         }
         let canonical_path = path.to_path_buf().canonicalize()?;
+        // Filter on the canonical path: that is the form FSEvents reports at event time, so
+        // watch-time and event-time filtering see the same paths (e.g. /private/tmp, not /tmp).
+        let path_is_dir = canonical_path.is_dir();
+        crate::paths::check_watch_barriers(
+            &canonical_path,
+            path,
+            path_is_dir,
+            recursive_mode.is_recursive() && path_is_dir,
+            &watch_filter,
+            self.recursive_info
+                .iter()
+                .map(|(path, info)| (path, info.is_dir, info.is_recursive, &info.watch_filter)),
+        )?;
         let mut err: *mut cf::CFError = ptr::null_mut();
         let Some(cf_path) = (unsafe { path_to_cfstring_ref(&canonical_path, &mut err) }) else {
             if let Some(err) = NonNull::new(err) {
@@ -499,8 +553,10 @@ impl FsEventWatcher {
         self.recursive_info.insert(
             canonical_path,
             WatchInfo {
+                is_dir: path_is_dir,
                 is_recursive: recursive_mode.is_recursive(),
                 reported_path: path.to_path_buf(),
+                watch_filter,
             },
         );
         Ok(())
@@ -707,6 +763,10 @@ unsafe fn callback_impl(
                     false
                 };
 
+                // FSEvents cannot selectively watch directories, so directory filtering happens
+                // at delivery time: suppress the event if a directory between the watch root and
+                // the event path is rejected. The filter runs last so the user closure is only
+                // invoked for entries that would actually win the longest-prefix selection.
                 if matches_watch
                     && watch_match.as_ref().is_none_or(
                         |(matched_path, _): &(&PathBuf, &WatchInfo)| {
@@ -714,6 +774,7 @@ unsafe fn callback_impl(
                                 > matched_path.as_os_str().as_bytes().len()
                         },
                     )
+                    && watch_info.watch_filter.allows_event_under(watch_path, path)
                 {
                     watch_match = Some((watch_path, watch_info));
                 }
@@ -776,8 +837,13 @@ impl Watcher for FsEventWatcher {
         )
     }
 
-    fn watch(&mut self, path: &Path, recursive_mode: RecursiveMode) -> Result<()> {
-        self.watch_inner(path, recursive_mode)
+    fn watch_filtered(
+        &mut self,
+        path: &Path,
+        recursive_mode: RecursiveMode,
+        watch_filter: WatchFilter,
+    ) -> Result<()> {
+        self.watch_inner(path, recursive_mode, watch_filter)
     }
 
     fn unwatch(&mut self, path: &Path) -> Result<()> {
@@ -866,7 +932,7 @@ unsafe fn path_to_cfstring_ref(
 mod tests {
     use std::time::Duration;
 
-    use crate::{ErrorKind, WatchPathConfig};
+    use crate::{ErrorKind, PathOp, WatchPathConfig};
 
     use super::*;
     use crate::test::*;
@@ -881,10 +947,18 @@ mod tests {
         let mut watcher = FsEventWatcher::new(|_| {}, Config::default()).unwrap();
 
         watcher
-            .append_path(dir.path(), RecursiveMode::Recursive)
+            .append_path(
+                dir.path(),
+                RecursiveMode::Recursive,
+                WatchFilter::accept_all(),
+            )
             .expect("watch recursively");
         watcher
-            .append_path(dir.path(), RecursiveMode::NonRecursive)
+            .append_path(
+                dir.path(),
+                RecursiveMode::NonRecursive,
+                WatchFilter::accept_all(),
+            )
             .expect("rewatch non-recursively");
 
         let watched = watcher.watched_paths().expect("watched paths");
@@ -893,6 +967,90 @@ mod tests {
             vec![(dir.path().to_path_buf(), RecursiveMode::NonRecursive)]
         );
         assert_eq!(watcher.paths.iter().count(), 1);
+    }
+
+    #[test]
+    fn update_paths_carries_watch_filter() {
+        let dir = tempfile::tempdir().unwrap();
+        let excluded = dir.path().join("excluded");
+        std::fs::create_dir(&excluded).unwrap();
+        let mut watcher = FsEventWatcher::new(|_| {}, Config::default()).unwrap();
+
+        watcher
+            .update_paths_inner(vec![PathOp::Watch(
+                dir.path().to_path_buf(),
+                WatchPathConfig::new(RecursiveMode::Recursive).with_watch_filter(
+                    WatchFilter::with_filter(|p: &Path| {
+                        p.file_name() != Some(std::ffi::OsStr::new("excluded"))
+                    }),
+                ),
+            )])
+            .expect("update paths");
+
+        let canonical_root = dir.path().canonicalize().unwrap();
+        let info = watcher
+            .recursive_info
+            .get(&canonical_root)
+            .expect("stored watch info");
+        assert!(
+            !info.watch_filter.should_watch(&excluded),
+            "update_paths must store the filter on the FSEvents watch"
+        );
+    }
+
+    #[test]
+    fn update_paths_rejected_root_does_not_add_watch() {
+        let dir = tempfile::tempdir().unwrap();
+        let rejecting = dir.path().canonicalize().unwrap();
+        let mut watcher = FsEventWatcher::new(|_| {}, Config::default()).unwrap();
+
+        let result = watcher.update_paths_inner(vec![PathOp::Watch(
+            dir.path().to_path_buf(),
+            WatchPathConfig::new(RecursiveMode::Recursive).with_watch_filter(
+                WatchFilter::with_filter(move |p: &Path| p != rejecting.as_path()),
+            ),
+        )]);
+
+        assert!(
+            matches!(result, Err(ref e) if matches!(e.source.kind, ErrorKind::PathExcluded)),
+            "update_paths must fail with PathExcluded for rejected roots, got {result:?}"
+        );
+        assert!(watcher.recursive_info.is_empty());
+        assert_eq!(watcher.paths.iter().count(), 0);
+    }
+
+    #[test]
+    fn rejected_root_preserves_existing_watch() {
+        let dir = tempfile::tempdir().unwrap();
+        let rejecting = dir.path().canonicalize().unwrap();
+        let mut watcher = FsEventWatcher::new(|_| {}, Config::default()).unwrap();
+
+        watcher
+            .append_path(
+                dir.path(),
+                RecursiveMode::Recursive,
+                WatchFilter::accept_all(),
+            )
+            .expect("watch recursively");
+        let before = watcher.watched_paths().expect("watched paths");
+        let cf_path_count = watcher.paths.iter().count();
+
+        let result = watcher.append_path(
+            dir.path(),
+            RecursiveMode::Recursive,
+            WatchFilter::with_filter(move |p: &Path| p != rejecting.as_path()),
+        );
+
+        assert!(
+            matches!(result, Err(ref e) if matches!(e.kind, ErrorKind::PathExcluded)),
+            "watching a rejected root must fail with PathExcluded: {result:?}"
+        );
+        assert_eq!(
+            watcher.watched_paths().expect("watched paths"),
+            before,
+            "a failed rewatch must leave existing watches unchanged"
+        );
+        assert_eq!(watcher.paths.iter().count(), cf_path_count);
     }
 
     #[test]
@@ -1043,8 +1201,10 @@ mod tests {
         recursive_info.insert(
             PathBuf::from("/tmp"),
             WatchInfo {
+                is_dir: true,
                 is_recursive: true,
                 reported_path: PathBuf::from("/tmp"),
+                watch_filter: WatchFilter::accept_all(),
             },
         );
 
@@ -1096,6 +1256,220 @@ mod tests {
     }
 
     #[test]
+    fn callback_impl_suppresses_events_under_filtered_directories() {
+        use std::ffi::CString;
+        use std::ptr;
+
+        let (tx, rx) = std::sync::mpsc::channel::<crate::Result<Event>>();
+        let event_handler: Arc<Mutex<dyn EventHandler>> = Arc::new(Mutex::new(tx));
+
+        let mut recursive_info = HashMap::new();
+        recursive_info.insert(
+            PathBuf::from("/tmp"),
+            WatchInfo {
+                is_dir: true,
+                is_recursive: true,
+                reported_path: PathBuf::from("/tmp"),
+                watch_filter: WatchFilter::with_filter(|p: &Path| {
+                    p.file_name() != Some(OsStr::new("excluded"))
+                }),
+            },
+        );
+
+        let context = Box::new(StreamContextInfo {
+            event_handler,
+            recursive_info,
+            event_kinds: EventKindMask::ALL,
+        });
+        let context_ptr = Box::into_raw(context) as *mut libc::c_void;
+
+        let suppressed = CString::new("/tmp/excluded/file.txt").expect("cstring");
+        let delivered = CString::new("/tmp/other/file.txt").expect("cstring");
+        let path_ptrs = [suppressed.as_ptr(), delivered.as_ptr()];
+        let event_paths = NonNull::new(path_ptrs.as_ptr() as *mut libc::c_void).unwrap();
+
+        let flags = (StreamFlags::ITEM_CREATED | StreamFlags::IS_FILE).bits()
+            as fs::FSEventStreamEventFlags;
+        let flags_arr = [flags, flags];
+        let event_flags =
+            NonNull::new(flags_arr.as_ptr() as *mut fs::FSEventStreamEventFlags).unwrap();
+
+        let ids_arr = [0 as fs::FSEventStreamEventId, 1 as fs::FSEventStreamEventId];
+        let event_ids = NonNull::new(ids_arr.as_ptr() as *mut fs::FSEventStreamEventId).unwrap();
+
+        let res = std::panic::catch_unwind(|| unsafe {
+            callback_impl(
+                ptr::null(),
+                context_ptr,
+                2,
+                event_paths,
+                event_flags,
+                event_ids,
+            );
+        });
+        unsafe {
+            drop(Box::from_raw(context_ptr as *mut StreamContextInfo));
+        }
+
+        assert!(res.is_ok(), "callback_impl should not panic");
+
+        let event = rx
+            .recv_timeout(Duration::from_secs(1))
+            .expect("expected event for the non-excluded path")
+            .expect("expected Ok(Event)");
+        assert_eq!(event.paths, vec![PathBuf::from("/tmp/other/file.txt")]);
+        assert!(
+            rx.try_recv().is_err(),
+            "event under the excluded directory must be suppressed"
+        );
+    }
+
+    #[test]
+    fn callback_impl_delivers_excluded_directory_own_event() {
+        use std::ffi::CString;
+        use std::ptr;
+
+        let (tx, rx) = std::sync::mpsc::channel::<crate::Result<Event>>();
+        let event_handler: Arc<Mutex<dyn EventHandler>> = Arc::new(Mutex::new(tx));
+
+        let mut recursive_info = HashMap::new();
+        recursive_info.insert(
+            PathBuf::from("/tmp"),
+            WatchInfo {
+                is_dir: true,
+                is_recursive: true,
+                reported_path: PathBuf::from("/tmp"),
+                watch_filter: WatchFilter::with_filter(|p: &Path| {
+                    p.file_name() != Some(OsStr::new("excluded"))
+                }),
+            },
+        );
+
+        let context = Box::new(StreamContextInfo {
+            event_handler,
+            recursive_info,
+            event_kinds: EventKindMask::ALL,
+        });
+        let context_ptr = Box::into_raw(context) as *mut libc::c_void;
+
+        // The excluded directory's *own* creation is delivered (its watched parent sees it);
+        // only events strictly beneath it are suppressed. This matches the walk-based
+        // backends, which report the excluded directory's own create/remove.
+        let own = CString::new("/tmp/excluded").expect("cstring");
+        let child = CString::new("/tmp/excluded/inside.txt").expect("cstring");
+        let path_ptrs = [own.as_ptr(), child.as_ptr()];
+        let event_paths = NonNull::new(path_ptrs.as_ptr() as *mut libc::c_void).unwrap();
+
+        let dir_flags =
+            (StreamFlags::ITEM_CREATED | StreamFlags::IS_DIR).bits() as fs::FSEventStreamEventFlags;
+        let file_flags = (StreamFlags::ITEM_CREATED | StreamFlags::IS_FILE).bits()
+            as fs::FSEventStreamEventFlags;
+        let flags_arr = [dir_flags, file_flags];
+        let event_flags =
+            NonNull::new(flags_arr.as_ptr() as *mut fs::FSEventStreamEventFlags).unwrap();
+
+        let ids_arr = [0 as fs::FSEventStreamEventId, 1 as fs::FSEventStreamEventId];
+        let event_ids = NonNull::new(ids_arr.as_ptr() as *mut fs::FSEventStreamEventId).unwrap();
+
+        let res = std::panic::catch_unwind(|| unsafe {
+            callback_impl(
+                ptr::null(),
+                context_ptr,
+                2,
+                event_paths,
+                event_flags,
+                event_ids,
+            );
+        });
+        unsafe {
+            drop(Box::from_raw(context_ptr as *mut StreamContextInfo));
+        }
+
+        assert!(res.is_ok(), "callback_impl should not panic");
+
+        let event = rx
+            .recv_timeout(Duration::from_secs(1))
+            .expect("expected the excluded directory's own event")
+            .expect("expected Ok(Event)");
+        assert_eq!(event.paths, vec![PathBuf::from("/tmp/excluded")]);
+        assert!(
+            rx.try_recv().is_err(),
+            "events inside the excluded directory must be suppressed"
+        );
+    }
+
+    #[test]
+    fn callback_impl_suppresses_deeply_nested_events() {
+        use std::ffi::CString;
+        use std::ptr;
+
+        let (tx, rx) = std::sync::mpsc::channel::<crate::Result<Event>>();
+        let event_handler: Arc<Mutex<dyn EventHandler>> = Arc::new(Mutex::new(tx));
+
+        let mut recursive_info = HashMap::new();
+        recursive_info.insert(
+            PathBuf::from("/tmp"),
+            WatchInfo {
+                is_dir: true,
+                is_recursive: true,
+                reported_path: PathBuf::from("/tmp"),
+                watch_filter: WatchFilter::with_filter(|p: &Path| {
+                    p.file_name() != Some(OsStr::new("excluded"))
+                }),
+            },
+        );
+
+        let context = Box::new(StreamContextInfo {
+            event_handler,
+            recursive_info,
+            event_kinds: EventKindMask::ALL,
+        });
+        let context_ptr = Box::into_raw(context) as *mut libc::c_void;
+
+        // A rejected directory anywhere in the ancestor chain suppresses the event, however
+        // deeply nested; a deep path with no rejected ancestor is still delivered.
+        let suppressed = CString::new("/tmp/excluded/a/b/deep.txt").expect("cstring");
+        let delivered = CString::new("/tmp/kept/a/b/deep.txt").expect("cstring");
+        let path_ptrs = [suppressed.as_ptr(), delivered.as_ptr()];
+        let event_paths = NonNull::new(path_ptrs.as_ptr() as *mut libc::c_void).unwrap();
+
+        let flags = (StreamFlags::ITEM_CREATED | StreamFlags::IS_FILE).bits()
+            as fs::FSEventStreamEventFlags;
+        let flags_arr = [flags, flags];
+        let event_flags =
+            NonNull::new(flags_arr.as_ptr() as *mut fs::FSEventStreamEventFlags).unwrap();
+
+        let ids_arr = [0 as fs::FSEventStreamEventId, 1 as fs::FSEventStreamEventId];
+        let event_ids = NonNull::new(ids_arr.as_ptr() as *mut fs::FSEventStreamEventId).unwrap();
+
+        let res = std::panic::catch_unwind(|| unsafe {
+            callback_impl(
+                ptr::null(),
+                context_ptr,
+                2,
+                event_paths,
+                event_flags,
+                event_ids,
+            );
+        });
+        unsafe {
+            drop(Box::from_raw(context_ptr as *mut StreamContextInfo));
+        }
+
+        assert!(res.is_ok(), "callback_impl should not panic");
+
+        let event = rx
+            .recv_timeout(Duration::from_secs(1))
+            .expect("expected the deeply nested non-excluded event")
+            .expect("expected Ok(Event)");
+        assert_eq!(event.paths, vec![PathBuf::from("/tmp/kept/a/b/deep.txt")]);
+        assert!(
+            rx.try_recv().is_err(),
+            "events deep beneath the excluded directory must be suppressed"
+        );
+    }
+
+    #[test]
     fn callback_impl_ignores_unknown_flag_bits_without_panicking() {
         use std::ffi::CString;
         use std::ptr;
@@ -1107,8 +1481,10 @@ mod tests {
         recursive_info.insert(
             PathBuf::from("/tmp"),
             WatchInfo {
+                is_dir: true,
                 is_recursive: true,
                 reported_path: PathBuf::from("/tmp"),
+                watch_filter: WatchFilter::accept_all(),
             },
         );
 

--- a/notify/src/inotify.rs
+++ b/notify/src/inotify.rs
@@ -5,10 +5,11 @@
 //! will return events for the directory itself, and for files inside the directory.
 
 use super::event::*;
-use super::{Config, Error, ErrorKind, EventHandler, RecursiveMode, Result, Watcher};
+use super::{Config, Error, ErrorKind, EventHandler, RecursiveMode, Result, WatchFilter, Watcher};
 use crate::paths::{
-    absolute_path, is_preserved_watch_root, preserved_watch_mode, preserved_watch_roots,
-    recursive_user_watch_ancestor, reported_path, WatchMetadata, WatchPath,
+    absolute_path, check_watch_barriers, filter_keeps_walk_entry, is_preserved_watch_root,
+    preserved_watch_mode, preserved_watch_roots, recursive_user_watch_ancestor, reported_path,
+    WatchMetadata, WatchPath,
 };
 use crate::{bounded, unbounded, BoundSender, Receiver, Sender};
 use inotify as inotify_sys;
@@ -112,7 +113,7 @@ pub struct INotifyWatcher {
 }
 
 enum EventLoopMsg {
-    AddWatch(WatchPath, RecursiveMode, Sender<Result<()>>),
+    AddWatch(WatchPath, RecursiveMode, WatchFilter, Sender<Result<()>>),
     RemoveWatch(PathBuf, Sender<Result<()>>),
     GetWatchedPaths(Sender<Vec<(PathBuf, RecursiveMode)>>),
     Shutdown,
@@ -124,15 +125,18 @@ fn add_watch_by_event(
     path: &PathBuf,
     event: &inotify_sys::Event<&OsStr>,
     watches: &HashMap<PathBuf, Watch>,
-    add_watches: &mut Vec<WatchPath>,
+    add_watches: &mut Vec<(WatchPath, WatchFilter)>,
 ) {
     if event.mask.contains(EventMask::ISDIR) {
         if let Some(parent_path) = path.parent() {
             if let Some(watch) = watches.get(parent_path) {
                 if watch.metadata.is_recursive {
-                    add_watches.push(WatchPath::from_parts(
-                        path.to_owned(),
-                        reported_path(parent_path, &watch.metadata.reported_path, path),
+                    add_watches.push((
+                        WatchPath::from_parts(
+                            path.to_owned(),
+                            reported_path(parent_path, &watch.metadata.reported_path, path),
+                        ),
+                        watch.metadata.watch_filter.clone(),
                     ));
                 }
             }
@@ -241,8 +245,13 @@ impl EventLoop {
     fn handle_messages(&mut self) {
         while let Ok(msg) = self.event_loop_rx.try_recv() {
             match msg {
-                EventLoopMsg::AddWatch(path, recursive_mode, tx) => {
-                    let _ = tx.send(self.add_watch(path, recursive_mode.is_recursive(), true));
+                EventLoopMsg::AddWatch(path, recursive_mode, watch_filter, tx) => {
+                    let _ = tx.send(self.add_watch(
+                        path,
+                        recursive_mode.is_recursive(),
+                        true,
+                        watch_filter,
+                    ));
                 }
                 EventLoopMsg::RemoveWatch(path, tx) => {
                     let _ = tx.send(self.remove_watch(path, false));
@@ -504,8 +513,8 @@ impl EventLoop {
             }
         }
 
-        for path in add_watches {
-            if let Err(add_watch_error) = self.add_watch(path, true, false) {
+        for (path, watch_filter) in add_watches {
+            if let Err(add_watch_error) = self.add_watch(path, true, false, watch_filter) {
                 // The handler should be notified if we have reached the limit.
                 // Otherwise, the user might expect that a recursive watch
                 // is continuing to work correctly, but it's not.
@@ -521,27 +530,56 @@ impl EventLoop {
         }
     }
 
-    fn add_watch(&mut self, path: WatchPath, is_recursive: bool, watch_self: bool) -> Result<()> {
+    fn add_watch(
+        &mut self,
+        path: WatchPath,
+        is_recursive: bool,
+        watch_self: bool,
+        watch_filter: WatchFilter,
+    ) -> Result<()> {
         let path_is_dir = metadata(&path.absolute).map_err(Error::io_watch)?.is_dir();
         let requested_is_recursive = is_recursive && path_is_dir;
+        if watch_self {
+            check_watch_barriers(
+                &path.absolute,
+                &path.requested,
+                path_is_dir,
+                requested_is_recursive,
+                &watch_filter,
+                self.watches
+                    .iter()
+                    .filter(|(_, watch)| watch.metadata.is_user_watch)
+                    .map(|(path, watch)| {
+                        (
+                            path,
+                            watch.is_dir,
+                            watch.metadata.user_is_recursive,
+                            &watch.metadata.watch_filter,
+                        )
+                    }),
+            )?;
+        }
+        let mut inherited_recursive_root = None;
         if watch_self {
             if let Some(watch) = self
                 .watches
                 .get(&path.absolute)
                 .filter(|watch| watch.metadata.is_user_watch)
             {
-                if watch.metadata.user_is_recursive == requested_is_recursive
-                    && watch.metadata.reported_path == path.requested
+                if watch
+                    .metadata
+                    .rewatch_is_noop(&path, requested_is_recursive, &watch_filter)
                 {
                     return Ok(());
                 }
 
-                // Rewatching an explicit user watch replaces its requested mode and reported path
-                // instead of merging with the previous metadata. If the current entry also carries
-                // recursive coverage from an ancestor, remember that ancestor before removal so we
-                // can rebuild that inherited coverage below.
-                let inherited_recursive_root =
-                    if !requested_is_recursive && path_is_dir && watch.metadata.is_recursive {
+                // Rewatching an explicit user watch replaces its requested mode, reported
+                // path, and filter instead of merging with the previous metadata. If a
+                // recursive ancestor also covers this directory, remember it so coverage
+                // the removal drops (or the new mode no longer provides) is rebuilt below;
+                // the overlap barrier guarantees such an ancestor is unfiltered.
+                inherited_recursive_root =
+                    if path_is_dir && !requested_is_recursive && watch.metadata.is_recursive {
                         recursive_user_watch_ancestor(
                             &path.absolute,
                             self.watches
@@ -551,42 +589,46 @@ impl EventLoop {
                     } else {
                         None
                     };
-                let replaced_path = path.absolute.clone();
-                self.remove_watch(replaced_path.clone(), false)?;
-
-                if let Some((ancestor_path, ancestor_reported_path)) = inherited_recursive_root {
-                    // Removing a directory watch removes its recursively inherited children too.
-                    // Re-add them as non-user watches so the ancestor recursive watch still covers
-                    // this subtree after the user watch is replaced.
-                    let entries = WalkDir::new(&replaced_path)
-                        .follow_links(self.follow_links)
-                        .into_iter()
-                        .filter_map(filter_dir)
-                        .map(|entry| {
-                            let absolute = entry.into_path();
-                            let requested =
-                                reported_path(&ancestor_path, &ancestor_reported_path, &absolute);
-                            WatchPath::from_parts(absolute, requested)
-                        });
-                    self.add_watches_for_paths(entries, true, false)?;
-                }
+                self.remove_watch(path.absolute.clone(), false)?;
             }
         }
 
-        // If the watch is not recursive, or if we determine (by stat'ing the path to get its
-        // metadata) that the watched path is not a directory, add a single path watch.
         if !requested_is_recursive {
-            return self.add_single_watch(path, false, true);
+            // If the watch is not recursive, or if we determine (by stat'ing the path to
+            // get its metadata) that the watched path is not a directory, add a single
+            // path watch.
+            self.add_single_watch(path.clone(), false, true, watch_filter)?;
+        } else {
+            let root = path.clone();
+            let filter = watch_filter.clone();
+            let entries = WalkDir::new(&root.absolute)
+                .follow_links(self.follow_links)
+                .into_iter()
+                // Prune rejected directories: don't watch them and don't descend into them.
+                .filter_entry(move |entry| filter_keeps_walk_entry(&filter, entry))
+                .filter_map(filter_dir)
+                .map(move |entry| root.child(entry.into_path()));
+
+            self.add_watches_for_paths(entries, is_recursive, watch_self, watch_filter)?;
         }
 
-        let root = path.clone();
-        let entries = WalkDir::new(&root.absolute)
-            .follow_links(self.follow_links)
-            .into_iter()
-            .filter_map(filter_dir)
-            .map(move |entry| root.child(entry.into_path()));
+        if let Some((ancestor_path, ancestor_reported_path)) = inherited_recursive_root {
+            // Re-add, as non-user watches, the coverage the covering ancestor provides but
+            // the removal above dropped (or the new non-recursive mode no longer provides).
+            let entries = WalkDir::new(&path.absolute)
+                .follow_links(self.follow_links)
+                .into_iter()
+                .filter_map(filter_dir)
+                .map(move |entry| {
+                    let absolute = entry.into_path();
+                    let requested =
+                        reported_path(&ancestor_path, &ancestor_reported_path, &absolute);
+                    WatchPath::from_parts(absolute, requested)
+                });
+            self.add_watches_for_paths(entries, true, false, WatchFilter::accept_all())?;
+        }
 
-        self.add_watches_for_paths(entries, is_recursive, watch_self)
+        Ok(())
     }
 
     fn add_watches_for_paths<I>(
@@ -594,12 +636,13 @@ impl EventLoop {
         paths: I,
         is_recursive: bool,
         mut watch_self: bool,
+        watch_filter: WatchFilter,
     ) -> Result<()>
     where
         I: IntoIterator<Item = WatchPath>,
     {
         for path in paths {
-            match self.add_single_watch(path, is_recursive, watch_self) {
+            match self.add_single_watch(path, is_recursive, watch_self, watch_filter.clone()) {
                 Ok(()) => {}
                 // TOCTOU: a subdirectory can disappear between walkdir listing it and us adding an
                 // inotify watch for it. This should not fail the overall recursive watch call.
@@ -617,6 +660,7 @@ impl EventLoop {
         path: WatchPath,
         is_recursive: bool,
         watch_self: bool,
+        watch_filter: WatchFilter,
     ) -> Result<()> {
         // Build watch mask from configured event kinds for kernel-level filtering
         let mut watchmask = event_kind_mask_to_watch_mask(self.event_kind_mask, is_recursive);
@@ -658,24 +702,17 @@ impl EventLoop {
                             return Err(Error::io_watch(e).add_path(path.requested));
                         }
                     };
-                    let metadata = if let Some(existing_watch) = existing_watch {
-                        WatchMetadata::new(
-                            &path,
-                            is_recursive,
-                            watch_self,
-                            Some(&existing_watch.metadata),
-                            self.watches
-                                .iter()
-                                .map(|(path, watch)| (path, &watch.metadata)),
-                        )
-                    } else {
-                        WatchMetadata {
-                            is_recursive,
-                            reported_path: path.requested.clone(),
-                            is_user_watch: watch_self,
-                            user_is_recursive: watch_self && is_recursive,
-                        }
-                    };
+                    let metadata = WatchMetadata::new(
+                        &path,
+                        is_dir,
+                        is_recursive,
+                        watch_self,
+                        existing_watch.map(|watch| &watch.metadata),
+                        self.watches
+                            .iter()
+                            .map(|(path, watch)| (path, &watch.metadata)),
+                        watch_filter,
+                    );
 
                     self.watches.insert(
                         path.absolute.clone(),
@@ -868,10 +905,15 @@ impl INotifyWatcher {
         Ok(INotifyWatcher { channel, waker })
     }
 
-    fn watch_inner(&mut self, path: &Path, recursive_mode: RecursiveMode) -> Result<()> {
+    fn watch_inner(
+        &mut self,
+        path: &Path,
+        recursive_mode: RecursiveMode,
+        watch_filter: WatchFilter,
+    ) -> Result<()> {
         let pb = WatchPath::new(path)?;
         let (tx, rx) = unbounded();
-        let msg = EventLoopMsg::AddWatch(pb, recursive_mode, tx);
+        let msg = EventLoopMsg::AddWatch(pb, recursive_mode, watch_filter, tx);
 
         self.channel.send(msg)?;
         self.waker.wake()?;
@@ -902,8 +944,13 @@ impl Watcher for INotifyWatcher {
         Self::from_event_handler(Box::new(event_handler), &config)
     }
 
-    fn watch(&mut self, path: &Path, recursive_mode: RecursiveMode) -> Result<()> {
-        self.watch_inner(path, recursive_mode)
+    fn watch_filtered(
+        &mut self,
+        path: &Path,
+        recursive_mode: RecursiveMode,
+        watch_filter: WatchFilter,
+    ) -> Result<()> {
+        self.watch_inner(path, recursive_mode, watch_filter)
     }
 
     fn unwatch(&mut self, path: &Path) -> Result<()> {
@@ -946,7 +993,7 @@ mod tests {
     use super::inotify_sys::WatchMask;
     use super::{
         Config, Error, ErrorKind, Event, EventKind, EventLoop, INotifyWatcher, RecursiveMode,
-        Result, WatchPath, Watcher,
+        Result, WatchFilter, WatchPath, Watcher,
     };
     use notify_types::event::{EventKindMask, RemoveKind};
 
@@ -954,6 +1001,11 @@ mod tests {
 
     fn watcher() -> (TestWatcher<INotifyWatcher>, Receiver) {
         channel()
+    }
+
+    fn test_event_loop() -> EventLoop {
+        let inotify = super::inotify_sys::Inotify::init().unwrap();
+        EventLoop::new(inotify, Box::new(|_| {}), &Config::default()).unwrap()
     }
 
     /// Create a watcher configured to receive ALL events including Access events.
@@ -1001,8 +1053,7 @@ mod tests {
         fs::create_dir(&disappearing).unwrap();
         fs::remove_dir_all(&disappearing).unwrap();
 
-        let inotify = super::inotify_sys::Inotify::init().unwrap();
-        let mut event_loop = EventLoop::new(inotify, Box::new(|_| {}), &Config::default()).unwrap();
+        let mut event_loop = test_event_loop();
 
         // Simulate the TOCTOU: we *intend* to watch a subdirectory discovered during initial scan,
         // but it's already gone by the time we call `inotify_add_watch`.
@@ -1012,11 +1063,186 @@ mod tests {
                 .map(|path| WatchPath::new(&path).unwrap()),
             true,
             true,
+            WatchFilter::accept_all(),
         );
         assert!(
             result.is_ok(),
             "expected recursive watch to succeed, got: {result:?}"
         );
+    }
+
+    #[test]
+    fn watch_filter_prunes_excluded_directories() {
+        let tmpdir = tempfile::tempdir().unwrap();
+        let root = tmpdir.path().to_path_buf();
+        let excluded = root.join("excluded");
+        let excluded_sub = excluded.join("sub");
+        let included = root.join("included");
+        std::fs::create_dir_all(&excluded_sub).unwrap();
+        std::fs::create_dir_all(&included).unwrap();
+
+        let mut event_loop = test_event_loop();
+
+        let filter = reject_name("excluded");
+        event_loop
+            .add_watch(WatchPath::new(&root).unwrap(), true, true, filter)
+            .expect("watch recursively");
+
+        assert!(event_loop.watches.contains_key(&root));
+        assert!(event_loop.watches.contains_key(&included));
+        assert!(!event_loop.watches.contains_key(&excluded));
+        assert!(
+            !event_loop.watches.contains_key(&excluded_sub),
+            "descent into excluded directories must be pruned"
+        );
+    }
+
+    #[test]
+    fn rewatch_with_different_filter_rebuilds_watch() {
+        let tmpdir = tempfile::tempdir().unwrap();
+        let root = tmpdir.path().to_path_buf();
+        let excluded = root.join("excluded");
+        std::fs::create_dir_all(&excluded).unwrap();
+
+        let mut event_loop = test_event_loop();
+
+        event_loop
+            .add_watch(
+                WatchPath::new(&root).unwrap(),
+                true,
+                true,
+                reject_name("excluded"),
+            )
+            .expect("watch recursively with filter");
+        assert!(!event_loop.watches.contains_key(&excluded));
+
+        // Re-watching with a different filter (here: accept-all, i.e. plain `watch()`)
+        // must rebuild the watch instead of short-circuiting as unchanged.
+        event_loop
+            .add_watch(
+                WatchPath::new(&root).unwrap(),
+                true,
+                true,
+                WatchFilter::accept_all(),
+            )
+            .expect("rewatch with accept-all");
+        assert!(
+            event_loop.watches.contains_key(&excluded),
+            "a rewatch with a different filter must take effect"
+        );
+    }
+
+    #[test]
+    fn rejected_root_preserves_existing_watch() {
+        let tmpdir = tempfile::tempdir().unwrap();
+        let root = tmpdir.path().to_path_buf();
+        let child = root.join("child");
+        std::fs::create_dir_all(&child).unwrap();
+
+        let mut event_loop = test_event_loop();
+
+        event_loop
+            .add_watch(
+                WatchPath::new(&root).unwrap(),
+                true,
+                true,
+                WatchFilter::accept_all(),
+            )
+            .expect("watch recursively");
+        let before = event_loop
+            .watches
+            .keys()
+            .cloned()
+            .collect::<std::collections::HashSet<_>>();
+
+        let rejecting = root.clone();
+        let result = event_loop.add_watch(
+            WatchPath::new(&root).unwrap(),
+            true,
+            true,
+            WatchFilter::with_filter(move |p: &std::path::Path| p != rejecting),
+        );
+
+        assert!(
+            matches!(
+                result,
+                Err(Error {
+                    kind: ErrorKind::PathExcluded,
+                    ..
+                })
+            ),
+            "watching a rejected root must fail with PathExcluded: {result:?}"
+        );
+        assert_eq!(
+            event_loop
+                .watches
+                .keys()
+                .cloned()
+                .collect::<std::collections::HashSet<_>>(),
+            before,
+            "a failed rewatch must leave existing watches unchanged"
+        );
+    }
+
+    #[test]
+    fn symlink_to_excluded_directory_is_pruned() {
+        let tmpdir = tempfile::tempdir().unwrap();
+        let root = tmpdir.path().to_path_buf();
+        let excluded = root.join("excluded");
+        std::fs::create_dir_all(&excluded).unwrap();
+        let link = root.join("link");
+        std::os::unix::fs::symlink(&excluded, &link).unwrap();
+
+        // follow_symlinks defaults to true.
+        let mut event_loop = test_event_loop();
+
+        event_loop
+            .add_watch(
+                WatchPath::new(&root).unwrap(),
+                true,
+                true,
+                reject_name("excluded"),
+            )
+            .expect("watch recursively");
+
+        assert!(!event_loop.watches.contains_key(&excluded));
+        assert!(
+            !event_loop.watches.contains_key(&link),
+            "a symlink to an excluded directory must not be watched"
+        );
+    }
+
+    #[test]
+    fn identical_rewatch_is_noop() {
+        let tmpdir = tempfile::tempdir().unwrap();
+        let root = tmpdir.path().to_path_buf();
+        std::fs::create_dir_all(root.join("sub")).unwrap();
+
+        let mut event_loop = test_event_loop();
+
+        let filter = reject_name("excluded");
+        event_loop
+            .add_watch(WatchPath::new(&root).unwrap(), true, true, filter.clone())
+            .expect("watch root");
+
+        // A directory created behind the event loop's back is only discovered by a rebuild
+        // walk; the identical rewatch below must short-circuit and NOT rebuild.
+        let newdir = root.join("newdir");
+        std::fs::create_dir(&newdir).unwrap();
+        event_loop
+            .add_watch(WatchPath::new(&root).unwrap(), true, true, filter)
+            .expect("identical rewatch");
+        assert!(
+            !event_loop.watches.contains_key(&newdir),
+            "an identical rewatch must be a no-op, not a rebuild"
+        );
+
+        // Sanity check: a rewatch with a fresh filter DOES rebuild and discover it.
+        let fresh = reject_name("excluded");
+        event_loop
+            .add_watch(WatchPath::new(&root).unwrap(), true, true, fresh)
+            .expect("rewatch with fresh filter");
+        assert!(event_loop.watches.contains_key(&newdir));
     }
 
     #[test]
@@ -1026,16 +1252,25 @@ mod tests {
         let child = root.join("child");
         std::fs::create_dir(&child).unwrap();
 
-        let inotify = super::inotify_sys::Inotify::init().unwrap();
-        let mut event_loop = EventLoop::new(inotify, Box::new(|_| {}), &Config::default()).unwrap();
+        let mut event_loop = test_event_loop();
 
         event_loop
-            .add_watch(WatchPath::new(&root).unwrap(), true, true)
+            .add_watch(
+                WatchPath::new(&root).unwrap(),
+                true,
+                true,
+                WatchFilter::accept_all(),
+            )
             .expect("watch recursively");
         assert!(event_loop.watches.contains_key(&child));
 
         event_loop
-            .add_watch(WatchPath::new(&root).unwrap(), false, true)
+            .add_watch(
+                WatchPath::new(&root).unwrap(),
+                false,
+                true,
+                WatchFilter::accept_all(),
+            )
             .expect("rewatch non-recursively");
 
         let watch = event_loop.watches.get(&root).expect("root watch");
@@ -1053,20 +1288,30 @@ mod tests {
         let grandchild = child.join("grandchild");
         std::fs::create_dir_all(&grandchild).unwrap();
 
-        let inotify = super::inotify_sys::Inotify::init().unwrap();
-        let mut event_loop = EventLoop::new(inotify, Box::new(|_| {}), &Config::default()).unwrap();
+        let mut event_loop = test_event_loop();
 
         event_loop
-            .add_watch(WatchPath::new(&root).unwrap(), true, true)
+            .add_watch(
+                WatchPath::new(&root).unwrap(),
+                true,
+                true,
+                WatchFilter::accept_all(),
+            )
             .expect("watch root recursively");
         event_loop
-            .add_watch(WatchPath::new(&child).unwrap(), false, true)
+            .add_watch(
+                WatchPath::new(&child).unwrap(),
+                false,
+                true,
+                WatchFilter::accept_all(),
+            )
             .expect("watch child non-recursively");
         event_loop
             .add_watch(
                 WatchPath::from_parts(child.clone(), PathBuf::from("reported-child")),
                 false,
                 true,
+                WatchFilter::accept_all(),
             )
             .expect("rewatch child non-recursively");
 
@@ -1095,23 +1340,33 @@ mod tests {
         let grandchild = child.join("grandchild");
         std::fs::create_dir_all(&grandchild).unwrap();
 
-        let inotify = super::inotify_sys::Inotify::init().unwrap();
-        let mut event_loop = EventLoop::new(inotify, Box::new(|_| {}), &Config::default()).unwrap();
+        let mut event_loop = test_event_loop();
 
         event_loop
-            .add_watch(WatchPath::new(&root).unwrap(), true, true)
+            .add_watch(
+                WatchPath::new(&root).unwrap(),
+                true,
+                true,
+                WatchFilter::accept_all(),
+            )
             .expect("watch root recursively");
         event_loop
             .remove_watch(child.clone(), false)
             .expect("carve out child");
         event_loop
-            .add_watch(WatchPath::new(&child).unwrap(), false, true)
+            .add_watch(
+                WatchPath::new(&child).unwrap(),
+                false,
+                true,
+                WatchFilter::accept_all(),
+            )
             .expect("watch child non-recursively");
         event_loop
             .add_watch(
                 WatchPath::from_parts(child.clone(), PathBuf::from("reported-child")),
                 false,
                 true,
+                WatchFilter::accept_all(),
             )
             .expect("rewatch child non-recursively");
 
@@ -1286,11 +1541,15 @@ mod tests {
         let watched = tmpdir.path().join("watched");
         std::fs::create_dir(&watched).unwrap();
 
-        let inotify = super::inotify_sys::Inotify::init().unwrap();
-        let mut event_loop = EventLoop::new(inotify, Box::new(|_| {}), &Config::default()).unwrap();
+        let mut event_loop = test_event_loop();
 
         event_loop
-            .add_watch(WatchPath::new(&watched).unwrap(), false, true)
+            .add_watch(
+                WatchPath::new(&watched).unwrap(),
+                false,
+                true,
+                WatchFilter::accept_all(),
+            )
             .expect("add_watch");
 
         event_loop

--- a/notify/src/kqueue.rs
+++ b/notify/src/kqueue.rs
@@ -6,15 +6,17 @@
 
 use super::event::*;
 use super::{
-    Config, Error, ErrorKind, EventHandler, EventKindMask, RecursiveMode, Result, Watcher,
+    Config, Error, ErrorKind, EventHandler, EventKindMask, RecursiveMode, Result, WatchFilter,
+    Watcher,
 };
 use crate::paths::{
-    absolute_path, is_preserved_watch_root, preserved_watch_mode, preserved_watch_roots,
+    absolute_path, check_watch_barriers, filter_allows_dir, filter_keeps_walk_entry,
+    is_preserved_watch_root, preserved_watch_mode, preserved_watch_roots,
     recursive_user_watch_ancestor, reported_path, WatchMetadata as Watch, WatchPath,
 };
 use crate::{unbounded, Receiver, Sender};
 use kqueue::{EventData, EventFilter, FilterFlag, Ident};
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::fs::metadata;
 use std::os::unix::io::AsRawFd;
 use std::path::{Path, PathBuf};
@@ -39,6 +41,10 @@ struct EventLoop {
     kqueue: kqueue::Watcher,
     event_handler: Box<dyn EventHandler>,
     watches: HashMap<PathBuf, Watch>,
+    // Directories the filter excluded from watching. New-entry discovery treats "not watched"
+    // as "new", so excluded directories must be remembered or they would be re-discovered
+    // (and re-reported as created) on every write to their parent.
+    seen_excluded: HashSet<PathBuf>,
     follow_symlinks: bool,
     event_kinds: EventKindMask,
 }
@@ -51,7 +57,7 @@ pub struct KqueueWatcher {
 }
 
 enum EventLoopMsg {
-    AddWatch(WatchPath, RecursiveMode, Sender<Result<()>>),
+    AddWatch(WatchPath, RecursiveMode, WatchFilter, Sender<Result<()>>),
     RemoveWatch(PathBuf, Sender<Result<()>>),
     GetWatchedPaths(Sender<Vec<(PathBuf, RecursiveMode)>>),
     Shutdown,
@@ -83,6 +89,7 @@ impl EventLoop {
             kqueue,
             event_handler,
             watches: HashMap::new(),
+            seen_excluded: HashSet::new(),
             follow_symlinks,
             event_kinds,
         };
@@ -139,8 +146,13 @@ impl EventLoop {
     fn handle_messages(&mut self) {
         while let Ok(msg) = self.event_loop_rx.try_recv() {
             match msg {
-                EventLoopMsg::AddWatch(path, recursive_mode, tx) => {
-                    let _ = tx.send(self.add_watch(path, recursive_mode.is_recursive(), true));
+                EventLoopMsg::AddWatch(path, recursive_mode, watch_filter, tx) => {
+                    let _ = tx.send(self.add_watch(
+                        path,
+                        recursive_mode.is_recursive(),
+                        true,
+                        watch_filter,
+                    ));
                 }
                 EventLoopMsg::RemoveWatch(path, tx) => {
                     let _ = tx.send(self.remove_watch(path, false));
@@ -188,7 +200,7 @@ impl EventLoop {
                     let event_path = watch
                         .map(|watch| watch.reported_path.clone())
                         .unwrap_or_else(|| path.clone());
-                    let is_user_watch = watch.is_some_and(|watch| watch.is_user_watch);
+                    let mut extra_events: Vec<Result<Event>> = Vec::new();
                     let event = match data {
                         /*
                         TODO: Differentiate folders and files
@@ -217,42 +229,82 @@ impl EventLoop {
                                 } =>
                         {
                             // find which file is new in the directory by comparing it with our
-                            // list of known watches
-                            std::fs::read_dir(&path)
-                                .map(|dir| {
-                                    dir.filter_map(std::result::Result::ok)
+                            // list of known watches (and remembered excluded directories)
+                            match std::fs::read_dir(&path) {
+                                Ok(dir) => {
+                                    let watch_filter = watch
+                                        .map(|watch| watch.watch_filter.clone())
+                                        .unwrap_or_else(WatchFilter::accept_all);
+                                    // Tombstoned excluded directories that vanished from this
+                                    // directory never had their own watch to report their
+                                    // deletion; synthesize the Remove event the other backends
+                                    // deliver, and drop the tombstone so a re-creation is
+                                    // reported again (this also covers replacement by a file,
+                                    // which discovery below then announces as created).
+                                    self.seen_excluded.retain(|p| {
+                                        let still_excluded_dir = std::fs::symlink_metadata(p)
+                                            .is_ok_and(|metadata| metadata.is_dir());
+                                        if p.parent() != Some(path.as_path()) || still_excluded_dir
+                                        {
+                                            return true;
+                                        }
+                                        extra_events.push(Ok(Event::new(EventKind::Remove(
+                                            RemoveKind::Folder,
+                                        ))
+                                        .add_path(reported_path(&path, &event_path, p))));
+                                        false
+                                    });
+                                    let new_entry = dir
+                                        .filter_map(std::result::Result::ok)
                                         .map(|f| f.path())
-                                        .find(|f| !self.watches.contains_key(f))
-                                })
-                                .map(|file| {
-                                    if let Some(file) = file {
-                                        // watch this new file
+                                        .find(|f| {
+                                            !self.watches.contains_key(f)
+                                                && !self.seen_excluded.contains(f)
+                                        });
+                                    if let Some(file) = new_entry {
                                         let reported_file =
                                             reported_path(&path, &event_path, &file);
-                                        add_watches.push((
-                                            WatchPath::from_parts(
-                                                file.clone(),
-                                                reported_file.clone(),
-                                            ),
-                                            false,
-                                        ));
+                                        let is_symlink = std::fs::symlink_metadata(&file)
+                                            .map(|meta| meta.file_type().is_symlink())
+                                            .unwrap_or(false);
+                                        if file.is_dir()
+                                            && !filter_allows_dir(&watch_filter, &file, is_symlink)
+                                        {
+                                            // The filter gates directories: an excluded
+                                            // directory is reported as created but never
+                                            // watched. Remember it so it is not "discovered"
+                                            // again on every later write to this directory.
+                                            self.seen_excluded.insert(file.clone());
+                                        } else {
+                                            // watch this new file
+                                            add_watches.push((
+                                                WatchPath::from_parts(
+                                                    file.clone(),
+                                                    reported_file.clone(),
+                                                ),
+                                                false,
+                                                true,
+                                                watch_filter,
+                                            ));
+                                        }
 
-                                        Event::new(EventKind::Create(if file.is_dir() {
+                                        Ok(Event::new(EventKind::Create(if file.is_dir() {
                                             CreateKind::Folder
                                         } else if file.is_file() {
                                             CreateKind::File
                                         } else {
                                             CreateKind::Other
                                         }))
-                                        .add_path(reported_file)
+                                        .add_path(reported_file))
                                     } else {
-                                        Event::new(EventKind::Modify(ModifyKind::Data(
+                                        Ok(Event::new(EventKind::Modify(ModifyKind::Data(
                                             DataChange::Any,
                                         )))
-                                        .add_path(event_path)
+                                        .add_path(event_path))
                                     }
-                                })
-                                .map_err(Into::into)
+                                }
+                                Err(e) => Err(e.into()),
+                            }
                         }
 
                         // data was written to this file
@@ -298,15 +350,25 @@ impl EventLoop {
                             // also introduce a race condition, where multiple files could
                             // all ready be remove from the directory, and we could get out
                             // of sync.
-                            // So for now, until we find a better solution, let remove and
-                            // readd the whole directory.
-                            // This is a expensive operation, as we recursive through all
-                            // subdirectories.
-                            remove_watches.push((path.clone(), false));
-                            add_watches.push((
-                                WatchPath::from_parts(path.clone(), event_path.clone()),
-                                is_user_watch,
-                            ));
+                            // So for now, until we find a better solution, re-add the whole
+                            // directory: the walk registers watches for entries that appeared
+                            // (kqueue treats re-adding an existing kevent as an update, and
+                            // deleted children fire their own NOTE_DELETE), merging into the
+                            // existing entries. This is an expensive operation, as we recurse
+                            // through all subdirectories.
+                            //
+                            // The re-add is a non-user merge: it must not disturb the entry's
+                            // user metadata (requested mode and filter), so it re-walks with
+                            // the entry's current merged mode and stored chain coverage and
+                            // lets `WatchMetadata::new` preserve the user fields.
+                            if let Some(watch) = watch {
+                                add_watches.push((
+                                    WatchPath::from_parts(path.clone(), event_path.clone()),
+                                    false,
+                                    watch.is_recursive,
+                                    watch.watch_filter.clone(),
+                                ));
+                            }
                             Ok(Event::new(EventKind::Modify(ModifyKind::Any)).add_path(event_path))
                         }
 
@@ -332,11 +394,13 @@ impl EventLoop {
                     };
                     // Filter events based on EventKindMask
                     // Errors always pass through, OK events only if they match the mask
-                    match &event {
-                        Ok(e) if !self.event_kinds.matches(&e.kind) => {
-                            // Event filtered out
+                    for event in extra_events.into_iter().chain(std::iter::once(event)) {
+                        match &event {
+                            Ok(e) if !self.event_kinds.matches(&e.kind) => {
+                                // Event filtered out
+                            }
+                            _ => self.event_handler.handle_event(event),
                         }
-                        _ => self.event_handler.handle_event(event),
                     }
                 }
                 // as we don't add any other EVFILTER to kqueue we should never get here
@@ -348,8 +412,9 @@ impl EventLoop {
             self.remove_watch(path, remove_recursive).ok();
         }
 
-        for (path, is_user_watch) in add_watches {
-            self.add_watch(path, true, is_user_watch).ok();
+        for (path, is_user_watch, is_recursive, watch_filter) in add_watches {
+            self.add_watch(path, is_recursive, is_user_watch, watch_filter)
+                .ok();
         }
     }
 
@@ -358,83 +423,107 @@ impl EventLoop {
         path: WatchPath,
         is_recursive: bool,
         is_user_watch: bool,
+        watch_filter: WatchFilter,
     ) -> Result<()> {
         let path_is_dir = metadata(&path.absolute).map_err(Error::io)?.is_dir();
         let requested_is_recursive = is_recursive && path_is_dir;
+        let mut inherited_recursive_root = None;
         if is_user_watch {
+            check_watch_barriers(
+                &path.absolute,
+                &path.requested,
+                path_is_dir,
+                requested_is_recursive,
+                &watch_filter,
+                self.watches
+                    .iter()
+                    .filter(|(_, watch)| watch.is_user_watch)
+                    .map(|(path, watch)| {
+                        (
+                            path,
+                            watch.is_dir,
+                            watch.user_is_recursive,
+                            &watch.watch_filter,
+                        )
+                    }),
+            )?;
             if let Some(watch) = self
                 .watches
                 .get(&path.absolute)
                 .filter(|watch| watch.is_user_watch)
             {
-                if watch.user_is_recursive == requested_is_recursive
-                    && watch.reported_path == path.requested
-                {
+                if watch.rewatch_is_noop(&path, requested_is_recursive, &watch_filter) {
                     return Ok(());
                 }
 
-                // Rewatching an explicit user watch replaces its requested mode and reported path
-                // instead of merging with the previous metadata. If the current entry also carries
-                // recursive coverage from an ancestor, remember that ancestor before removal so we
-                // can rebuild that inherited coverage below.
-                let inherited_recursive_root =
-                    if !requested_is_recursive && path_is_dir && watch.is_recursive {
+                // Rewatching an explicit user watch replaces its requested mode, reported
+                // path, and filter instead of merging with the previous metadata. If a
+                // recursive ancestor also covers this directory, remember it so coverage
+                // the removal drops (or the new mode no longer provides) is rebuilt below;
+                // the overlap barrier guarantees such an ancestor is unfiltered.
+                inherited_recursive_root =
+                    if path_is_dir && !requested_is_recursive && watch.is_recursive {
                         recursive_user_watch_ancestor(&path.absolute, self.watches.iter())
                     } else {
                         None
                     };
-                let replaced_path = path.absolute.clone();
-                self.remove_watch(replaced_path.clone(), false)?;
-
-                if let Some((ancestor_path, ancestor_reported_path)) = inherited_recursive_root {
-                    // Removing a directory watch removes its recursively inherited children too.
-                    // Re-add them as non-user watches so the ancestor recursive watch still covers
-                    // this subtree after the user watch is replaced.
-                    for entry in WalkDir::new(&replaced_path)
-                        .follow_links(self.follow_symlinks)
-                        .into_iter()
-                    {
-                        let absolute = match entry {
-                            Ok(entry) => entry.into_path(),
-                            Err(err) if walkdir_error_is_not_found(&err) => continue,
-                            Err(err) => return Err(map_walkdir_error(err)),
-                        };
-                        let requested =
-                            reported_path(&ancestor_path, &ancestor_reported_path, &absolute);
-                        let result = self.add_single_watch(
-                            WatchPath::from_parts(absolute, requested),
-                            true,
-                            false,
-                        );
-                        if let Err(err) = result {
-                            if !error_is_not_found(&err) {
-                                return Err(err);
-                            }
-                        }
-                    }
-                }
+                self.remove_watch(path.absolute.clone(), false)?;
             }
         }
 
-        // If the watch is not recursive, or if we determine (by stat'ing the path to get its
-        // metadata) that the watched path is not a directory, add a single path watch.
+        // If the watch is not recursive, or if we determine (by stat'ing the path to get
+        // its metadata) that the watched path is not a directory, add a single path watch.
         if !requested_is_recursive {
-            self.add_single_watch(path, false, is_user_watch)?;
+            self.add_single_watch(path.clone(), false, is_user_watch, watch_filter)?;
         } else {
-            let root = path;
+            let root = path.clone();
             let mut first = true;
-            for entry in WalkDir::new(&root.absolute)
+            // Prune rejected directories manually: don't watch them and don't descend
+            // into them (shielding the walk from errors inside excluded subtrees), and
+            // remember them so runtime discovery doesn't treat them as new entries.
+            let mut walk = WalkDir::new(&root.absolute)
                 .follow_links(self.follow_symlinks)
-                .into_iter()
-            {
+                .into_iter();
+            while let Some(entry) = walk.next() {
                 let entry = entry.map_err(map_walkdir_error)?;
+                if !filter_keeps_walk_entry(&watch_filter, &entry) {
+                    let excluded = entry.into_path();
+                    walk.skip_current_dir();
+                    self.seen_excluded.insert(excluded);
+                    continue;
+                }
                 // WalkDir yields the root first; only it is the user-requested watch.
                 self.add_single_watch(
                     root.child(entry.into_path()),
                     is_recursive,
                     is_user_watch && first,
+                    watch_filter.clone(),
                 )?;
                 first = false;
+            }
+        }
+
+        if let Some((ancestor_path, ancestor_reported_path)) = inherited_recursive_root {
+            // Re-add, as non-user watches, the coverage the covering ancestor provides but
+            // the removal above dropped (or the new non-recursive mode no longer provides).
+            for entry in WalkDir::new(&path.absolute).follow_links(self.follow_symlinks) {
+                let absolute = match entry {
+                    Ok(entry) => entry.into_path(),
+                    Err(err) if walkdir_error_is_not_found(&err) => continue,
+                    Err(err) => return Err(map_walkdir_error(err)),
+                };
+                let requested = reported_path(&ancestor_path, &ancestor_reported_path, &absolute);
+                let result = self.add_single_watch(
+                    WatchPath::from_parts(absolute, requested),
+                    true,
+                    false,
+                    WatchFilter::accept_all(),
+                );
+                if let Err(err) = result {
+                    if !error_is_not_found(&err) {
+                        return Err(err);
+                    }
+                }
             }
         }
 
@@ -452,6 +541,7 @@ impl EventLoop {
         path: WatchPath,
         is_recursive: bool,
         is_user_watch: bool,
+        watch_filter: WatchFilter,
     ) -> Result<()> {
         let event_filter = EventFilter::EVFILT_VNODE;
         let filter_flags = FilterFlag::NOTE_DELETE
@@ -470,10 +560,12 @@ impl EventLoop {
         let existing_watch = self.watches.get(&path.absolute);
         let watch = Watch::new(
             &path,
+            path.absolute.is_dir(),
             is_recursive,
             is_user_watch,
             existing_watch,
             self.watches.iter(),
+            watch_filter,
         );
         self.watches.insert(path.absolute, watch);
 
@@ -525,6 +617,12 @@ impl EventLoop {
                         .map_err(|e| Error::io(e).add_path(path.clone()))?;
                 }
 
+                // Drop excluded-directory tombstones under the removed path. The overlap
+                // barrier guarantees they belonged to this watch alone (no other watch may
+                // overlap a filtered one). Runs only after a successful removal; a failed
+                // unwatch must not disturb tombstones.
+                self.seen_excluded.retain(|p| !p.starts_with(&path));
+
                 self.kqueue.watch()?;
             }
         }
@@ -565,10 +663,15 @@ impl KqueueWatcher {
         Ok(KqueueWatcher { channel, waker })
     }
 
-    fn watch_inner(&mut self, path: &Path, recursive_mode: RecursiveMode) -> Result<()> {
+    fn watch_inner(
+        &mut self,
+        path: &Path,
+        recursive_mode: RecursiveMode,
+        watch_filter: WatchFilter,
+    ) -> Result<()> {
         let pb = WatchPath::new(path)?;
         let (tx, rx) = unbounded();
-        let msg = EventLoopMsg::AddWatch(pb, recursive_mode, tx);
+        let msg = EventLoopMsg::AddWatch(pb, recursive_mode, watch_filter, tx);
 
         self.channel
             .send(msg)
@@ -611,8 +714,13 @@ impl Watcher for KqueueWatcher {
         )
     }
 
-    fn watch(&mut self, path: &Path, recursive_mode: RecursiveMode) -> Result<()> {
-        self.watch_inner(path, recursive_mode)
+    fn watch_filtered(
+        &mut self,
+        path: &Path,
+        recursive_mode: RecursiveMode,
+        watch_filter: WatchFilter,
+    ) -> Result<()> {
+        self.watch_inner(path, recursive_mode, watch_filter)
     }
 
     fn unwatch(&mut self, path: &Path) -> Result<()> {
@@ -663,6 +771,316 @@ mod tests {
     }
 
     #[test]
+    fn watch_filter_prunes_excluded_directories(
+    ) -> std::result::Result<(), Box<dyn std::error::Error>> {
+        let dir = tempfile::tempdir()?;
+        let excluded = dir.path().join("excluded");
+        let excluded_sub = excluded.join("sub");
+        let included = dir.path().join("included");
+        std::fs::create_dir_all(&excluded_sub)?;
+        std::fs::create_dir_all(&included)?;
+
+        let kqueue = kqueue::Watcher::new()?;
+        let mut event_loop = EventLoop::new(kqueue, Box::new(|_| {}), false, EventKindMask::ALL)?;
+
+        event_loop.add_watch(
+            WatchPath::new(dir.path())?,
+            true,
+            true,
+            WatchFilter::with_filter(|p: &Path| {
+                p.file_name() != Some(std::ffi::OsStr::new("excluded"))
+            }),
+        )?;
+
+        assert!(event_loop.watches.contains_key(dir.path()));
+        assert!(event_loop.watches.contains_key(&included));
+        assert!(!event_loop.watches.contains_key(&excluded));
+        assert!(
+            !event_loop.watches.contains_key(&excluded_sub),
+            "descent into excluded directories must be pruned"
+        );
+        assert!(
+            event_loop.seen_excluded.contains(&excluded),
+            "the walk must seed tombstones so discovery doesn't re-report pre-existing \
+             excluded directories as new"
+        );
+        assert!(
+            !event_loop.seen_excluded.contains(&excluded_sub),
+            "tombstones only cover the pruned root, not its unvisited contents"
+        );
+
+        Ok(())
+    }
+
+    #[test]
+    fn nonrecursive_rewatch_preserves_ancestor_filter(
+    ) -> std::result::Result<(), Box<dyn std::error::Error>> {
+        let dir = tempfile::tempdir()?;
+        let child = dir.path().join("child");
+        std::fs::create_dir_all(&child)?;
+
+        let kqueue = kqueue::Watcher::new()?;
+        let mut event_loop = EventLoop::new(kqueue, Box::new(|_| {}), false, EventKindMask::ALL)?;
+
+        event_loop.add_watch(
+            WatchPath::new(dir.path())?,
+            true,
+            true,
+            WatchFilter::with_filter(|p: &Path| {
+                p.file_name() != Some(std::ffi::OsStr::new("excluded"))
+            }),
+        )?;
+        // Simulates a plain `watch(child, NonRecursive)`, which passes an accept-all filter.
+        let result = event_loop.add_watch(
+            WatchPath::new(&child)?,
+            false,
+            true,
+            WatchFilter::accept_all(),
+        );
+        assert!(
+            matches!(result, Err(ref e) if matches!(e.kind, ErrorKind::Generic(_))),
+            "overlapping a filtered ancestor must fail, got {result:?}"
+        );
+
+        let stored = event_loop.watches.get(&child).expect("child watch");
+        assert!(stored.is_recursive, "child keeps inherited coverage");
+        assert!(
+            !stored.watch_filter.should_watch(&child.join("excluded")),
+            "the ancestor's filter must survive a non-recursive rewatch"
+        );
+
+        Ok(())
+    }
+
+    #[test]
+    fn rewatch_with_different_filter_rebuilds_watch(
+    ) -> std::result::Result<(), Box<dyn std::error::Error>> {
+        let dir = tempfile::tempdir()?;
+        let excluded = dir.path().join("excluded");
+        std::fs::create_dir_all(&excluded)?;
+
+        let kqueue = kqueue::Watcher::new()?;
+        let mut event_loop = EventLoop::new(kqueue, Box::new(|_| {}), false, EventKindMask::ALL)?;
+
+        event_loop.add_watch(
+            WatchPath::new(dir.path())?,
+            true,
+            true,
+            WatchFilter::with_filter(|p: &Path| {
+                p.file_name() != Some(std::ffi::OsStr::new("excluded"))
+            }),
+        )?;
+        assert!(!event_loop.watches.contains_key(&excluded));
+
+        // Re-watching with a different filter (here: accept-all) must rebuild the watch
+        // instead of short-circuiting as unchanged.
+        event_loop.add_watch(
+            WatchPath::new(dir.path())?,
+            true,
+            true,
+            WatchFilter::accept_all(),
+        )?;
+        assert!(
+            event_loop.watches.contains_key(&excluded),
+            "a rewatch with a different filter must take effect"
+        );
+
+        Ok(())
+    }
+
+    #[test]
+    fn rejected_root_preserves_existing_watch(
+    ) -> std::result::Result<(), Box<dyn std::error::Error>> {
+        let dir = tempfile::tempdir()?;
+        let child = dir.path().join("child");
+        std::fs::create_dir_all(&child)?;
+
+        let kqueue = kqueue::Watcher::new()?;
+        let mut event_loop = EventLoop::new(kqueue, Box::new(|_| {}), false, EventKindMask::ALL)?;
+
+        event_loop.add_watch(
+            WatchPath::new(dir.path())?,
+            true,
+            true,
+            WatchFilter::accept_all(),
+        )?;
+        let before = event_loop
+            .watches
+            .keys()
+            .cloned()
+            .collect::<std::collections::HashSet<_>>();
+
+        let rejecting = dir.path().to_path_buf();
+        let result = event_loop.add_watch(
+            WatchPath::new(dir.path())?,
+            true,
+            true,
+            WatchFilter::with_filter(move |p: &Path| p != rejecting.as_path()),
+        );
+
+        assert!(
+            matches!(result, Err(ref e) if matches!(e.kind, ErrorKind::PathExcluded)),
+            "watching a rejected root must fail with PathExcluded: {result:?}"
+        );
+        assert_eq!(
+            event_loop
+                .watches
+                .keys()
+                .cloned()
+                .collect::<std::collections::HashSet<_>>(),
+            before,
+            "a failed rewatch must leave existing watches unchanged"
+        );
+
+        Ok(())
+    }
+
+    // A directory the filter excludes is reported (its watched parent sees the change) but
+    // never watched, and is remembered as a tombstone so runtime discovery does not keep
+    // re-reporting it. Prove both halves: the create surfaces, and nothing beneath it leaks.
+    #[test]
+    fn runtime_excluded_directory_is_reported_but_not_watched() {
+        use crate::Watcher;
+        use std::time::{Duration, Instant};
+
+        let tmpdir = testdir();
+        let root = tmpdir.path();
+
+        let (mut watcher, mut rx) = watcher();
+        watcher
+            .watcher
+            .watch_filtered(root, RecursiveMode::Recursive, reject_name("excluded"))
+            .expect("watch filtered");
+
+        let excluded = root.join("excluded");
+        let included = root.join("included");
+
+        // kqueue discovers one new directory entry per write notification, so create the
+        // entries one at a time and wait for each discovery before creating the next.
+        std::fs::create_dir(&excluded).expect("create excluded");
+        rx.wait_unordered([expected(&excluded).create_folder()]);
+
+        std::fs::create_dir(&included).expect("create included");
+        rx.wait_unordered([expected(&included).create_folder()]);
+
+        // The runtime watch on `included` is installed just after its create event is
+        // emitted, so a single write could race ahead of the watch. Keep writing to both
+        // directories until an event from `included` arrives, and assert nothing ever
+        // leaks from inside the excluded (tombstoned, unwatched) directory.
+        let deadline = Instant::now() + Duration::from_secs(5);
+        let mut saw_included_file = false;
+        while !saw_included_file && Instant::now() < deadline {
+            std::fs::write(excluded.join("hidden.txt"), "x").expect("write hidden");
+            std::fs::write(included.join("seen.txt"), "x").expect("write seen");
+
+            let attempt_deadline = Instant::now() + Duration::from_millis(200);
+            while !saw_included_file && Instant::now() < attempt_deadline {
+                if let Ok(Ok(event)) = rx.rx.recv_timeout(Duration::from_millis(50)) {
+                    assert!(
+                        !event
+                            .paths
+                            .iter()
+                            .any(|p| p.starts_with(&excluded) && *p != excluded),
+                        "event leaked from inside the excluded directory: {event:?}"
+                    );
+                    saw_included_file = event.paths.iter().any(|p| p.starts_with(&included));
+                }
+            }
+        }
+        assert!(
+            saw_included_file,
+            "expected an event from inside the included directory"
+        );
+    }
+
+    // A pre-existing excluded directory is tombstoned by the initial walk and has no fd of
+    // its own, so it cannot signal its own deletion. When it vanishes, the write to its
+    // watched parent must make the backend synthesize the Remove event it could not emit.
+    #[test]
+    fn deleting_tombstoned_excluded_directory_reports_synthesized_remove() {
+        use crate::Watcher;
+
+        let tmpdir = testdir();
+        let root = tmpdir.path();
+
+        let excluded = root.join("excluded");
+        std::fs::create_dir(&excluded).expect("create excluded");
+
+        let (mut watcher, mut rx) = watcher();
+        watcher
+            .watcher
+            .watch_filtered(root, RecursiveMode::Recursive, reject_name("excluded"))
+            .expect("watch filtered");
+
+        std::fs::remove_dir(&excluded).expect("remove excluded");
+        rx.wait_unordered([expected(&excluded).remove_folder()]);
+    }
+
+    // Deleting a tombstoned excluded directory must also drop its tombstone, so that a later
+    // re-creation is discovered and reported as new again rather than being swallowed as an
+    // already-known entry. This is the observable proof that the tombstone drop happened.
+    #[test]
+    fn recreating_excluded_directory_after_deletion_is_reported_again() {
+        use crate::Watcher;
+
+        let tmpdir = testdir();
+        let root = tmpdir.path();
+
+        let excluded = root.join("excluded");
+        std::fs::create_dir(&excluded).expect("create excluded");
+
+        let (mut watcher, mut rx) = watcher();
+        watcher
+            .watcher
+            .watch_filtered(root, RecursiveMode::Recursive, reject_name("excluded"))
+            .expect("watch filtered");
+
+        std::fs::remove_dir(&excluded).expect("remove excluded");
+        rx.wait_unordered([expected(&excluded).remove_folder()]);
+
+        std::fs::create_dir(&excluded).expect("recreate excluded");
+        rx.wait_unordered([expected(&excluded).create_folder()]);
+    }
+
+    // Unwatching a root drops the tombstones seeded beneath it. The overlap barrier
+    // guarantees those tombstones belonged to this watch alone, so none may survive it.
+    #[test]
+    fn unwatch_drops_excluded_tombstones() -> std::result::Result<(), Box<dyn std::error::Error>> {
+        let dir = tempfile::tempdir()?;
+        let excluded = dir.path().join("excluded");
+        std::fs::create_dir_all(&excluded)?;
+
+        let kqueue = kqueue::Watcher::new()?;
+        let mut event_loop = EventLoop::new(kqueue, Box::new(|_| {}), false, EventKindMask::ALL)?;
+
+        event_loop.add_watch(
+            WatchPath::new(dir.path())?,
+            true,
+            true,
+            reject_name("excluded"),
+        )?;
+        assert!(
+            event_loop.seen_excluded.contains(&excluded),
+            "the initial walk must seed a tombstone for the excluded directory"
+        );
+
+        // `false` mirrors the real `unwatch()` path; the watch's own recursive flag still
+        // drives the recursive teardown that reaches the tombstone cleanup.
+        event_loop.remove_watch(dir.path().to_path_buf(), false)?;
+        assert!(
+            !event_loop.seen_excluded.contains(&excluded),
+            "unwatching the root must drop tombstones beneath it"
+        );
+        assert!(
+            event_loop.seen_excluded.is_empty(),
+            "no tombstone may outlive removal of its only watch: {:?}",
+            event_loop.seen_excluded
+        );
+
+        Ok(())
+    }
+
+    #[test]
     fn internal_recursive_refresh_preserves_explicit_child(
     ) -> std::result::Result<(), Box<dyn std::error::Error>> {
         let dir = tempfile::tempdir()?;
@@ -672,8 +1090,18 @@ mod tests {
         let kqueue = kqueue::Watcher::new()?;
         let mut event_loop = EventLoop::new(kqueue, Box::new(|_| {}), false, EventKindMask::ALL)?;
 
-        event_loop.add_watch(WatchPath::new(dir.path())?, true, true)?;
-        event_loop.add_watch(WatchPath::new(&child)?, false, true)?;
+        event_loop.add_watch(
+            WatchPath::new(dir.path())?,
+            true,
+            true,
+            WatchFilter::accept_all(),
+        )?;
+        event_loop.add_watch(
+            WatchPath::new(&child)?,
+            false,
+            true,
+            WatchFilter::accept_all(),
+        )?;
 
         event_loop.remove_watch(dir.path().to_path_buf(), false)?;
         assert!(
@@ -684,7 +1112,12 @@ mod tests {
             "internal refresh removed explicit child watch"
         );
 
-        event_loop.add_watch(WatchPath::new(dir.path())?, true, true)?;
+        event_loop.add_watch(
+            WatchPath::new(dir.path())?,
+            true,
+            true,
+            WatchFilter::accept_all(),
+        )?;
 
         let watched: HashMap<_, _> = event_loop
             .watches
@@ -708,7 +1141,12 @@ mod tests {
         let kqueue = kqueue::Watcher::new()?;
         let mut event_loop = EventLoop::new(kqueue, Box::new(|_| {}), false, EventKindMask::ALL)?;
 
-        event_loop.add_watch(WatchPath::new(dir.path())?, true, true)?;
+        event_loop.add_watch(
+            WatchPath::new(dir.path())?,
+            true,
+            true,
+            WatchFilter::accept_all(),
+        )?;
         assert!(event_loop.watches.contains_key(&child));
 
         std::fs::remove_file(&child)?;
@@ -729,10 +1167,20 @@ mod tests {
         let kqueue = kqueue::Watcher::new()?;
         let mut event_loop = EventLoop::new(kqueue, Box::new(|_| {}), false, EventKindMask::ALL)?;
 
-        event_loop.add_watch(WatchPath::new(dir.path())?, true, true)?;
+        event_loop.add_watch(
+            WatchPath::new(dir.path())?,
+            true,
+            true,
+            WatchFilter::accept_all(),
+        )?;
         assert!(event_loop.watches.contains_key(&child));
 
-        event_loop.add_watch(WatchPath::new(dir.path())?, false, true)?;
+        event_loop.add_watch(
+            WatchPath::new(dir.path())?,
+            false,
+            true,
+            WatchFilter::accept_all(),
+        )?;
 
         let watch = event_loop.watches.get(dir.path()).expect("root watch");
         assert!(watch.is_user_watch);
@@ -754,12 +1202,23 @@ mod tests {
         let kqueue = kqueue::Watcher::new()?;
         let mut event_loop = EventLoop::new(kqueue, Box::new(|_| {}), false, EventKindMask::ALL)?;
 
-        event_loop.add_watch(WatchPath::new(dir.path())?, true, true)?;
-        event_loop.add_watch(WatchPath::new(&child)?, false, true)?;
+        event_loop.add_watch(
+            WatchPath::new(dir.path())?,
+            true,
+            true,
+            WatchFilter::accept_all(),
+        )?;
+        event_loop.add_watch(
+            WatchPath::new(&child)?,
+            false,
+            true,
+            WatchFilter::accept_all(),
+        )?;
         event_loop.add_watch(
             WatchPath::from_parts(child.clone(), PathBuf::from("reported-child")),
             false,
             true,
+            WatchFilter::accept_all(),
         )?;
 
         let child_watch = event_loop.watches.get(&child).expect("child watch");
@@ -789,13 +1248,24 @@ mod tests {
         let kqueue = kqueue::Watcher::new()?;
         let mut event_loop = EventLoop::new(kqueue, Box::new(|_| {}), false, EventKindMask::ALL)?;
 
-        event_loop.add_watch(WatchPath::new(dir.path())?, true, true)?;
+        event_loop.add_watch(
+            WatchPath::new(dir.path())?,
+            true,
+            true,
+            WatchFilter::accept_all(),
+        )?;
         event_loop.remove_watch(child.clone(), false)?;
-        event_loop.add_watch(WatchPath::new(&child)?, false, true)?;
+        event_loop.add_watch(
+            WatchPath::new(&child)?,
+            false,
+            true,
+            WatchFilter::accept_all(),
+        )?;
         event_loop.add_watch(
             WatchPath::from_parts(child.clone(), PathBuf::from("reported-child")),
             false,
             true,
+            WatchFilter::accept_all(),
         )?;
 
         let child_watch = event_loop.watches.get(&child).expect("child watch");

--- a/notify/src/lib.rs
+++ b/notify/src/lib.rs
@@ -177,6 +177,7 @@ pub use config::{Config, PathOp, RecursiveMode, WatchPathConfig, WindowsPathSepa
 pub use error::{Error, ErrorKind, Result, UpdatePathsError};
 pub use notify_types::event::{self, Event, EventKind, EventKindMask};
 use std::path::{Path, PathBuf};
+use std::sync::Arc;
 
 pub(crate) type StdResult<T, E> = std::result::Result<T, E>;
 pub(crate) type Receiver<T> = std::sync::mpsc::Receiver<T>;
@@ -323,6 +324,121 @@ pub enum WatcherKind {
     NullWatcher,
 }
 
+type FilterFn = dyn Fn(&Path) -> bool + Send + Sync;
+
+/// Directory filter to limit what gets watched.
+///
+/// A directory for which the filter returns `false` is not watched: recursive scans do not
+/// descend into it and events beneath it are suppressed. The filter receives backend-resolved
+/// absolute paths. It is only ever applied to directories: it is not applied to non-directory
+/// children of an accepted directory (events for files inside a watched directory are always
+/// delivered), and watching a non-directory path is never affected by the filter.
+#[derive(Clone)]
+pub struct WatchFilter(Option<Arc<FilterFn>>);
+
+impl std::fmt::Debug for WatchFilter {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_tuple("WatchFilter")
+            .field(&self.0.as_ref().map_or("no filter", |_| "filter fn"))
+            .finish()
+    }
+}
+
+impl WatchFilter {
+    /// A filter that accepts any path, use to watch all paths.
+    #[must_use]
+    pub fn accept_all() -> WatchFilter {
+        WatchFilter(None)
+    }
+
+    /// A filter to limit the paths that get watched.
+    ///
+    /// Only paths for which `filter` returns `true` will be watched. The filter must not
+    /// panic; a panic is caught, logged, and treated as `false` (with `panic = "abort"` there
+    /// is no unwinding to catch, so a panicking filter aborts the process instead).
+    #[must_use]
+    pub fn with_filter(filter: impl Fn(&Path) -> bool + Send + Sync + 'static) -> WatchFilter {
+        WatchFilter(Some(Arc::new(filter)))
+    }
+
+    /// Returns whether `path` passes this filter.
+    ///
+    /// Always returns `true` for [`WatchFilter::accept_all`]. If the filter closure panics,
+    /// the panic is caught and logged, and the path is treated as rejected. `Watcher`
+    /// implementations call this to decide whether a directory should be watched.
+    #[must_use]
+    pub fn should_watch(&self, path: &Path) -> bool {
+        let Some(filter) = self.0.as_ref() else {
+            return true;
+        };
+        std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| filter(path))).unwrap_or_else(
+            |_| {
+                log::error!(
+                    "watch filter panicked for path {}; treating it as rejected",
+                    path.display()
+                );
+                false
+            },
+        )
+    }
+
+    /// Returns whether this filter is [`WatchFilter::accept_all`], i.e. it never rejects any
+    /// path. `Watcher` implementations can use this to skip filtering work entirely.
+    #[must_use]
+    pub fn is_accept_all(&self) -> bool {
+        self.0.is_none()
+    }
+
+    /// Returns whether `self` and `other` are the same filter: both accept-all, or both
+    /// sharing the same underlying closure (pointer identity, not behavioral equality). Two
+    /// independently-built filters with identical behavior are not considered the same.
+    ///
+    /// `Watcher` implementations and wrappers use this to detect filter changes on rewatch:
+    /// re-registering a path with the same mode and the same filter can be treated as a
+    /// no-op instead of tearing the watch down and rebuilding it.
+    #[must_use]
+    pub fn same_filter(&self, other: &Self) -> bool {
+        match (&self.0, &other.0) {
+            (None, None) => true,
+            (Some(a), Some(b)) => Arc::ptr_eq(a, b),
+            _ => false,
+        }
+    }
+
+    /// Whether a watch root at `absolute` is rejected by this filter under the documented
+    /// contract: the filter gates directories only, so non-directory roots are never
+    /// rejected. This is the basic root check for already-resolved paths; backends that
+    /// accept symlink paths must also check the resolved directory target.
+    #[must_use]
+    pub fn rejects_root(&self, absolute: &Path, is_dir: bool) -> bool {
+        is_dir && !self.should_watch(absolute)
+    }
+
+    /// Event-time equivalent of directory gating for backends that cannot selectively watch
+    /// directories (FSEvents, ReadDirectoryChangesW): an event is allowed unless one of the
+    /// strict ancestors of its path below `root` (exclusive) is rejected by the filter.
+    // Only used by the FSEvents and Windows backends; dead on targets that compile neither
+    // (including macOS builds where `macos_kqueue` replaces the FSEvents backend).
+    #[allow(dead_code)]
+    pub(crate) fn allows_event_under(&self, root: &Path, path: &Path) -> bool {
+        if self.is_accept_all() {
+            return true;
+        }
+        let Some(parent) = path.parent() else {
+            return true;
+        };
+        for ancestor in parent.ancestors() {
+            if ancestor == root || !ancestor.starts_with(root) {
+                break;
+            }
+            if !self.should_watch(ancestor) {
+                return false;
+            }
+        }
+        true
+    }
+}
+
 /// Type that can deliver file activity notifications
 ///
 /// `Watcher` is implemented per platform using the best implementation available on that platform.
@@ -376,7 +492,72 @@ pub trait Watcher {
     ///
     /// [#165]: https://github.com/notify-rs/notify/issues/165
     /// [#166]: https://github.com/notify-rs/notify/issues/166
-    fn watch(&mut self, path: &Path, recursive_mode: RecursiveMode) -> Result<()>;
+    fn watch(&mut self, path: &Path, recursive_mode: RecursiveMode) -> Result<()> {
+        self.watch_filtered(path, recursive_mode, WatchFilter::accept_all())
+    }
+
+    /// Begin watching a new path, excluding directories rejected by `watch_filter`.
+    ///
+    /// Behaves like [`Watcher::watch`], except that directories for which `watch_filter`
+    /// returns `false` are not watched: recursive scans do not descend into them, directories
+    /// discovered later (e.g. created under a recursive watch) are checked against the filter
+    /// before being watched, and events beneath rejected directories are suppressed. The filter
+    /// receives backend-resolved absolute paths, so match on path components or prefixes, not
+    /// on relative names. Events for non-directory children of an accepted directory are always
+    /// delivered. Events for an excluded directory itself may still be reported by a watched
+    /// parent (for example, its creation or removal), but events beneath that directory are
+    /// suppressed.
+    ///
+    /// The filter only applies to directories: watching a non-directory `path` is never
+    /// affected by the filter.
+    ///
+    /// # Errors
+    ///
+    /// Violating either restriction below returns an error and leaves all watches
+    /// unchanged:
+    ///
+    /// - Watching a directory the filter itself rejects returns
+    ///   [`ErrorKind::PathExcluded`]. A `path` that is a symlink to a directory is checked
+    ///   against both the link path and its resolved target.
+    /// - A directory watch carrying a filter must not overlap another directory watch in
+    ///   either direction; filters are never merged across watches. Watches whose filters
+    ///   are all [`WatchFilter::accept_all`] may overlap as before, file watches never
+    ///   conflict, and re-watching the same `path` replaces that watch as usual. To
+    ///   observe a region inside a filtered subtree, use a separate `Watcher` instance.
+    ///
+    /// Backend notes: the `PollWatcher` applies the filter when scanning; FSEvents (macOS) and
+    /// ReadDirectoryChangesW (Windows) cannot selectively watch directories, so the filter is
+    /// applied to event paths at delivery time with equivalent semantics (an event is
+    /// suppressed when a strict ancestor below the watch root is rejected). On macOS the
+    /// filter sees canonicalized paths (symlinks resolved, e.g. `/private/tmp` rather than
+    /// `/tmp`); on Windows it sees native `\`-separated absolute paths regardless of
+    /// [`Config::with_windows_path_separator_style`], so match on [`Path::components`] rather
+    /// than on separator-sensitive strings.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// use notify::{RecursiveMode, WatchFilter, Watcher};
+    /// use std::path::Path;
+    ///
+    /// # fn main() -> notify::Result<()> {
+    /// let mut watcher = notify::recommended_watcher(|_res| {})?;
+    /// watcher.watch_filtered(
+    ///     Path::new("."),
+    ///     RecursiveMode::Recursive,
+    ///     WatchFilter::with_filter(|path: &Path| {
+    ///         path.file_name() != Some(std::ffi::OsStr::new(".git"))
+    ///     }),
+    /// )?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    fn watch_filtered(
+        &mut self,
+        path: &Path,
+        recursive_mode: RecursiveMode,
+        watch_filter: WatchFilter,
+    ) -> Result<()>;
 
     /// Stop watching a path.
     ///
@@ -422,10 +603,13 @@ pub trait Watcher {
     /// # Ok(())
     /// # }
     /// ```
+    // The error intentionally carries the failed and unapplied `PathOp`s back to the caller,
+    // which makes it larger than clippy's default threshold.
+    #[allow(clippy::result_large_err)]
     fn update_paths(&mut self, ops: Vec<PathOp>) -> StdResult<(), UpdatePathsError> {
         update_paths(ops, |op| match op {
             PathOp::Watch(path, config) => self
-                .watch(&path, config.recursive_mode())
+                .watch_filtered(&path, config.recursive_mode(), config.watch_filter())
                 .map_err(|e| (PathOp::Watch(path, config), e)),
             PathOp::Unwatch(path) => self.unwatch(&path).map_err(|e| (PathOp::Unwatch(path), e)),
         })
@@ -520,6 +704,9 @@ where
     RecommendedWatcher::new(event_handler, Config::default())
 }
 
+// The error intentionally carries the failed and unapplied `PathOp`s back to the caller,
+// which makes it larger than clippy's default threshold.
+#[allow(clippy::result_large_err)]
 pub(crate) fn update_paths<F>(ops: Vec<PathOp>, mut apply: F) -> StdResult<(), UpdatePathsError>
 where
     F: FnMut(PathOp) -> StdResult<(), (PathOp, Error)>,
@@ -551,13 +738,84 @@ mod tests {
 
     use super::{
         Config, Error, ErrorKind, Event, NullWatcher, PathOp, PollWatcher, RecommendedWatcher,
-        RecursiveMode, Result, StdResult, WatchPathConfig, Watcher, WatcherKind,
+        RecursiveMode, Result, StdResult, WatchFilter, WatchPathConfig, Watcher, WatcherKind,
     };
     use crate::test::*;
 
     #[test]
     fn test_object_safe() {
         let _watcher: &dyn Watcher = &NullWatcher;
+    }
+
+    #[test]
+    fn watch_filter_accept_all_accepts_everything() {
+        let filter = WatchFilter::accept_all();
+        assert!(filter.is_accept_all());
+        assert!(filter.should_watch(Path::new("/any/path")));
+    }
+
+    #[test]
+    fn watch_filter_applies_closure() {
+        let filter = reject_name("excluded");
+        assert!(!filter.is_accept_all());
+        assert!(filter.should_watch(Path::new("/root/included")));
+        assert!(!filter.should_watch(Path::new("/root/excluded")));
+    }
+
+    #[test]
+    fn watch_filter_panic_is_caught_and_rejects() {
+        let filter = WatchFilter::with_filter(|_: &Path| panic!("filter panicked"));
+        assert!(!filter.should_watch(Path::new("/some/path")));
+    }
+
+    #[test]
+    fn watch_filter_allows_event_under_gates_on_ancestor_directories() {
+        let root = Path::new("/watch/root");
+        let filter = reject_name("excluded");
+
+        // Files directly under the root are always allowed.
+        assert!(filter.allows_event_under(root, Path::new("/watch/root/file.txt")));
+        // An event on the rejected directory itself is delivered (its parent is watched),
+        // matching the walk-based backends.
+        assert!(filter.allows_event_under(root, Path::new("/watch/root/excluded")));
+        // Events beneath a rejected directory are suppressed, at any depth.
+        assert!(!filter.allows_event_under(root, Path::new("/watch/root/excluded/file.txt")));
+        assert!(!filter.allows_event_under(root, Path::new("/watch/root/excluded/deep/file.txt")));
+        assert!(filter.allows_event_under(root, Path::new("/watch/root/ok/file.txt")));
+        // The accept-all fast path never rejects.
+        assert!(WatchFilter::accept_all()
+            .allows_event_under(root, Path::new("/watch/root/excluded/file.txt")));
+        // An event on the watch root itself has no gating ancestors.
+        assert!(filter.allows_event_under(root, root));
+    }
+
+    #[test]
+    fn watch_filter_debug_names_the_type() {
+        assert!(format!("{:?}", WatchFilter::accept_all()).contains("WatchFilter"));
+        assert!(format!("{:?}", WatchFilter::with_filter(|_: &Path| true)).contains("WatchFilter"));
+    }
+
+    #[test]
+    fn watch_filter_same_filter_uses_identity() {
+        let f = WatchFilter::with_filter(|_: &Path| true);
+        assert!(f.same_filter(&f.clone()), "clones share the closure");
+        assert!(WatchFilter::accept_all().same_filter(&WatchFilter::accept_all()));
+        assert!(!f.same_filter(&WatchFilter::accept_all()));
+        assert!(
+            !f.same_filter(&WatchFilter::with_filter(|_: &Path| true)),
+            "independently built filters are distinct even if behaviorally identical"
+        );
+    }
+
+    #[test]
+    fn watch_path_config_carries_watch_filter() {
+        let config = WatchPathConfig::new(RecursiveMode::Recursive).with_watch_filter(
+            WatchFilter::with_filter(|p: &Path| !p.ends_with("excluded")),
+        );
+        assert!(config.watch_filter().should_watch(Path::new("/root/other")));
+        assert!(!config
+            .watch_filter()
+            .should_watch(Path::new("/root/excluded")));
     }
 
     #[test]

--- a/notify/src/null.rs
+++ b/notify/src/null.rs
@@ -4,7 +4,7 @@
 
 use crate::Config;
 
-use super::{RecursiveMode, Result, Watcher};
+use super::{RecursiveMode, Result, WatchFilter, Watcher};
 use std::path::{Path, PathBuf};
 
 /// Stub `Watcher` implementation
@@ -14,7 +14,12 @@ use std::path::{Path, PathBuf};
 pub struct NullWatcher;
 
 impl Watcher for NullWatcher {
-    fn watch(&mut self, path: &Path, recursive_mode: RecursiveMode) -> Result<()> {
+    fn watch_filtered(
+        &mut self,
+        path: &Path,
+        recursive_mode: RecursiveMode,
+        watch_filter: WatchFilter,
+    ) -> Result<()> {
         Ok(())
     }
 

--- a/notify/src/paths.rs
+++ b/notify/src/paths.rs
@@ -1,4 +1,4 @@
-use crate::{Error, Result};
+use crate::{Error, Result, WatchFilter};
 use std::{
     env,
     path::{Path, PathBuf},
@@ -12,10 +12,17 @@ pub(crate) struct WatchPath {
 
 #[derive(Clone, Debug)]
 pub(crate) struct WatchMetadata {
+    #[allow(dead_code)]
+    pub(crate) is_dir: bool,
     pub(crate) is_recursive: bool,
     pub(crate) reported_path: PathBuf,
     pub(crate) is_user_watch: bool,
     pub(crate) user_is_recursive: bool,
+    /// The filter governing this entry: the user's requested filter for user watches
+    /// (compared on rewatch), and the covering root's filter for entries added by that
+    /// root's walks and discovery. The overlap barrier in [`check_watch_barriers`] keeps
+    /// filtered watches disjoint, so a single filter per entry is sufficient.
+    pub(crate) watch_filter: WatchFilter,
 }
 
 impl WatchPath {
@@ -42,10 +49,12 @@ impl WatchPath {
 impl WatchMetadata {
     pub(crate) fn new<'a, I>(
         path: &WatchPath,
+        is_dir: bool,
         is_recursive: bool,
         is_user_watch: bool,
         existing_watch: Option<&Self>,
-        user_roots: I,
+        _watches: I,
+        watch_filter: WatchFilter,
     ) -> Self
     where
         I: IntoIterator<Item = (&'a PathBuf, &'a Self)>,
@@ -56,36 +65,192 @@ impl WatchMetadata {
             existing_watch.is_some_and(|watch| watch.user_is_recursive);
         let existing_is_recursive = existing_watch.is_some_and(|watch| watch.is_recursive);
 
+        let user_is_recursive = if is_user_watch {
+            is_recursive
+        } else {
+            existing_user_is_recursive
+        };
+        // A user watch records the filter the user passed; merging a walk entry over an
+        // existing user watch must not disturb it (the walk's filter is that of a plain
+        // overlapping root, which the overlap barrier guarantees is accept-all).
+        let watch_filter = if !is_user_watch && existing_is_user_watch {
+            existing_watch
+                .map(|watch| watch.watch_filter.clone())
+                .unwrap_or_else(WatchFilter::accept_all)
+        } else {
+            watch_filter
+        };
+
         let reported_path = if is_user_watch {
             path.requested.clone()
         } else if existing_is_user_watch {
             existing_reported_path.unwrap_or_else(|| path.requested.clone())
         } else {
-            user_roots
-                .into_iter()
-                .filter(|(candidate, watch)| {
-                    watch.is_user_watch
-                        && watch.user_is_recursive
-                        && path.absolute.starts_with(candidate)
-                })
-                .max_by_key(|(candidate, _)| candidate.as_os_str().len())
-                .map_or_else(
-                    || path.requested.clone(),
-                    |(root, watch)| reported_path(root, &watch.reported_path, &path.absolute),
-                )
+            path.requested.clone()
         };
 
         Self {
             is_recursive: is_recursive || existing_is_recursive,
+            is_dir,
             reported_path,
             is_user_watch: is_user_watch || existing_is_user_watch,
-            user_is_recursive: if is_user_watch {
-                is_recursive
-            } else {
-                existing_user_is_recursive
-            },
+            user_is_recursive,
+            watch_filter,
         }
     }
+
+    /// Whether a user rewatch with these parameters requests exactly the current watch, so
+    /// the backend can skip the teardown/rebuild entirely.
+    pub(crate) fn rewatch_is_noop(
+        &self,
+        path: &WatchPath,
+        requested_is_recursive: bool,
+        watch_filter: &WatchFilter,
+    ) -> bool {
+        self.user_is_recursive == requested_is_recursive
+            && self.reported_path == path.requested
+            && self.watch_filter.same_filter(watch_filter)
+    }
+}
+
+/// Enforces both `watch_filtered` barriers for a user watch request, before any backend
+/// state is touched: a directory root the filter itself rejects (checking a symlink root's
+/// target too) is refused with [`crate::ErrorKind::PathExcluded`], and a directory watch
+/// involving a filter may not overlap another user directory watch in either direction,
+/// since filters are never merged across watches. Accept-all watches keep the pre-filter
+/// overlap semantics; file watches never conflict.
+pub(crate) fn check_watch_barriers<'a, I>(
+    absolute: &Path,
+    requested: &Path,
+    is_dir: bool,
+    is_recursive: bool,
+    watch_filter: &WatchFilter,
+    user_watches: I,
+) -> Result<()>
+where
+    I: IntoIterator<Item = (&'a PathBuf, bool, bool, &'a WatchFilter)>,
+{
+    if root_rejected(watch_filter, absolute, is_dir) {
+        return Err(Error::path_excluded().add_path(requested.to_path_buf()));
+    }
+    if let Some(conflicting) =
+        filtered_watch_conflict(absolute, is_dir, is_recursive, watch_filter, user_watches)
+    {
+        return Err(
+            Error::generic("a watch with a filter must not overlap another watch")
+                .add_path(requested.to_path_buf())
+                .add_path(conflicting),
+        );
+    }
+    Ok(())
+}
+
+/// Returns the path of an existing user watch the new watch may not coexist with, if any.
+/// See [`check_watch_barriers`] for the contract.
+fn filtered_watch_conflict<'a, I>(
+    path: &Path,
+    path_is_dir: bool,
+    is_recursive: bool,
+    watch_filter: &WatchFilter,
+    user_watches: I,
+) -> Option<PathBuf>
+where
+    I: IntoIterator<Item = (&'a PathBuf, bool, bool, &'a WatchFilter)>,
+{
+    if !path_is_dir {
+        return None;
+    }
+    let canonical_path = std::fs::canonicalize(path).ok();
+    for (candidate, candidate_is_dir, candidate_is_recursive, candidate_filter) in user_watches {
+        if !candidate_is_dir {
+            continue;
+        }
+        if candidate.as_path() == path {
+            // Rewatching the same path replaces the watch.
+            continue;
+        }
+        if watch_filter.is_accept_all() && candidate_filter.is_accept_all() {
+            continue;
+        }
+        let canonical_candidate = std::fs::canonicalize(candidate).ok();
+        let covers_new = candidate_is_recursive
+            && any_starts_with(
+                path,
+                canonical_path.as_deref(),
+                candidate,
+                canonical_candidate.as_deref(),
+            );
+        // The new watch only covers existing DIRECTORY watches; a watched file inside the
+        // new subtree does not interact with directory filtering.
+        let new_covers = is_recursive
+            && any_starts_with(
+                candidate,
+                canonical_candidate.as_deref(),
+                path,
+                canonical_path.as_deref(),
+            );
+        if covers_new || new_covers {
+            return Some(candidate.clone());
+        }
+    }
+    None
+}
+
+fn any_starts_with(
+    path: &Path,
+    canonical_path: Option<&Path>,
+    prefix: &Path,
+    canonical_prefix: Option<&Path>,
+) -> bool {
+    path.starts_with(prefix)
+        || canonical_path.is_some_and(|path| path.starts_with(prefix))
+        || canonical_prefix.is_some_and(|prefix| path.starts_with(prefix))
+        || canonical_path
+            .zip(canonical_prefix)
+            .is_some_and(|(path, prefix)| path.starts_with(prefix))
+}
+
+/// Root-level filter gate shared by the backends: whether the directory root at `absolute`
+/// is rejected by `filter`. A symlink root is checked against its resolved target too, so
+/// an excluded directory cannot be watched through a link. Non-directories are never
+/// rejected: the filter gates directories only.
+fn root_rejected(filter: &WatchFilter, absolute: &Path, is_dir: bool) -> bool {
+    if !is_dir || filter.is_accept_all() {
+        return false;
+    }
+    let is_symlink = std::fs::symlink_metadata(absolute)
+        .map(|meta| meta.file_type().is_symlink())
+        .unwrap_or(false);
+    !filter_allows_dir(filter, absolute, is_symlink)
+}
+
+/// Whether the filter allows watching the directory at `path`. A symlink to a directory is
+/// checked against both its own path and its resolved target, so an excluded directory
+/// cannot be watched through a link.
+pub(crate) fn filter_allows_dir(filter: &WatchFilter, path: &Path, is_symlink: bool) -> bool {
+    if filter.is_accept_all() {
+        // Skip the filter and (for symlinks) the canonicalize syscall entirely: unfiltered
+        // watches must not pay filtering costs.
+        return true;
+    }
+    if !filter.should_watch(path) {
+        return false;
+    }
+    if is_symlink {
+        // The caller determined the target is a directory, but `path` is the link side;
+        // consult the target too so name-based exclusions cannot be bypassed via symlinks.
+        if let Ok(target) = std::fs::canonicalize(path) {
+            return filter.should_watch(&target);
+        }
+    }
+    true
+}
+
+/// Shared `WalkDir::filter_entry` predicate implementing the `WatchFilter` pruning contract:
+/// the filter gates directories only (files always pass), and a rejected directory is neither
+/// yielded nor descended into.
+pub(crate) fn filter_keeps_walk_entry(filter: &WatchFilter, entry: &walkdir::DirEntry) -> bool {
+    !entry.file_type().is_dir() || filter_allows_dir(filter, entry.path(), entry.path_is_symlink())
 }
 
 pub(crate) fn absolute_path(path: &Path) -> Result<PathBuf> {
@@ -147,11 +312,13 @@ pub(crate) fn is_preserved_watch_root(path: &Path, preserved_roots: &[(PathBuf, 
     preserved_roots.iter().any(|(root, _)| path == root)
 }
 
-/// Finds the nearest recursive user watch that covers `path`.
+/// Finds the nearest recursive user watch covering `path`, returning its path and reported
+/// path.
 ///
-/// Backends use this when replacing an explicit watch that also inherits recursive coverage from an
-/// ancestor. Returning the ancestor's reported path lets them rebuild the inherited subtree with the
-/// same path representation users expect from that ancestor watch.
+/// Backends use this when replacing an explicit watch that also inherits recursive coverage
+/// from an ancestor, so the rebuilt subtree keeps the path representation users expect from
+/// that watch. The overlap barrier guarantees any such ancestor is unfiltered (a filtered
+/// watch never overlaps another watch), so the rebuild needs no filter gating.
 pub(crate) fn recursive_user_watch_ancestor<'a, I>(
     path: &Path,
     watches: I,
@@ -162,11 +329,168 @@ where
     watches
         .into_iter()
         .filter(|(candidate, watch)| {
-            *candidate != path
+            candidate.as_path() != path
                 && path.starts_with(candidate)
                 && watch.is_user_watch
                 && watch.user_is_recursive
         })
         .max_by_key(|(candidate, _)| candidate.as_os_str().len())
-        .map(|(path, watch)| (path.clone(), watch.reported_path.clone()))
+        .map(|(candidate, watch)| (candidate.clone(), watch.reported_path.clone()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::ErrorKind;
+    use std::ffi::OsStr;
+
+    fn reject_name(name: &'static str) -> WatchFilter {
+        WatchFilter::with_filter(move |p: &Path| p.file_name() != Some(OsStr::new(name)))
+    }
+
+    fn check(
+        absolute: &Path,
+        is_dir: bool,
+        is_recursive: bool,
+        watch_filter: &WatchFilter,
+        user_watches: &[(PathBuf, bool, bool, WatchFilter)],
+    ) -> Result<()> {
+        check_watch_barriers(
+            absolute,
+            absolute,
+            is_dir,
+            is_recursive,
+            watch_filter,
+            user_watches
+                .iter()
+                .map(|(path, is_dir, is_recursive, filter)| (path, *is_dir, *is_recursive, filter)),
+        )
+    }
+
+    #[test]
+    fn check_watch_barriers_rejects_filtered_directory_root() {
+        let dir = tempfile::tempdir().unwrap();
+        let filter = WatchFilter::with_filter({
+            let root = dir.path().to_path_buf();
+            move |p: &Path| p != root.as_path()
+        });
+
+        let result = check(dir.path(), true, true, &filter, &[]);
+
+        assert!(
+            matches!(&result, Err(error) if matches!(error.kind, ErrorKind::PathExcluded)),
+            "watching a rejected directory root must fail with PathExcluded: {result:?}"
+        );
+        assert_eq!(result.unwrap_err().paths, vec![dir.path().to_path_buf()]);
+    }
+
+    #[test]
+    fn check_watch_barriers_does_not_reject_file_roots() {
+        let dir = tempfile::tempdir().unwrap();
+        let file = dir.path().join("watched.txt");
+        std::fs::write(&file, "data").unwrap();
+        let filter = WatchFilter::with_filter({
+            let file = file.clone();
+            move |p: &Path| p != file.as_path()
+        });
+
+        check(&file, false, false, &filter, &[]).expect("file roots are never filtered");
+    }
+
+    #[test]
+    fn check_watch_barriers_allows_accept_all_overlaps_and_same_path_rewatch() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path().to_path_buf();
+        let child = root.join("child");
+        std::fs::create_dir(&child).unwrap();
+        let accept_all = WatchFilter::accept_all();
+        let filtered = reject_name("excluded");
+
+        let accept_all_watch = vec![(root.clone(), true, true, WatchFilter::accept_all())];
+        check(&child, true, true, &accept_all, &accept_all_watch)
+            .expect("accept-all directory watches may overlap");
+
+        let same_path_watch = vec![(root.clone(), true, true, filtered.clone())];
+        check(&root, true, true, &filtered, &same_path_watch)
+            .expect("rewatching the same path is replacement, not overlap");
+    }
+
+    #[test]
+    fn check_watch_barriers_rejects_filtered_overlap_in_both_directions() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path().to_path_buf();
+        let child = root.join("child");
+        std::fs::create_dir(&child).unwrap();
+        let grandchild = child.join("grandchild");
+        std::fs::create_dir(&grandchild).unwrap();
+        let filter = reject_name("excluded");
+
+        let recursive_root = vec![(root.clone(), true, true, WatchFilter::accept_all())];
+        assert!(
+            check(&child, true, true, &filter, &recursive_root).is_err(),
+            "a filtered watch nested under a recursive directory watch must be refused"
+        );
+
+        let filtered_root = vec![(root.clone(), true, true, filter.clone())];
+        assert!(
+            check(
+                &child,
+                true,
+                false,
+                &WatchFilter::accept_all(),
+                &filtered_root,
+            )
+            .is_err(),
+            "a directory watch inside a filtered recursive watch must be refused"
+        );
+
+        let nested_directory = vec![(grandchild.clone(), true, false, WatchFilter::accept_all())];
+        assert!(
+            check(&child, true, true, &filter, &nested_directory).is_err(),
+            "a filtered recursive watch over an existing directory watch must be refused"
+        );
+    }
+
+    #[test]
+    fn check_watch_barriers_ignores_file_watch_overlap() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path().to_path_buf();
+        let file = root.join("file.txt");
+        std::fs::write(&file, "data").unwrap();
+        let file_watch = vec![(file, false, false, WatchFilter::accept_all())];
+
+        check(&root, true, true, &reject_name("excluded"), &file_watch)
+            .expect("file watches never conflict with filtered directory watches");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn check_watch_barriers_detects_symlink_alias_overlap() {
+        let dir = tempfile::tempdir().unwrap();
+        let real = dir.path().join("real");
+        let alias = dir.path().join("alias");
+        std::fs::create_dir(&real).unwrap();
+        std::os::unix::fs::symlink(&real, &alias).unwrap();
+        let real_watch = vec![(real, true, true, WatchFilter::accept_all())];
+
+        assert!(
+            check(&alias, true, true, &reject_name("excluded"), &real_watch).is_err(),
+            "canonicalized aliases must not bypass filtered overlap checks"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn filter_allows_dir_checks_symlink_target() {
+        let dir = tempfile::tempdir().unwrap();
+        let excluded = dir.path().join("excluded");
+        let alias = dir.path().join("alias");
+        std::fs::create_dir(&excluded).unwrap();
+        std::os::unix::fs::symlink(&excluded, &alias).unwrap();
+
+        assert!(
+            !filter_allows_dir(&reject_name("excluded"), &alias, true),
+            "a symlink to an excluded directory must be rejected"
+        );
+    }
 }

--- a/notify/src/poll.rs
+++ b/notify/src/poll.rs
@@ -5,7 +5,7 @@
 
 use crate::{
     paths::{absolute_path, WatchPath},
-    unbounded, Config, Error, EventHandler, Receiver, RecursiveMode, Sender, Watcher,
+    unbounded, Config, Error, EventHandler, Receiver, RecursiveMode, Sender, WatchFilter, Watcher,
 };
 use std::{
     collections::HashMap,
@@ -72,7 +72,7 @@ use data::{DataBuilder, WatchData};
 mod data {
     use crate::{
         event::{CreateKind, DataChange, Event, EventKind, MetadataKind, ModifyKind, RemoveKind},
-        paths::{reported_path, WatchPath},
+        paths::{filter_keeps_walk_entry, reported_path, WatchPath},
         EventHandler, RecursiveMode,
     };
     use notify_types::event::EventKindMask;
@@ -149,8 +149,9 @@ mod data {
             root: WatchPath,
             is_recursive: bool,
             follow_symlinks: bool,
+            watch_filter: crate::WatchFilter,
         ) -> Option<WatchData> {
-            WatchData::new(self, root, is_recursive, follow_symlinks)
+            WatchData::new(self, root, is_recursive, follow_symlinks, watch_filter)
         }
 
         /// Create [`PathData`].
@@ -173,8 +174,10 @@ mod data {
         // config part, won't change.
         root: PathBuf,
         requested_root: PathBuf,
+        root_is_dir: bool,
         is_recursive: bool,
         follow_symlinks: bool,
+        watch_filter: crate::WatchFilter,
 
         // current status part.
         all_path_data: HashMap<PathBuf, PathData>,
@@ -191,6 +194,7 @@ mod data {
             root: WatchPath,
             is_recursive: bool,
             follow_symlinks: bool,
+            watch_filter: crate::WatchFilter,
         ) -> Option<Self> {
             // If metadata read error at `root` path, it will emit
             // a error event and stop to create the whole `WatchData`.
@@ -210,10 +214,13 @@ mod data {
             //
             // FIXME: Can we always allow to watch a path, even file not
             // found at this path?
-            if let Err(e) = fs::metadata(&root.absolute) {
-                data_builder.emitter.emit_io_err(e, Some(&root.requested));
-                return None;
-            }
+            let root_is_dir = match fs::metadata(&root.absolute) {
+                Ok(metadata) => metadata.is_dir(),
+                Err(e) => {
+                    data_builder.emitter.emit_io_err(e, Some(&root.requested));
+                    return None;
+                }
+            };
 
             let all_path_data = Self::scan_all_path_data(
                 data_builder,
@@ -221,6 +228,7 @@ mod data {
                 root.requested.clone(),
                 is_recursive,
                 follow_symlinks,
+                watch_filter.clone(),
                 true,
             )
             .collect();
@@ -228,8 +236,10 @@ mod data {
             Some(Self {
                 root: root.absolute,
                 requested_root: root.requested,
+                root_is_dir,
                 is_recursive,
                 follow_symlinks,
+                watch_filter,
                 all_path_data,
             })
         }
@@ -247,6 +257,7 @@ mod data {
                 self.requested_root.clone(),
                 self.is_recursive,
                 self.follow_symlinks,
+                self.watch_filter.clone(),
                 false,
             ) {
                 let event_kind = if let Some(old_path_data) = self.all_path_data.get_mut(&path) {
@@ -304,6 +315,7 @@ mod data {
             requested_root: PathBuf,
             is_recursive: bool,
             follow_symlinks: bool,
+            watch_filter: crate::WatchFilter,
             // whether this is an initial scan, used only for events
             is_initial: bool,
         ) -> impl Iterator<Item = (PathBuf, PathData)> + '_ {
@@ -312,53 +324,77 @@ mod data {
             // so we can use single logic to do the both file & dir's jobs.
             //
             // See: https://docs.rs/walkdir/2.0.1/walkdir/struct.WalkDir.html#method.new
-            WalkDir::new(root.clone())
+            let mut walk = WalkDir::new(root.clone())
                 .follow_links(follow_symlinks)
                 .max_depth(Self::dir_scan_depth(is_recursive))
-                .into_iter()
-                .filter_map(|entry_res| match entry_res {
-                    Ok(entry) => Some(entry),
-                    Err(err) => {
-                        log::warn!("walkdir error scanning {err:?}");
+                .into_iter();
+            // A rejected directory is still yielded (so its own creation and removal are
+            // reported, matching the other backends) but never descended into, which keeps
+            // everything beneath it out of the scan. This applies to the walk root
+            // too: a symlink root is checked against its target (the root gate normally
+            // rejects such a watch upfront, but the target can change between scans).
+            std::iter::from_fn(move || {
+                let entry_res = walk.next()?;
+                let mut excluded = false;
+                if let Ok(entry) = &entry_res {
+                    if !filter_keeps_walk_entry(&watch_filter, entry) {
+                        excluded = true;
+                        walk.skip_current_dir();
+                    }
+                }
+                Some((entry_res, excluded))
+            })
+            .filter_map(|(entry_res, excluded)| match entry_res {
+                Ok(entry) => Some((entry, excluded)),
+                Err(err) => {
+                    log::warn!("walkdir error scanning {err:?}");
 
-                        if let Some(io_error) = err.io_error() {
-                            // clone an io::Error, so we have to create a new one.
-                            let new_io_error = io::Error::new(io_error.kind(), err.to_string());
-                            data_builder.emitter.emit_io_err(new_io_error, err.path());
-                        } else {
-                            let crate_err =
-                                crate::Error::new(crate::ErrorKind::Generic(err.to_string()));
-                            data_builder.emitter.emit(Err(crate_err));
+                    if let Some(io_error) = err.io_error() {
+                        // clone an io::Error, so we have to create a new one.
+                        let new_io_error = io::Error::new(io_error.kind(), err.to_string());
+                        data_builder.emitter.emit_io_err(new_io_error, err.path());
+                    } else {
+                        let crate_err =
+                            crate::Error::new(crate::ErrorKind::Generic(err.to_string()));
+                        data_builder.emitter.emit(Err(crate_err));
+                    }
+                    None
+                }
+            })
+            .filter_map(move |(entry, excluded)| match entry.metadata() {
+                Ok(metadata) => {
+                    let path = entry.into_path();
+                    if is_initial {
+                        // emit initial scans
+                        if let Some(ref emitter) = data_builder.scan_emitter {
+                            emitter.borrow_mut().handle_event(Ok(reported_path(
+                                &root,
+                                &requested_root,
+                                &path,
+                            )));
                         }
-                        None
                     }
-                })
-                .filter_map(move |entry| match entry.metadata() {
-                    Ok(metadata) => {
-                        let path = entry.into_path();
-                        if is_initial {
-                            // emit initial scans
-                            if let Some(ref emitter) = data_builder.scan_emitter {
-                                emitter.borrow_mut().handle_event(Ok(reported_path(
-                                    &root,
-                                    &requested_root,
-                                    &path,
-                                )));
-                            }
-                        }
-                        let meta_path = MetaPath::from_parts_unchecked(path, metadata);
-                        let data_path = data_builder.build_path_data(&meta_path);
+                    let meta_path = MetaPath::from_parts_unchecked(path, metadata);
+                    let mut data_path = data_builder.build_path_data(&meta_path);
+                    if excluded {
+                        // The excluded directory is tracked only so its own creation and
+                        // removal are reported. Activity inside its (unscanned) subtree
+                        // bumps its mtime, and comparing that would leak a Modify event
+                        // every poll cycle, so its metadata is pinned instead.
+                        data_path.mtime = 0;
+                        data_path.hash = None;
+                    }
 
-                        Some((meta_path.into_path(), data_path))
-                    }
-                    Err(e) => {
-                        // emit event.
-                        let path = entry.into_path();
-                        data_builder.emitter.emit_io_err(e, Some(path));
+                    Some((meta_path.into_path(), data_path))
+                }
+                Err(e) => {
+                    // emit event.
+                    let path = entry.into_path();
+                    data_builder.emitter.emit_io_err(e, Some(path));
 
-                        None
-                    }
-                })
+                    None
+                }
+            })
         }
 
         fn dir_scan_depth(is_recursive: bool) -> usize {
@@ -377,8 +413,16 @@ mod data {
             }
         }
 
+        pub(super) fn root_is_dir(&self) -> bool {
+            self.root_is_dir
+        }
+
         pub(super) fn requested_root(&self) -> &Path {
             &self.requested_root
+        }
+
+        pub(super) fn watch_filter(&self) -> &crate::WatchFilter {
+            &self.watch_filter
         }
     }
 
@@ -690,7 +734,12 @@ impl PollWatcher {
     ///
     /// QUESTION: this function never return an Error, is it as intend?
     /// Please also consider the IO Error event problem.
-    fn watch_inner(&mut self, path: &Path, recursive_mode: RecursiveMode) -> crate::Result<()> {
+    fn watch_inner(
+        &mut self,
+        path: &Path,
+        recursive_mode: RecursiveMode,
+        watch_filter: WatchFilter,
+    ) -> crate::Result<()> {
         let watch_path = WatchPath::new(path)?;
 
         // HINT: Make sure always lock in the same order to avoid deadlock.
@@ -699,12 +748,34 @@ impl PollWatcher {
         let mut watches = self.watches.lock().unwrap_or_else(|e| e.into_inner());
         let mut data_builder = self.data_builder.lock().unwrap_or_else(|e| e.into_inner());
 
+        // Missing paths fall through so the scan reports the IO error the way it always
+        // has.
+        let path_is_dir = std::fs::metadata(&watch_path.absolute)
+            .map(|metadata| metadata.is_dir())
+            .unwrap_or(false);
+        crate::paths::check_watch_barriers(
+            &watch_path.absolute,
+            &watch_path.requested,
+            path_is_dir,
+            recursive_mode.is_recursive() && path_is_dir,
+            &watch_filter,
+            watches.iter().map(|(path, data)| {
+                (
+                    path,
+                    data.root_is_dir(),
+                    data.recursive_mode().is_recursive(),
+                    data.watch_filter(),
+                )
+            }),
+        )?;
+
         data_builder.update_timestamp();
 
         let watch_data = data_builder.build_watch_data(
             watch_path.clone(),
             recursive_mode.is_recursive(),
             self.follow_sylinks,
+            watch_filter,
         );
 
         // if create watch_data successful, add it to watching list.
@@ -737,8 +808,13 @@ impl Watcher for PollWatcher {
         Self::new(event_handler, config)
     }
 
-    fn watch(&mut self, path: &Path, recursive_mode: RecursiveMode) -> crate::Result<()> {
-        self.watch_inner(path, recursive_mode)
+    fn watch_filtered(
+        &mut self,
+        path: &Path,
+        recursive_mode: RecursiveMode,
+        watch_filter: WatchFilter,
+    ) -> crate::Result<()> {
+        self.watch_inner(path, recursive_mode, watch_filter)
     }
 
     fn unwatch(&mut self, path: &Path) -> crate::Result<()> {
@@ -771,6 +847,22 @@ mod tests {
 
     fn watcher() -> (TestWatcher<PollWatcher>, Receiver) {
         poll_watcher_channel()
+    }
+
+    fn manual_watcher() -> (
+        PollWatcher,
+        std::sync::mpsc::Receiver<crate::Result<notify_types::event::Event>>,
+    ) {
+        let (tx, rx) = std::sync::mpsc::channel();
+        let watcher =
+            PollWatcher::new(tx, Config::default().with_manual_polling()).expect("create watcher");
+        (watcher, rx)
+    }
+
+    fn drain(
+        rx: &std::sync::mpsc::Receiver<crate::Result<notify_types::event::Event>>,
+    ) -> Vec<notify_types::event::Event> {
+        rx.try_iter().filter_map(|r| r.ok()).collect()
     }
 
     #[test]
@@ -1001,6 +1093,299 @@ mod tests {
         );
 
         rx.wait_unordered([expected(&overwritten_file).modify_data_any()]);
+    }
+
+    #[test]
+    fn update_paths_carries_watch_filter() {
+        use crate::{PathOp, WatchPathConfig, Watcher};
+
+        let tmpdir = testdir();
+        let root = tmpdir.path();
+        let excluded = root.join("excluded");
+        std::fs::create_dir_all(&excluded).expect("create excluded");
+
+        let (mut watcher, rx) = manual_watcher();
+        watcher
+            .update_paths(vec![PathOp::Watch(
+                root.to_path_buf(),
+                WatchPathConfig::new(crate::RecursiveMode::Recursive)
+                    .with_watch_filter(reject_name("excluded")),
+            )])
+            .expect("update_paths");
+
+        std::fs::write(excluded.join("ignored.txt"), "data").expect("write excluded file");
+        watcher.poll_blocking().expect("poll");
+
+        let events = drain(&rx);
+        assert!(
+            events.iter().all(|e| e
+                .paths
+                .iter()
+                .all(|p| !p.starts_with(&excluded) || *p == excluded)),
+            "the filter carried by update_paths was not applied: {events:?}"
+        );
+        // Guard against a vacuous pass: prove the watch itself is alive.
+        std::fs::write(root.join("seen.txt"), "data").expect("write included file");
+        watcher.poll_blocking().expect("poll 2");
+        let events = drain(&rx);
+        assert!(
+            events
+                .iter()
+                .any(|e| e.paths.iter().any(|p| p.ends_with("seen.txt"))),
+            "expected an event proving the update_paths watch is active, got: {events:?}"
+        );
+    }
+
+    #[test]
+    fn filtered_watch_conflicts_with_deleted_directory_watch() {
+        use crate::Watcher;
+
+        let tmpdir = testdir();
+        let root = tmpdir.path();
+        let nested = root.join("nested");
+        std::fs::create_dir(&nested).expect("create nested");
+
+        let (mut watcher, _rx) = manual_watcher();
+        watcher
+            .watch(&nested, crate::RecursiveMode::Recursive)
+            .expect("watch nested");
+        std::fs::remove_dir_all(&nested).expect("remove nested");
+
+        let result = watcher.watch_filtered(
+            root,
+            crate::RecursiveMode::Recursive,
+            reject_name("excluded"),
+        );
+        assert!(
+            result.is_err(),
+            "a deleted directory watch still reserves its overlap region: {result:?}"
+        );
+        assert_eq!(
+            watcher.watched_paths().expect("watched"),
+            vec![(nested, crate::RecursiveMode::Recursive)]
+        );
+    }
+
+    #[test]
+    fn rejected_root_preserves_existing_watch() {
+        use crate::{ErrorKind, WatchFilter, Watcher};
+
+        let tmpdir = testdir();
+        let root = tmpdir.path();
+
+        let (mut watcher, _rx) = manual_watcher();
+        watcher
+            .watch(root, crate::RecursiveMode::Recursive)
+            .expect("watch");
+        let before = watcher.watched_paths().expect("watched");
+
+        let rejecting = root.to_path_buf();
+        let result = watcher.watch_filtered(
+            root,
+            crate::RecursiveMode::Recursive,
+            WatchFilter::with_filter(move |p: &std::path::Path| p != rejecting.as_path()),
+        );
+
+        assert!(
+            matches!(result, Err(ref e) if matches!(e.kind, ErrorKind::PathExcluded)),
+            "watching a rejected root must fail with PathExcluded: {result:?}"
+        );
+        assert_eq!(
+            watcher.watched_paths().expect("watched"),
+            before,
+            "a failed rewatch must leave existing watches unchanged"
+        );
+    }
+
+    #[test]
+    fn watch_filter_does_not_apply_to_files() {
+        use crate::Watcher;
+
+        let tmpdir = testdir();
+        let root = tmpdir.path();
+
+        let (mut watcher, rx) = manual_watcher();
+        watcher
+            .watch_filtered(
+                root,
+                crate::RecursiveMode::Recursive,
+                reject_name("seen.txt"),
+            )
+            .expect("watch filtered");
+
+        std::fs::write(root.join("seen.txt"), "data").expect("write file");
+        watcher.poll_blocking().expect("poll");
+
+        let events = drain(&rx);
+        assert!(
+            events
+                .iter()
+                .any(|e| e.paths.iter().any(|p| p.ends_with("seen.txt"))),
+            "the filter gates directories only; file events must still be delivered: {events:?}"
+        );
+    }
+
+    #[test]
+    fn excluded_directory_own_events_are_reported() {
+        use crate::Watcher;
+
+        let tmpdir = testdir();
+        let root = tmpdir.path();
+
+        let (mut watcher, rx) = manual_watcher();
+        watcher
+            .watch_filtered(
+                root,
+                crate::RecursiveMode::Recursive,
+                reject_name("excluded"),
+            )
+            .expect("watch filtered");
+
+        let excluded = root.join("excluded");
+        std::fs::create_dir(&excluded).expect("create excluded");
+        std::fs::write(excluded.join("inside.txt"), "data").expect("write inside excluded");
+        watcher.poll_blocking().expect("poll");
+
+        let events = drain(&rx);
+        assert!(
+            events
+                .iter()
+                .any(|e| e.kind.is_create() && e.paths.contains(&excluded)),
+            "the excluded directory's own creation must be reported: {events:?}"
+        );
+        assert!(
+            events.iter().all(|e| e
+                .paths
+                .iter()
+                .all(|p| !p.starts_with(&excluded) || *p == excluded)),
+            "events leaked from inside the excluded directory: {events:?}"
+        );
+
+        std::fs::remove_dir_all(&excluded).expect("remove excluded");
+        watcher.poll_blocking().expect("poll 2");
+        let events = drain(&rx);
+        assert!(
+            events
+                .iter()
+                .any(|e| e.kind.is_remove() && e.paths.contains(&excluded)),
+            "the excluded directory's own removal must be reported: {events:?}"
+        );
+    }
+
+    #[test]
+    fn excluded_directory_mtime_changes_are_not_reported() {
+        use crate::Watcher;
+
+        let tmpdir = testdir();
+        let root = tmpdir.path();
+        let excluded = root.join("excluded");
+        std::fs::create_dir(&excluded).expect("create excluded");
+
+        let (mut watcher, rx) = manual_watcher();
+        watcher
+            .watch_filtered(
+                root,
+                crate::RecursiveMode::Recursive,
+                reject_name("excluded"),
+            )
+            .expect("watch filtered");
+
+        // Activity inside the excluded subtree bumps the excluded directory's own mtime.
+        // Only the directory's creation and removal are reportable; a Modify per poll cycle
+        // would leak the excluded activity through the directory's metadata.
+        std::fs::write(excluded.join("inside.txt"), "data").expect("write inside excluded");
+        std::fs::write(root.join("seen.txt"), "data").expect("write included file");
+        watcher.poll_blocking().expect("poll");
+
+        let events = drain(&rx);
+        assert!(
+            events
+                .iter()
+                .all(|e| !e.kind.is_modify() || !e.paths.contains(&excluded)),
+            "excluded-subtree activity leaked as a Modify on the excluded directory: {events:?}"
+        );
+        // Guard against a vacuous pass: prove the watch itself is alive.
+        assert!(
+            events
+                .iter()
+                .any(|e| e.paths.iter().any(|p| p.ends_with("seen.txt"))),
+            "expected an event proving the watch is active, got: {events:?}"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn symlink_root_to_excluded_directory_watches_nothing() {
+        use crate::Watcher;
+
+        let tmpdir = testdir();
+        let root = tmpdir.path();
+        let excluded = root.join("excluded");
+        std::fs::create_dir(&excluded).expect("create excluded");
+        std::fs::write(excluded.join("inside.txt"), "data").expect("write inside");
+        let link = root.join("link");
+        std::os::unix::fs::symlink(&excluded, &link).expect("symlink");
+
+        let (mut watcher, rx) = manual_watcher();
+
+        // The root gate resolves symlink roots: a link to an excluded directory is a
+        // rejected root, matching the walk backends; the excluded target must not be
+        // scanned under the link's name.
+        let result = watcher.watch_filtered(
+            &link,
+            crate::RecursiveMode::Recursive,
+            reject_name("excluded"),
+        );
+        assert!(
+            matches!(result, Err(ref e) if matches!(e.kind, crate::ErrorKind::PathExcluded)),
+            "a symlink root resolving to an excluded directory must be rejected: {result:?}"
+        );
+        assert!(watcher.watched_paths().expect("watched").is_empty());
+
+        std::fs::write(excluded.join("more.txt"), "data").expect("write more");
+        watcher.poll_blocking().expect("poll");
+        let events = drain(&rx);
+        assert!(
+            events.is_empty(),
+            "nothing is watched, so nothing may be reported: {events:?}"
+        );
+    }
+
+    #[test]
+    fn file_roots_are_not_filtered() {
+        use crate::{WatchFilter, Watcher};
+
+        let tmpdir = testdir();
+        let file = tmpdir.path().join("watched.txt");
+        std::fs::write(&file, "data").expect("write file");
+
+        let (tx, rx) = std::sync::mpsc::channel();
+        // compare_contents so the same-second modification below is detectable (poll's
+        // mtime comparison has whole-second granularity).
+        let config = Config::default()
+            .with_manual_polling()
+            .with_compare_contents(true);
+        let mut watcher = PollWatcher::new(tx, config).expect("create watcher");
+
+        // The filter gates directories only: even a filter rejecting this exact path must
+        // not prevent watching a file.
+        let rejecting = file.clone();
+        watcher
+            .watch_filtered(
+                &file,
+                crate::RecursiveMode::NonRecursive,
+                WatchFilter::with_filter(move |p: &std::path::Path| p != rejecting),
+            )
+            .expect("watch file");
+
+        std::fs::write(&file, "changed").expect("modify file");
+        watcher.poll_blocking().expect("poll");
+
+        let events = drain(&rx);
+        assert!(
+            events.iter().any(|e| e.paths.contains(&file)),
+            "file watches must not be affected by the directory filter: {events:?}"
+        );
     }
 
     #[test]

--- a/notify/src/test.rs
+++ b/notify/src/test.rs
@@ -20,6 +20,13 @@ use pretty_assertions::assert_eq;
 
 pub use expect::*;
 
+/// A [`crate::WatchFilter`] rejecting directories named `name`.
+pub fn reject_name(name: &'static str) -> crate::WatchFilter {
+    crate::WatchFilter::with_filter(move |p: &Path| {
+        p.file_name() != Some(std::ffi::OsStr::new(name))
+    })
+}
+
 /// Waits any events from the watcher and provides with some helper methods
 pub struct Receiver {
     pub rx: mpsc::Receiver<Result<Event, Error>>,

--- a/notify/src/windows.rs
+++ b/notify/src/windows.rs
@@ -8,7 +8,9 @@
 use crate::paths::{absolute_path, WatchPath};
 use crate::{bounded, unbounded, BoundSender, Config, Receiver, Sender};
 use crate::{event::*, WatcherKind};
-use crate::{Error, EventHandler, RecursiveMode, Result, Watcher, WindowsPathSeparatorStyle};
+use crate::{
+    Error, EventHandler, RecursiveMode, Result, WatchFilter, Watcher, WindowsPathSeparatorStyle,
+};
 use std::alloc;
 use std::collections::HashMap;
 use std::ffi::OsString;
@@ -133,6 +135,9 @@ struct ReadData {
     is_recursive: bool,
     separator_style: SeparatorStyle,
     stopping: Arc<AtomicBool>,
+    // ReadDirectoryChangesW cannot selectively watch directories, so directory filtering is
+    // applied to event paths in the completion routine instead.
+    watch_filter: WatchFilter,
 }
 
 struct ReadDirectoryRequest {
@@ -153,7 +158,7 @@ impl ReadDirectoryRequest {
 }
 
 enum Action {
-    Watch(WatchPath, RecursiveMode, SeparatorStyle),
+    Watch(WatchPath, RecursiveMode, SeparatorStyle, WatchFilter),
     // Internal self-unwatch from the completion callback.
     Unwatch(PathBuf),
     // Public `Watcher::unwatch` path. This variant must ack only after `remove_watch` finishes so
@@ -173,8 +178,10 @@ pub enum MetaEvent {
 struct WatchState {
     dir_handle: HANDLE,
     complete_sem: HANDLE,
+    watch_path_is_dir: bool,
     recursive_mode: RecursiveMode,
     reported_path: PathBuf,
+    watch_filter: WatchFilter,
     stopping: Arc<AtomicBool>,
 }
 
@@ -229,9 +236,13 @@ impl ReadDirectoryChangesServer {
 
             while let Ok(action) = self.rx.try_recv() {
                 match action {
-                    Action::Watch(path, recursive_mode, separator_style) => {
-                        let res =
-                            self.add_watch(path, recursive_mode.is_recursive(), separator_style);
+                    Action::Watch(path, recursive_mode, separator_style, watch_filter) => {
+                        let res = self.add_watch(
+                            path,
+                            recursive_mode.is_recursive(),
+                            separator_style,
+                            watch_filter,
+                        );
                         let _ = self.cmd_tx.send(res);
                     }
                     Action::Unwatch(path) => self.remove_watch(path),
@@ -286,7 +297,25 @@ impl ReadDirectoryChangesServer {
         path: WatchPath,
         is_recursive: bool,
         separator_style: SeparatorStyle,
+        watch_filter: WatchFilter,
     ) -> Result<PathBuf> {
+        let path_is_dir = path.absolute.is_dir();
+        crate::paths::check_watch_barriers(
+            &path.absolute,
+            &path.requested,
+            path_is_dir,
+            is_recursive && path_is_dir,
+            &watch_filter,
+            self.watches.iter().map(|(path, state)| {
+                (
+                    path,
+                    state.watch_path_is_dir,
+                    state.recursive_mode.is_recursive(),
+                    &state.watch_filter,
+                )
+            }),
+        )?;
+
         // path must exist and be either a file or directory
         if !path.absolute.is_dir() && !path.absolute.is_file() {
             return Err(
@@ -370,16 +399,19 @@ impl ReadDirectoryChangesServer {
             is_recursive,
             separator_style,
             stopping: stopping.clone(),
+            watch_filter: watch_filter.clone(),
         };
         let ws = WatchState {
             dir_handle: handle,
             complete_sem: semaphore,
+            watch_path_is_dir: path_is_dir,
             recursive_mode: if is_recursive {
                 RecursiveMode::Recursive
             } else {
                 RecursiveMode::NonRecursive
             },
             reported_path: path.requested,
+            watch_filter,
             stopping,
         };
         if let Err(err) = start_read(
@@ -517,6 +549,15 @@ fn is_delete_pending(handle: HANDLE) -> bool {
     success != 0 && info.DeletePending
 }
 
+fn read_data_allows_event(data: &ReadData, path: &Path, absolute_path: &Path) -> bool {
+    (match &data.file {
+        None => true,
+        Some(watch_path) => watch_path == path,
+    }) && data
+        .watch_filter
+        .allows_event_under(&data.dir, absolute_path)
+}
+
 unsafe extern "system" fn handle_event(
     error_code: u32,
     _bytes_written: u32,
@@ -624,12 +665,9 @@ unsafe extern "system" fn handle_event(
             request.data.separator_style,
         );
 
-        // if we are watching a single file, ignore the event unless the path is exactly
-        // the watched file
-        let skip = match request.data.file {
-            None => false,
-            Some(ref watch_path) => *watch_path != path,
-        };
+        // If we are watching a single file, ignore other entries in its parent directory.
+        // Directory filtering suppresses events under directories the filter rejects.
+        let skip = !read_data_allows_event(&request.data, &path, &absolute_path);
 
         if !skip {
             log::trace!(
@@ -796,7 +834,12 @@ impl ReadDirectoryChangesWatcher {
         }
     }
 
-    fn watch_inner(&mut self, path: &Path, recursive_mode: RecursiveMode) -> Result<()> {
+    fn watch_inner(
+        &mut self,
+        path: &Path,
+        recursive_mode: RecursiveMode,
+        watch_filter: WatchFilter,
+    ) -> Result<()> {
         let separator_style = SeparatorStyle::resolve(self.windows_path_separator_style, path);
         let pb = WatchPath::new(path)?;
         // path must exist and be either a file or directory
@@ -806,7 +849,7 @@ impl ReadDirectoryChangesWatcher {
             ));
         }
         self.send_action_require_ack(
-            Action::Watch(pb.clone(), recursive_mode, separator_style),
+            Action::Watch(pb.clone(), recursive_mode, separator_style, watch_filter),
             &pb.absolute,
         )
     }
@@ -840,8 +883,13 @@ impl Watcher for ReadDirectoryChangesWatcher {
         )
     }
 
-    fn watch(&mut self, path: &Path, recursive_mode: RecursiveMode) -> Result<()> {
-        self.watch_inner(path, recursive_mode)
+    fn watch_filtered(
+        &mut self,
+        path: &Path,
+        recursive_mode: RecursiveMode,
+        watch_filter: WatchFilter,
+    ) -> Result<()> {
+        self.watch_inner(path, recursive_mode, watch_filter)
     }
 
     fn unwatch(&mut self, path: &Path) -> Result<()> {
@@ -880,7 +928,7 @@ unsafe impl Sync for ReadDirectoryChangesWatcher {}
 #[cfg(test)]
 pub mod tests {
     use std::env;
-    use std::ffi::OsString;
+    use std::ffi::{OsStr, OsString};
     use std::os::windows::ffi::OsStringExt;
     use std::path::{Path, PathBuf};
     use std::sync::atomic::{AtomicBool, Ordering};
@@ -890,13 +938,161 @@ pub mod tests {
 
     use super::{normalize_path_separators, trim_leading_separators, SeparatorStyle};
     use crate::{
-        test::*, ReadDirectoryChangesWatcher, RecursiveMode, Watcher, WindowsPathSeparatorStyle,
+        test::*, ErrorKind, PathOp, ReadDirectoryChangesWatcher, RecursiveMode, WatchFilter,
+        WatchPathConfig, Watcher, WindowsPathSeparatorStyle,
     };
 
     use std::time::Duration;
 
     fn watcher() -> (TestWatcher<ReadDirectoryChangesWatcher>, Receiver) {
         channel()
+    }
+
+    fn read_data_with_filter(watch_filter: WatchFilter) -> super::ReadData {
+        use windows_sys::Win32::Foundation::INVALID_HANDLE_VALUE;
+
+        super::ReadData {
+            watch_path: PathBuf::from(r"C:\watched"),
+            dir: PathBuf::from(r"C:\watched"),
+            reported_dir: PathBuf::from(r"C:\watched"),
+            file: None,
+            complete_sem: INVALID_HANDLE_VALUE,
+            is_recursive: true,
+            separator_style: SeparatorStyle::Backslash,
+            stopping: Arc::new(AtomicBool::new(false)),
+            watch_filter,
+        }
+    }
+
+    #[test]
+    fn read_data_allows_event_suppresses_filtered_descendants() {
+        let data = read_data_with_filter(WatchFilter::with_filter(|p: &Path| {
+            p.file_name() != Some(OsStr::new("excluded"))
+        }));
+
+        assert!(super::read_data_allows_event(
+            &data,
+            Path::new(r"C:\watched\included\file.txt"),
+            Path::new(r"C:\watched\included\file.txt")
+        ));
+        assert!(super::read_data_allows_event(
+            &data,
+            Path::new(r"C:\watched\excluded"),
+            Path::new(r"C:\watched\excluded")
+        ));
+        assert!(
+            !super::read_data_allows_event(
+                &data,
+                Path::new(r"C:\watched\excluded\file.txt"),
+                Path::new(r"C:\watched\excluded\file.txt")
+            ),
+            "events beneath a rejected directory must be suppressed"
+        );
+    }
+
+    #[test]
+    fn read_data_allows_event_does_not_filter_file_roots() {
+        let watched_file = PathBuf::from(r"C:\watched\blocked.txt");
+        let mut data = read_data_with_filter(WatchFilter::with_filter({
+            let watched_file = watched_file.clone();
+            move |p: &Path| p != watched_file.as_path()
+        }));
+        data.file = Some(watched_file.clone());
+
+        assert!(
+            super::read_data_allows_event(&data, &watched_file, &watched_file),
+            "the directory filter must not reject a directly watched file"
+        );
+        assert!(!super::read_data_allows_event(
+            &data,
+            Path::new(r"C:\watched\other.txt"),
+            Path::new(r"C:\watched\other.txt")
+        ));
+    }
+
+    #[test]
+    fn read_data_allows_event_suppresses_deeply_nested_descendants() {
+        let data = read_data_with_filter(WatchFilter::with_filter(|p: &Path| {
+            p.file_name() != Some(OsStr::new("excluded"))
+        }));
+
+        // A rejected directory anywhere in the ancestor chain suppresses the event, however
+        // deeply it is nested below that directory.
+        assert!(
+            !super::read_data_allows_event(
+                &data,
+                Path::new(r"C:\watched\excluded\a\b\deep.txt"),
+                Path::new(r"C:\watched\excluded\a\b\deep.txt"),
+            ),
+            "an event deep beneath a rejected directory must be suppressed"
+        );
+
+        // A deep path whose ancestors are all accepted is still delivered: the multi-level
+        // ancestor walk must not over-suppress.
+        assert!(
+            super::read_data_allows_event(
+                &data,
+                Path::new(r"C:\watched\a\b\c\deep.txt"),
+                Path::new(r"C:\watched\a\b\c\deep.txt"),
+            ),
+            "a deep event with no rejected ancestor must be delivered"
+        );
+    }
+
+    #[test]
+    fn update_paths_carries_watch_filter_to_root_rejection(
+    ) -> std::result::Result<(), Box<dyn std::error::Error>> {
+        let dir = tempdir()?;
+        let root = dir.path().to_path_buf();
+        let rejecting = std::path::absolute(&root)?;
+
+        let (tx, _rx) = mpsc::channel();
+        let mut watcher = ReadDirectoryChangesWatcher::new(tx, crate::Config::default())?;
+
+        let result = watcher.update_paths(vec![PathOp::Watch(
+            root,
+            WatchPathConfig::new(RecursiveMode::Recursive).with_watch_filter(
+                WatchFilter::with_filter(move |p: &Path| p != rejecting.as_path()),
+            ),
+        )]);
+        assert!(
+            matches!(result, Err(ref e) if matches!(e.source.kind, ErrorKind::PathExcluded)),
+            "update_paths must pass the filter through to watch_filtered, got {result:?}"
+        );
+        assert!(watcher.watched_paths()?.is_empty());
+
+        Ok(())
+    }
+
+    #[test]
+    fn rejected_root_preserves_existing_watch(
+    ) -> std::result::Result<(), Box<dyn std::error::Error>> {
+        let dir = tempdir()?;
+        let root = dir.path().to_path_buf();
+        let rejecting = std::path::absolute(&root)?;
+
+        let (tx, _rx) = mpsc::channel();
+        let mut watcher = ReadDirectoryChangesWatcher::new(tx, crate::Config::default())?;
+        watcher.watch(&root, RecursiveMode::Recursive)?;
+        let before = watcher.watched_paths()?;
+
+        let result = watcher.watch_filtered(
+            &root,
+            RecursiveMode::Recursive,
+            WatchFilter::with_filter(move |p: &Path| p != rejecting.as_path()),
+        );
+
+        assert!(
+            matches!(result, Err(ref e) if matches!(e.kind, ErrorKind::PathExcluded)),
+            "watching a rejected root must fail with PathExcluded: {result:?}"
+        );
+        assert_eq!(
+            watcher.watched_paths()?,
+            before,
+            "a failed rewatch must leave existing watches unchanged"
+        );
+
+        Ok(())
     }
 
     #[test]
@@ -1021,6 +1217,7 @@ pub mod tests {
                 is_recursive: false,
                 separator_style: SeparatorStyle::Backslash,
                 stopping: Arc::new(AtomicBool::new(false)),
+                watch_filter: crate::WatchFilter::accept_all(),
             },
             action_tx,
         });
@@ -1072,6 +1269,7 @@ pub mod tests {
                 is_recursive: false,
                 separator_style: SeparatorStyle::Backslash,
                 stopping: Arc::new(AtomicBool::new(true)),
+                watch_filter: crate::WatchFilter::accept_all(),
             },
             action_tx,
         });
@@ -1118,6 +1316,7 @@ pub mod tests {
                 is_recursive: false,
                 separator_style: SeparatorStyle::Backslash,
                 stopping: Arc::new(AtomicBool::new(false)),
+                watch_filter: crate::WatchFilter::accept_all(),
             },
             action_tx,
         };

--- a/notify/tests/watch_filtered.rs
+++ b/notify/tests/watch_filtered.rs
@@ -1,0 +1,369 @@
+//! Black-box integration tests for `Watcher::watch_filtered` exercised through the public API.
+//!
+//! Unlike the per-backend unit tests, these drive the real, platform-default `RecommendedWatcher`
+//! (inotify / FSEvents / kqueue / ReadDirectoryChangesW depending on the target) plus `PollWatcher`,
+//! so they cover the config -> `update_paths` -> backend plumbing end to end. The two guarantees
+//! asserted here hold on every backend:
+//!
+//! * events beneath a filter-rejected directory are suppressed, and
+//! * events under a sibling included directory are still delivered.
+//!
+//! Watching a filter-rejected root and overlapping filtered watches are also checked, since those
+//! errors come from shared code and must surface identically regardless of backend.
+
+use std::path::{Path, PathBuf};
+use std::sync::mpsc;
+use std::time::{Duration, Instant};
+
+use notify::{
+    recommended_watcher, Config, ErrorKind, Event, PollWatcher, RecursiveMode, Result, WatchFilter,
+    Watcher,
+};
+
+/// A temporary directory whose path is canonicalized, matching what the event-time backends
+/// report (macOS resolves `/var` -> `/private/var`; Windows returns a verbatim `\\?\` path).
+struct TestDir {
+    _tmp: tempfile::TempDir,
+    path: PathBuf,
+}
+
+impl TestDir {
+    fn path(&self) -> &Path {
+        &self.path
+    }
+}
+
+fn testdir() -> TestDir {
+    let tmp = tempfile::tempdir().expect("create tempdir");
+    let path = std::fs::canonicalize(tmp.path()).expect("canonicalize tempdir");
+    TestDir { _tmp: tmp, path }
+}
+
+/// A filter that rejects directories named `name`.
+fn reject_name(name: &'static str) -> WatchFilter {
+    WatchFilter::with_filter(move |p: &Path| p.file_name() != Some(std::ffi::OsStr::new(name)))
+}
+
+fn drain(rx: &mpsc::Receiver<Result<Event>>) -> Vec<Event> {
+    rx.try_iter()
+        .map(|res| res.expect("watcher delivered an error"))
+        .collect()
+}
+
+/// Drains events until one references `target` (its own path or something beneath it),
+/// asserting throughout that nothing ever leaks from strictly inside `excluded`. Returns
+/// whether `target` was observed before `deadline`.
+///
+/// The kqueue backend cannot tell *what* changed in a watched directory, so it rediscovers a
+/// single new entry per write notification to the parent. Waiting for each sibling's own
+/// creation before touching the next guarantees the backend gets a separate notification for
+/// each and watches both; the other backends are unaffected by the extra synchronization.
+fn wait_for_path(
+    rx: &mpsc::Receiver<Result<Event>>,
+    target: &Path,
+    excluded: &Path,
+    deadline: Instant,
+) -> bool {
+    while Instant::now() < deadline {
+        match rx.recv_timeout(Duration::from_millis(50)) {
+            Ok(Ok(event)) => {
+                assert!(
+                    !event
+                        .paths
+                        .iter()
+                        .any(|p| p.starts_with(excluded) && p.as_path() != excluded),
+                    "event leaked from inside the excluded directory: {event:?}"
+                );
+                if event.paths.iter().any(|p| p.starts_with(target)) {
+                    return true;
+                }
+            }
+            Ok(Err(e)) => panic!("watcher delivered an error: {e:?}"),
+            Err(mpsc::RecvTimeoutError::Timeout) => {}
+            Err(mpsc::RecvTimeoutError::Disconnected) => panic!("watcher channel disconnected"),
+        }
+    }
+    false
+}
+
+/// FSEvents can transiently fail to start its stream under load; retry as the in-repo test
+/// harness does. On the other backends the first attempt succeeds.
+fn watch_filtered_retrying(watcher: &mut impl Watcher, root: &Path, filter: WatchFilter) {
+    for attempt in 0..5 {
+        match watcher.watch_filtered(root, RecursiveMode::Recursive, filter.clone()) {
+            Ok(()) => return,
+            Err(e) if attempt < 4 => {
+                eprintln!("watch_filtered attempt {attempt} failed: {e:?}; retrying");
+                std::thread::sleep(Duration::from_millis(100));
+            }
+            Err(e) => panic!("watch_filtered failed: {e:?}"),
+        }
+    }
+}
+
+fn assert_rejected_root_is_path_excluded(mut watcher: impl Watcher, root: &Path) {
+    let rejecting = root.to_path_buf();
+    let result = watcher.watch_filtered(
+        root,
+        RecursiveMode::Recursive,
+        WatchFilter::with_filter(move |p: &Path| p != rejecting.as_path()),
+    );
+    assert!(
+        matches!(result, Err(ref e) if matches!(e.kind, ErrorKind::PathExcluded)),
+        "watching a filter-rejected root must fail with PathExcluded: {result:?}"
+    );
+}
+
+#[test]
+fn rejected_root_returns_path_excluded_recommended() {
+    let dir = testdir();
+    let (tx, _rx) = mpsc::channel();
+    let watcher = recommended_watcher(tx).expect("recommended watcher");
+    assert_rejected_root_is_path_excluded(watcher, dir.path());
+}
+
+#[test]
+fn rejected_root_returns_path_excluded_poll() {
+    let dir = testdir();
+    let (tx, _rx) = mpsc::channel();
+    let watcher = PollWatcher::new(tx, Config::default()).expect("poll watcher");
+    assert_rejected_root_is_path_excluded(watcher, dir.path());
+}
+
+#[test]
+fn overlapping_filtered_watches_are_refused() {
+    let dir = testdir();
+    let root = dir.path();
+    let child = root.join("child");
+    std::fs::create_dir(&child).expect("create child");
+
+    let (tx, _rx) = mpsc::channel();
+    let mut watcher = recommended_watcher(tx).expect("recommended watcher");
+    watcher
+        .watch_filtered(root, RecursiveMode::Recursive, reject_name("excluded"))
+        .expect("first filtered watch");
+
+    // A filtered directory watch may not overlap another watch in either direction.
+    let result = watcher.watch_filtered(&child, RecursiveMode::Recursive, reject_name("other"));
+    assert!(
+        matches!(result, Err(ref e) if matches!(e.kind, ErrorKind::Generic(_))),
+        "a filtered watch overlapping another must be refused: {result:?}"
+    );
+}
+
+/// Deterministic (manually polled) end-to-end check that `PollWatcher` suppresses events beneath a
+/// rejected directory while still delivering events from an included sibling.
+#[test]
+fn poll_watcher_suppresses_events_inside_excluded_directory() {
+    let dir = testdir();
+    let root = dir.path();
+    let excluded = root.join("excluded");
+    let included = root.join("included");
+    std::fs::create_dir(&excluded).expect("create excluded");
+    std::fs::create_dir(&included).expect("create included");
+
+    let (tx, rx) = mpsc::channel();
+    let mut watcher =
+        PollWatcher::new(tx, Config::default().with_manual_polling()).expect("poll watcher");
+    // The initial scan at watch time seeds the baseline (and prunes the excluded directory).
+    watcher
+        .watch_filtered(root, RecursiveMode::Recursive, reject_name("excluded"))
+        .expect("watch filtered");
+    let _ = drain(&rx);
+
+    std::fs::write(excluded.join("hidden.txt"), "x").expect("write hidden");
+    std::fs::write(included.join("seen.txt"), "x").expect("write seen");
+    watcher.poll_blocking().expect("poll");
+
+    let events = drain(&rx);
+    assert!(
+        events
+            .iter()
+            .any(|e| e.paths.contains(&included.join("seen.txt"))),
+        "expected an event for the file created under the included directory: {events:?}"
+    );
+    assert!(
+        events.iter().all(|e| e
+            .paths
+            .iter()
+            .all(|p| !p.starts_with(&excluded) || *p == excluded)),
+        "no event may originate strictly inside the excluded directory: {events:?}"
+    );
+}
+
+/// End-to-end check over the platform-default backend: writes beneath a rejected directory are
+/// never delivered, while writes under an included sibling are. Timing-sensitive (real backends
+/// deliver asynchronously), so it keeps writing until an included event arrives and asserts the
+/// absence of excluded-subtree events throughout.
+#[test]
+fn recommended_watcher_suppresses_events_inside_excluded_directory() {
+    let dir = testdir();
+    let root = dir.path();
+
+    let (tx, rx) = mpsc::channel();
+    let mut watcher = recommended_watcher(tx).expect("recommended watcher");
+    watch_filtered_retrying(&mut watcher, root, reject_name("excluded"));
+
+    let excluded = root.join("excluded");
+    let included = root.join("included");
+
+    let deadline = Instant::now() + Duration::from_secs(15);
+
+    // Create the siblings one at a time, waiting for each to be observed before creating the
+    // next, so the kqueue backend gets a separate parent notification per directory and watches
+    // `included` (see `wait_for_path`). Their own creation is delivered even though the filter
+    // rejects `excluded` — only events strictly beneath a rejected directory are suppressed.
+    std::fs::create_dir(&excluded).expect("create excluded");
+    assert!(
+        wait_for_path(&rx, &excluded, &excluded, deadline),
+        "expected the excluded directory's own creation to be reported"
+    );
+    std::fs::create_dir(&included).expect("create included");
+    assert!(
+        wait_for_path(&rx, &included, &excluded, deadline),
+        "expected the included directory's creation to be observed so it becomes watched"
+    );
+
+    let mut saw_included = false;
+    while !saw_included && Instant::now() < deadline {
+        std::fs::write(excluded.join("hidden.txt"), "x").expect("write hidden");
+        std::fs::write(included.join("seen.txt"), "x").expect("write seen");
+
+        let attempt_deadline = Instant::now() + Duration::from_millis(250);
+        while !saw_included && Instant::now() < attempt_deadline {
+            match rx.recv_timeout(Duration::from_millis(50)) {
+                Ok(Ok(event)) => {
+                    assert!(
+                        !event
+                            .paths
+                            .iter()
+                            .any(|p| p.starts_with(&excluded) && *p != excluded),
+                        "event leaked from inside the excluded directory: {event:?}"
+                    );
+                    if event
+                        .paths
+                        .iter()
+                        .any(|p| p.starts_with(&included) && *p != included)
+                    {
+                        saw_included = true;
+                    }
+                }
+                Ok(Err(e)) => panic!("watcher delivered an error: {e:?}"),
+                Err(mpsc::RecvTimeoutError::Timeout) => break,
+                Err(mpsc::RecvTimeoutError::Disconnected) => panic!("watcher channel disconnected"),
+            }
+        }
+    }
+
+    assert!(
+        saw_included,
+        "expected an event from inside the included directory within the deadline"
+    );
+}
+
+/// The filter gates directories only, so watching a non-directory root is never rejected — even
+/// when the filter would reject that exact path. Shared barrier logic, so check both backends.
+fn assert_file_root_is_not_filtered(mut watcher: impl Watcher, file: &Path) {
+    let rejecting = file.to_path_buf();
+    let result = watcher.watch_filtered(
+        file,
+        RecursiveMode::Recursive,
+        WatchFilter::with_filter(move |p: &Path| p != rejecting.as_path()),
+    );
+    assert!(
+        result.is_ok(),
+        "the filter gates directories only, so a file root must still be watched: {result:?}"
+    );
+}
+
+#[test]
+fn file_root_is_not_filtered_recommended() {
+    let dir = testdir();
+    let file = dir.path().join("watched.txt");
+    std::fs::write(&file, "init").expect("create file");
+    let (tx, _rx) = mpsc::channel();
+    assert_file_root_is_not_filtered(recommended_watcher(tx).expect("recommended watcher"), &file);
+}
+
+#[test]
+fn file_root_is_not_filtered_poll() {
+    let dir = testdir();
+    let file = dir.path().join("watched.txt");
+    std::fs::write(&file, "init").expect("create file");
+    let (tx, _rx) = mpsc::channel();
+    let watcher = PollWatcher::new(tx, Config::default()).expect("poll watcher");
+    assert_file_root_is_not_filtered(watcher, &file);
+}
+
+/// The filter gates directories only: a file whose name the filter would reject still produces
+/// events under a recursive filtered watch. Deterministic via manual polling.
+#[test]
+fn filter_gates_directories_not_files() {
+    let dir = testdir();
+    let root = dir.path();
+
+    let (tx, rx) = mpsc::channel();
+    let mut watcher =
+        PollWatcher::new(tx, Config::default().with_manual_polling()).expect("poll watcher");
+    // `reject_name("seen.txt")` would reject a *directory* named seen.txt; a file is never gated.
+    watcher
+        .watch_filtered(root, RecursiveMode::Recursive, reject_name("seen.txt"))
+        .expect("watch filtered");
+    let _ = drain(&rx);
+
+    let file = root.join("seen.txt");
+    std::fs::write(&file, "data").expect("write file");
+    watcher.poll_blocking().expect("poll");
+
+    let events = drain(&rx);
+    assert!(
+        events.iter().any(|e| e.paths.contains(&file)),
+        "the filter gates directories only; a matching file must still be reported: {events:?}"
+    );
+}
+
+/// Re-watching the same path with an accept-all filter replaces the filtered watch and lifts the
+/// exclusion, so contents that were previously suppressed start flowing. Deterministic.
+#[test]
+fn rewatching_with_accept_all_lifts_the_filter() {
+    let dir = testdir();
+    let root = dir.path();
+    let excluded = root.join("excluded");
+    std::fs::create_dir(&excluded).expect("create excluded");
+
+    let (tx, rx) = mpsc::channel();
+    let mut watcher =
+        PollWatcher::new(tx, Config::default().with_manual_polling()).expect("poll watcher");
+    watcher
+        .watch_filtered(root, RecursiveMode::Recursive, reject_name("excluded"))
+        .expect("watch filtered");
+    let _ = drain(&rx);
+
+    // With the filter in place, activity inside `excluded` is suppressed.
+    std::fs::write(excluded.join("first.txt"), "a").expect("write first");
+    watcher.poll_blocking().expect("poll");
+    let events = drain(&rx);
+    assert!(
+        events.iter().all(|e| e
+            .paths
+            .iter()
+            .all(|p| !p.starts_with(&excluded) || *p == excluded)),
+        "the filter should suppress excluded contents: {events:?}"
+    );
+
+    // Re-watching the same path without a filter replaces the watch and lifts the exclusion.
+    watcher
+        .watch(root, RecursiveMode::Recursive)
+        .expect("rewatch accept-all");
+    let _ = drain(&rx);
+
+    std::fs::write(excluded.join("second.txt"), "b").expect("write second");
+    watcher.poll_blocking().expect("poll");
+    let events = drain(&rx);
+    assert!(
+        events
+            .iter()
+            .any(|e| e.paths.contains(&excluded.join("second.txt"))),
+        "after re-watching without a filter, excluded contents must be reported: {events:?}"
+    );
+}


### PR DESCRIPTION
Adds `WatchFilter` and `Watcher::watch_filtered`, allowing directories to be excluded when setting up a watch. Implemented for the inotify, fsevents, kqueue, windows, poll, and null backends, with filter support plumbed through `Watcher::update_paths`, `notify-debouncer-full`, and the `FileIdCache` API.

The filter gates directories only: walk-based backends prune excluded directories at scan time and gate directories discovered while watching; FSEvents and Windows suppress matching events at delivery time. File watches are never affected.

Two restrictions keep the semantics simple and the implementation small:

- Watching a directory the filter itself rejects returns the new `ErrorKind::PathExcluded` and changes nothing. Symlink roots are checked against their resolved target too.
- A directory watch carrying a filter must not overlap another directory watch in either direction; such calls are refused with an error. Filters are never merged across watches, so each watch entry carries exactly one filter. Accept-all watches keep the existing overlap semantics, file watches never conflict, and re-watching the same path still replaces the watch (`WatchFilter::same_filter` identity makes an identical re-watch a no-op).

Based on the filter-watch-targets branch:
- Add `watch_filtered`, filtering paths to watch.
- Add fsevent support and filter newly added paths too.
- Add support for watch_filtered to Windows.
- Add filtered watch implementation for kqueue.
