### PR TITLE
feat(notify): use inotify as the FreeBSD backend

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -63,9 +63,9 @@ body:
       description: Which backend is being used?
       options:
         - Unknown/Auto-detected
-        - inotify (Linux)
+        - inotify (Linux/Android/FreeBSD 15+)
         - fsevents (macOS)
-        - kqueue (macOS/BSD)
+        - kqueue (macOS/BSD/FreeBSD 14.x)
         - ReadDirectoryChangesW (Windows)
         - polling (all platforms)
     validations:

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -64,8 +64,8 @@ body:
       options:
         - Unknown/Auto-detected
         - inotify (Linux/Android/FreeBSD 15+)
-        - fsevents (macOS)
-        - kqueue (macOS/BSD/FreeBSD 14.x)
+        - FSEvents (macOS)
+        - kqueue (macOS/iOS/BSDs)
         - ReadDirectoryChangesW (Windows)
         - polling (all platforms)
     validations:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -148,14 +148,34 @@ jobs:
         run: cargo test --workspace --exclude examples --verbose ${{ matrix.features }} --features tokio
 
   # FreeBSD
+  # 15.1: default features (freebsd_inotify → RecommendedWatcher = inotify).
+  # 14.4: --no-default-features (kqueue only; no inotify in base libc).
   freebsd:
-    name: FreeBSD - ${{ matrix.rust }}
+    name: FreeBSD ${{ matrix.release }} - ${{ matrix.rust }}${{ matrix.features != '' && format(' ({0})', matrix.features) || '' }}
     runs-on: ubuntu-latest
     needs: quality
     strategy:
       fail-fast: false
       matrix:
-        rust: [stable, nightly, 1.88]
+        include:
+          - rust: stable
+            release: "15.1"
+            features: ""
+          - rust: nightly
+            release: "15.1"
+            features: ""
+          - rust: "1.88"
+            release: "15.1"
+            features: ""
+          - rust: stable
+            release: "14.4"
+            features: "--no-default-features"
+          - rust: nightly
+            release: "14.4"
+            features: "--no-default-features"
+          - rust: "1.88"
+            release: "14.4"
+            features: "--no-default-features"
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
@@ -164,7 +184,7 @@ jobs:
       - name: Test in FreeBSD VM
         uses: vmactions/freebsd-vm@b84ab5559b5a1bb4b8ee2737d2506a16e1737636 # v1.4.8
         with:
-          release: "14.3"
+          release: ${{ matrix.release }}
           envs: "CARGO_TERM_COLOR RUST_BACKTRACE"
           usesh: true
           prepare: |
@@ -175,9 +195,9 @@ jobs:
             . $HOME/.cargo/env
             cargo --version
             rustc --version
-            cargo build --verbose
-            cargo build --examples --verbose
-            cargo test --verbose
+            cargo build --verbose ${{ matrix.features }}
+            cargo build --examples --verbose ${{ matrix.features }}
+            cargo test --verbose ${{ matrix.features }}
 
   # Android cross-compilation
   android:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -147,35 +147,23 @@ jobs:
         if: matrix.rust == 'stable'
         run: cargo test --workspace --exclude examples --verbose ${{ matrix.features }} --features tokio
 
-  # FreeBSD
-  # 15.1: default features (freebsd_inotify → RecommendedWatcher = inotify).
-  # 14.4: --no-default-features (kqueue only; no inotify in base libc).
+  # FreeBSD 14 tests the default kqueue backend; FreeBSD 15 tests native inotify.
   freebsd:
-    name: FreeBSD ${{ matrix.release }} - ${{ matrix.rust }}${{ matrix.features != '' && format(' ({0})', matrix.features) || '' }}
+    name: FreeBSD ${{ matrix.release }} (${{ matrix.backend }}) - ${{ matrix.rust }}
     runs-on: ubuntu-latest
     needs: quality
     strategy:
       fail-fast: false
       matrix:
+        rust: [stable, nightly, 1.88]
+        backend: [kqueue, inotify]
         include:
-          - rust: stable
-            release: "15.1"
-            features: ""
-          - rust: nightly
-            release: "15.1"
-            features: ""
-          - rust: "1.88"
-            release: "15.1"
-            features: ""
-          - rust: stable
+          - backend: kqueue
             release: "14.4"
-            features: "--no-default-features"
-          - rust: nightly
-            release: "14.4"
-            features: "--no-default-features"
-          - rust: "1.88"
-            release: "14.4"
-            features: "--no-default-features"
+            cargo_args: ""
+          - backend: inotify
+            release: "15.1"
+            cargo_args: "--features freebsd_inotify"
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
@@ -195,9 +183,9 @@ jobs:
             . $HOME/.cargo/env
             cargo --version
             rustc --version
-            cargo build --verbose ${{ matrix.features }}
-            cargo build --examples --verbose ${{ matrix.features }}
-            cargo test --verbose ${{ matrix.features }}
+            cargo build --verbose ${{ matrix.cargo_args }}
+            cargo build --examples --verbose ${{ matrix.cargo_args }}
+            cargo test --verbose ${{ matrix.cargo_args }}
 
   # Android cross-compilation
   android:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ objc2-core-foundation = { version = "0.3.2", default-features = false }
 objc2-core-services = { version = "0.3.2", default-features = false }
 futures = "0.3.30"
 tokio = { version = "1.49.0", default-features = false, features = ["sync"] }
-inotify = { version = "0.11.0", default-features = false }
+inotify = { version = "0.11.4", default-features = false }
 insta = "1.34.0"
 kqueue = "1.2.0"
 libc = "0.2.4"
@@ -37,9 +37,11 @@ log = "0.4.17"
 mio = { version = "1.0", features = ["os-ext"] }
 web-time = "1.1.0"
 nix = "0.31.0"
-notify = { version = "9.0.0-rc.4", path = "notify" }
-notify-debouncer-full = { version = "0.8.0-rc.2", path = "notify-debouncer-full" }
-notify-debouncer-mini = { version = "0.7.0", path = "notify-debouncer-mini" }
+# default-features = false so workspace members can opt into backends via features
+# (required for FreeBSD 14 CI: --no-default-features → kqueue only).
+notify = { version = "9.0.0-rc.4", path = "notify", default-features = false }
+notify-debouncer-full = { version = "0.8.0-rc.2", path = "notify-debouncer-full", default-features = false }
+notify-debouncer-mini = { version = "0.7.0", path = "notify-debouncer-mini", default-features = false }
 notify-types = { version = "2.1.0", path = "notify-types" }
 pretty_assertions = "1.3.0"
 rand = "0.10.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,11 +37,9 @@ log = "0.4.17"
 mio = { version = "1.0", features = ["os-ext"] }
 web-time = "1.1.0"
 nix = "0.31.0"
-# default-features = false so workspace members can opt into backends via features
-# (required for FreeBSD 14 CI: --no-default-features → kqueue only).
-notify = { version = "9.0.0-rc.4", path = "notify", default-features = false }
-notify-debouncer-full = { version = "0.8.0-rc.2", path = "notify-debouncer-full", default-features = false }
-notify-debouncer-mini = { version = "0.7.0", path = "notify-debouncer-mini", default-features = false }
+notify = { version = "9.0.0-rc.4", path = "notify" }
+notify-debouncer-full = { version = "0.8.0-rc.2", path = "notify-debouncer-full" }
+notify-debouncer-mini = { version = "0.7.0", path = "notify-debouncer-mini" }
 notify-types = { version = "2.1.0", path = "notify-types" }
 pretty_assertions = "1.3.0"
 rand = "0.10.0"

--- a/README.md
+++ b/README.md
@@ -45,9 +45,10 @@ We follow these MSRV rules:
 ## Platforms
 
 - Linux / Android: inotify
+- FreeBSD 15.0+: inotify (default `freebsd_inotify` feature); FreeBSD 14.x: disable default features to use kqueue
 - macOS: FSEvents or kqueue, see features
 - Windows: ReadDirectoryChangesW
-- iOS / FreeBSD / NetBSD / OpenBSD / DragonflyBSD: kqueue
+- iOS / NetBSD / OpenBSD / DragonflyBSD: kqueue
 - All platforms: polling
 
 ## License

--- a/README.md
+++ b/README.md
@@ -45,8 +45,8 @@ We follow these MSRV rules:
 ## Platforms
 
 - Linux / Android: inotify
-- FreeBSD 15.0+: inotify (default `freebsd_inotify` feature); FreeBSD 14.x: disable default features to use kqueue
-- macOS: FSEvents or kqueue, see features
+- FreeBSD: kqueue (default) or inotify, see features
+- macOS: FSEvents (default) or kqueue, see features
 - Windows: ReadDirectoryChangesW
 - iOS / NetBSD / OpenBSD / DragonflyBSD: kqueue
 - All platforms: polling

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -5,10 +5,23 @@ publish = false
 edition = "2021"
 license = "MIT OR Apache-2.0"
 
+[features]
+default = ["macos_fsevent", "freebsd_inotify"]
+macos_fsevent = [
+  "notify/macos_fsevent",
+  "notify-debouncer-mini/macos_fsevent",
+  "notify-debouncer-full/macos_fsevent",
+]
+freebsd_inotify = [
+  "notify/freebsd_inotify",
+  "notify-debouncer-mini/freebsd_inotify",
+  "notify-debouncer-full/freebsd_inotify",
+]
+
 [dev-dependencies]
-notify = { workspace = true }
-notify-debouncer-mini = { workspace = true }
-notify-debouncer-full = { workspace = true }
+notify.workspace = true
+notify-debouncer-mini.workspace = true
+notify-debouncer-full.workspace = true
 futures = { workspace = true }
 tempfile = { workspace = true }
 log = { workspace = true }

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -5,23 +5,10 @@ publish = false
 edition = "2021"
 license = "MIT OR Apache-2.0"
 
-[features]
-default = ["macos_fsevent", "freebsd_inotify"]
-macos_fsevent = [
-  "notify/macos_fsevent",
-  "notify-debouncer-mini/macos_fsevent",
-  "notify-debouncer-full/macos_fsevent",
-]
-freebsd_inotify = [
-  "notify/freebsd_inotify",
-  "notify-debouncer-mini/freebsd_inotify",
-  "notify-debouncer-full/freebsd_inotify",
-]
-
 [dev-dependencies]
-notify.workspace = true
-notify-debouncer-mini.workspace = true
-notify-debouncer-full.workspace = true
+notify = { workspace = true }
+notify-debouncer-mini = { workspace = true }
+notify-debouncer-full = { workspace = true }
 futures = { workspace = true }
 tempfile = { workspace = true }
 log = { workspace = true }

--- a/notify-debouncer-full/Cargo.toml
+++ b/notify-debouncer-full/Cargo.toml
@@ -13,13 +13,14 @@ homepage.workspace = true
 repository.workspace = true
 
 [features]
-default = ["macos_fsevent"]
+default = ["macos_fsevent", "freebsd_inotify"]
 serde = ["notify-types/serde"]
 web-time = ["notify-types/web-time"]
 crossbeam-channel = ["dep:crossbeam-channel", "notify/crossbeam-channel"]
 flume = ["dep:flume", "notify/flume"]
 macos_fsevent = ["notify/macos_fsevent"]
 macos_kqueue = ["notify/macos_kqueue"]
+freebsd_inotify = ["notify/freebsd_inotify"]
 serialization-compat-6 = ["notify/serialization-compat-6"]
 tokio = ["dep:tokio"]
 futures = ["dep:futures"]

--- a/notify-debouncer-full/Cargo.toml
+++ b/notify-debouncer-full/Cargo.toml
@@ -13,7 +13,7 @@ homepage.workspace = true
 repository.workspace = true
 
 [features]
-default = ["macos_fsevent", "freebsd_inotify"]
+default = ["macos_fsevent"]
 serde = ["notify-types/serde"]
 web-time = ["notify-types/web-time"]
 crossbeam-channel = ["dep:crossbeam-channel", "notify/crossbeam-channel"]

--- a/notify-debouncer-full/src/lib.rs
+++ b/notify-debouncer-full/src/lib.rs
@@ -47,15 +47,16 @@
 //!
 //! # Features
 //!
-//! The following crate features can be turned on or off in your cargo dependency config:
+//! The following crate features can be configured in your Cargo dependency:
 //!
-//! - `serde` passed down to notify-types, off by default
-//! - `web-time` passed down to notify-types, off by default
-//! - `crossbeam-channel` passed down to notify, off by default
-//! - `flume` passed down to notify, off by default
-//! - `macos_fsevent` passed down to notify, off by default
-//! - `macos_kqueue` passed down to notify, off by default
-//! - `serialization-compat-6` passed down to notify, off by default
+//! - `macos_fsevent` (default) enables notify's FSEvents backend on macOS
+//! - `freebsd_inotify` enables notify's native inotify backend on FreeBSD 15+
+//! - `macos_kqueue` enables notify's kqueue backend on macOS
+//! - `serde` enables serialization support in notify-types
+//! - `web-time` uses `web_time::Instant` for debounced events
+//! - `crossbeam-channel`, `flume`, `futures`, and `tokio` enable the corresponding
+//!   channel senders as event handlers
+//! - `serialization-compat-6` restores notify 6 serialization behavior
 //!
 //! # Caveats
 //!

--- a/notify-debouncer-mini/Cargo.toml
+++ b/notify-debouncer-mini/Cargo.toml
@@ -13,12 +13,13 @@ homepage.workspace = true
 repository.workspace = true
 
 [features]
-default = ["macos_fsevent"]
+default = ["macos_fsevent", "freebsd_inotify"]
 serde = ["notify-types/serde"]
 crossbeam-channel = ["dep:crossbeam-channel", "notify/crossbeam-channel"]
 flume = ["dep:flume", "notify/flume"]
 macos_fsevent = ["notify/macos_fsevent"]
 macos_kqueue = ["notify/macos_kqueue"]
+freebsd_inotify = ["notify/freebsd_inotify"]
 serialization-compat-6 = ["notify/serialization-compat-6"]
 tokio = ["dep:tokio"]
 futures = ["dep:futures"]

--- a/notify-debouncer-mini/Cargo.toml
+++ b/notify-debouncer-mini/Cargo.toml
@@ -13,7 +13,7 @@ homepage.workspace = true
 repository.workspace = true
 
 [features]
-default = ["macos_fsevent", "freebsd_inotify"]
+default = ["macos_fsevent"]
 serde = ["notify-types/serde"]
 crossbeam-channel = ["dep:crossbeam-channel", "notify/crossbeam-channel"]
 flume = ["dep:flume", "notify/flume"]

--- a/notify-debouncer-mini/src/lib.rs
+++ b/notify-debouncer-mini/src/lib.rs
@@ -43,14 +43,15 @@
 //!
 //! # Features
 //!
-//! The following crate features can be turned on or off in your cargo dependency config:
+//! The following crate features can be configured in your Cargo dependency:
 //!
-//! - `serde` passed down to notify-types, off by default
-//! - `crossbeam-channel` passed down to notify, off by default
-//! - `flume` passed down to notify, off by default
-//! - `macos_fsevent` passed down to notify, off by default
-//! - `macos_kqueue` passed down to notify, off by default
-//! - `serialization-compat-6` passed down to notify, off by default
+//! - `macos_fsevent` (default) enables notify's FSEvents backend on macOS
+//! - `freebsd_inotify` enables notify's native inotify backend on FreeBSD 15+
+//! - `macos_kqueue` enables notify's kqueue backend on macOS
+//! - `serde` enables serialization support in notify-types
+//! - `crossbeam-channel`, `flume`, `futures`, and `tokio` enable the corresponding
+//!   channel senders as event handlers
+//! - `serialization-compat-6` restores notify 6 serialization behavior
 //!
 //! # Caveats
 //!

--- a/notify/CHANGELOG.md
+++ b/notify/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## unreleased
 
+- CHANGE: [FreeBSD] default `RecommendedWatcher` is native inotify via the `freebsd_inotify` default feature (FreeBSD 15.0+). FreeBSD 14.x has no inotify in base: build with `default-features = false` to use kqueue. `KqueueWatcher` remains available on all FreeBSD versions.
+- DEPS: bump `inotify` to 0.11.4 (native FreeBSD inotify via `inotify-sys` 0.1.8)
 - FEATURE: [macOS] add `Config::with_fsevent_latency` to configure FSEvents stream latency [#930]
 - FIX: [windows] emit a Remove event when a watched directory is deleted, matching inotify and FSEvents
 - FIX: [windows] surface `ReadDirectoryChangesW` read-start failures [#935]

--- a/notify/CHANGELOG.md
+++ b/notify/CHANGELOG.md
@@ -2,8 +2,8 @@
 
 ## unreleased
 
-- CHANGE: [FreeBSD] default `RecommendedWatcher` is native inotify via the `freebsd_inotify` default feature (FreeBSD 15.0+). FreeBSD 14.x has no inotify in base: build with `default-features = false` to use kqueue. `KqueueWatcher` remains available on all FreeBSD versions.
-- DEPS: bump `inotify` to 0.11.4 (native FreeBSD inotify via `inotify-sys` 0.1.8)
+- FEATURE: [FreeBSD] add native inotify support on FreeBSD 15.0+ behind the `freebsd_inotify` feature. kqueue remains the default backend.
+- DEPS: bump `inotify` to 0.11.4 for native FreeBSD support
 - FEATURE: [macOS] add `Config::with_fsevent_latency` to configure FSEvents stream latency [#930]
 - FIX: [windows] emit a Remove event when a watched directory is deleted, matching inotify and FSEvents
 - FIX: [windows] surface `ReadDirectoryChangesW` read-start failures [#935]

--- a/notify/Cargo.toml
+++ b/notify/Cargo.toml
@@ -18,10 +18,15 @@ homepage.workspace = true
 repository.workspace = true
 
 [features]
-default = ["macos_fsevent"]
+default = ["macos_fsevent", "freebsd_inotify"]
 serde = ["notify-types/serde"]
 macos_kqueue = ["kqueue", "mio"]
 macos_fsevent = ["objc2-core-foundation", "objc2-core-services"]
+# Native inotify(2) as RecommendedWatcher on FreeBSD (base system since 15.0).
+# FreeBSD 14.x has no inotify libc wrappers: disable this feature
+# (`default-features = false`) to use kqueue instead. Kqueue remains available
+# either way via `KqueueWatcher`.
+freebsd_inotify = ["dep:inotify"]
 serialization-compat-6 = ["notify-types/serialization-compat-6"]
 tokio = ["dep:tokio"]
 futures = ["dep:futures"]
@@ -70,7 +75,13 @@ windows-sys = { workspace = true, features = [
   "Win32_System_IO",
 ] }
 
-[target.'cfg(any(target_os="freebsd", target_os="openbsd", target_os = "netbsd", target_os = "dragonfly", target_os = "ios"))'.dependencies]
+# FreeBSD: kqueue always; inotify when `freebsd_inotify` is enabled (default).
+[target.'cfg(target_os="freebsd")'.dependencies]
+inotify = { workspace = true, default-features = false, optional = true }
+kqueue.workspace = true
+mio.workspace = true
+
+[target.'cfg(any(target_os="openbsd", target_os = "netbsd", target_os = "dragonfly", target_os = "ios"))'.dependencies]
 kqueue.workspace = true
 mio.workspace = true
 

--- a/notify/Cargo.toml
+++ b/notify/Cargo.toml
@@ -18,14 +18,11 @@ homepage.workspace = true
 repository.workspace = true
 
 [features]
-default = ["macos_fsevent", "freebsd_inotify"]
+default = ["macos_fsevent"]
 serde = ["notify-types/serde"]
 macos_kqueue = ["kqueue", "mio"]
 macos_fsevent = ["objc2-core-foundation", "objc2-core-services"]
-# Native inotify(2) as RecommendedWatcher on FreeBSD (base system since 15.0).
-# FreeBSD 14.x has no inotify libc wrappers: disable this feature
-# (`default-features = false`) to use kqueue instead. Kqueue remains available
-# either way via `KqueueWatcher`.
+# Opt-in native inotify backend for FreeBSD 15+.
 freebsd_inotify = ["dep:inotify"]
 serialization-compat-6 = ["notify-types/serialization-compat-6"]
 tokio = ["dep:tokio"]
@@ -75,7 +72,7 @@ windows-sys = { workspace = true, features = [
   "Win32_System_IO",
 ] }
 
-# FreeBSD: kqueue always; inotify when `freebsd_inotify` is enabled (default).
+# Keep kqueue available when the inotify backend is enabled.
 [target.'cfg(target_os="freebsd")'.dependencies]
 inotify = { workspace = true, default-features = false, optional = true }
 kqueue.workspace = true

--- a/notify/src/inotify.rs
+++ b/notify/src/inotify.rs
@@ -1,4 +1,4 @@
-//! Watcher implementation for the inotify Linux API
+//! Watcher implementation for the inotify API (Linux, Android, FreeBSD 15.0+)
 //!
 //! The inotify API provides a mechanism for monitoring filesystem events.  Inotify can be used to
 //! monitor individual files, or to monitor directories.  When a directory is monitored, inotify
@@ -1693,7 +1693,10 @@ mod tests {
                 break event;
             }
         };
-        assert_eq!(event, expected(&path).modify_data_any());
+        // Linux's inotify reports utimensat as IN_MODIFY (Data); FreeBSD's
+        // reports it as IN_ATTRIB (Metadata), per inotify(7)'s own description.
+        // Accept either to test the portable contract.
+        assert_eq!(event, expected(&path).modify());
     }
 
     #[test]
@@ -1779,7 +1782,12 @@ mod tests {
         ]);
     }
 
+    // Linux-only: Linux's inotify is dirent-centric (events fire on the
+    // pathname used for the write), so writes through an external hardlink
+    // are invisible on the watched name. FreeBSD's inotify is inode-centric
+    // and surfaces events on every name pointing to the modified inode.
     #[test]
+    #[cfg(target_os = "linux")]
     fn write_to_a_hardlink_pointed_to_the_file_in_the_watched_dir_doesnt_trigger_an_event() {
         let tmpdir = testdir();
         let (mut watcher, mut rx) = watcher();

--- a/notify/src/inotify.rs
+++ b/notify/src/inotify.rs
@@ -1,4 +1,4 @@
-//! Watcher implementation for the inotify API (Linux, Android, FreeBSD 15.0+)
+//! Inotify watcher implementation for Linux, Android, and FreeBSD 15.0+.
 //!
 //! The inotify API provides a mechanism for monitoring filesystem events.  Inotify can be used to
 //! monitor individual files, or to monitor directories.  When a directory is monitored, inotify
@@ -1693,9 +1693,7 @@ mod tests {
                 break event;
             }
         };
-        // Linux's inotify reports utimensat as IN_MODIFY (Data); FreeBSD's
-        // reports it as IN_ATTRIB (Metadata), per inotify(7)'s own description.
-        // Accept either to test the portable contract.
+        // Linux and FreeBSD classify this modification differently.
         assert_eq!(event, expected(&path).modify());
     }
 
@@ -1782,12 +1780,9 @@ mod tests {
         ]);
     }
 
-    // Linux-only: Linux's inotify is dirent-centric (events fire on the
-    // pathname used for the write), so writes through an external hardlink
-    // are invisible on the watched name. FreeBSD's inotify is inode-centric
-    // and surfaces events on every name pointing to the modified inode.
+    // FreeBSD reports writes through any hard link to the watched inode.
     #[test]
-    #[cfg(target_os = "linux")]
+    #[cfg(not(target_os = "freebsd"))]
     fn write_to_a_hardlink_pointed_to_the_file_in_the_watched_dir_doesnt_trigger_an_event() {
         let tmpdir = testdir();
         let (mut watcher, mut rx) = watcher();

--- a/notify/src/lib.rs
+++ b/notify/src/lib.rs
@@ -17,6 +17,7 @@
 //! - `serde` for serialization of events
 //! - `macos_fsevent` enabled by default, for fsevent backend on macos
 //! - `macos_kqueue` for kqueue backend on macos
+//! - `freebsd_inotify` enabled by default; native inotify as FreeBSD recommended backend (15.0+). Disable default features on FreeBSD 14.x to use kqueue.
 //! - `serialization-compat-6` restores the serialization behavior of notify 6, off by default
 //!
 //! ### Serde
@@ -181,7 +182,12 @@ use std::path::{Path, PathBuf};
 pub(crate) type StdResult<T, E> = std::result::Result<T, E>;
 pub(crate) type Receiver<T> = std::sync::mpsc::Receiver<T>;
 pub(crate) type Sender<T> = std::sync::mpsc::Sender<T>;
-#[cfg(any(target_os = "linux", target_os = "android", target_os = "windows"))]
+#[cfg(any(
+    target_os = "linux",
+    target_os = "android",
+    all(target_os = "freebsd", feature = "freebsd_inotify"),
+    target_os = "windows",
+))]
 pub(crate) type BoundSender<T> = std::sync::mpsc::SyncSender<T>;
 
 #[inline]
@@ -189,7 +195,12 @@ pub(crate) fn unbounded<T>() -> (Sender<T>, Receiver<T>) {
     std::sync::mpsc::channel()
 }
 
-#[cfg(any(target_os = "linux", target_os = "android", target_os = "windows"))]
+#[cfg(any(
+    target_os = "linux",
+    target_os = "android",
+    all(target_os = "freebsd", feature = "freebsd_inotify"),
+    target_os = "windows",
+))]
 #[inline]
 pub(crate) fn bounded<T>(cap: usize) -> (BoundSender<T>, Receiver<T>) {
     std::sync::mpsc::sync_channel(cap)
@@ -197,7 +208,11 @@ pub(crate) fn bounded<T>(cap: usize) -> (BoundSender<T>, Receiver<T>) {
 
 #[cfg(all(target_os = "macos", not(feature = "macos_kqueue")))]
 pub use crate::fsevent::FsEventWatcher;
-#[cfg(any(target_os = "linux", target_os = "android"))]
+#[cfg(any(
+    target_os = "linux",
+    target_os = "android",
+    all(target_os = "freebsd", feature = "freebsd_inotify"),
+))]
 pub use crate::inotify::INotifyWatcher;
 #[cfg(any(
     target_os = "freebsd",
@@ -215,7 +230,11 @@ pub use windows::ReadDirectoryChangesWatcher;
 
 #[cfg(all(target_os = "macos", not(feature = "macos_kqueue")))]
 pub mod fsevent;
-#[cfg(any(target_os = "linux", target_os = "android"))]
+#[cfg(any(
+    target_os = "linux",
+    target_os = "android",
+    all(target_os = "freebsd", feature = "freebsd_inotify"),
+))]
 pub mod inotify;
 #[cfg(any(
     target_os = "freebsd",
@@ -309,7 +328,7 @@ impl EventHandler for std::sync::mpsc::Sender<Result<Event>> {
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 #[non_exhaustive]
 pub enum WatcherKind {
-    /// inotify backend (linux)
+    /// inotify backend (Linux, Android, FreeBSD 15+ with `freebsd_inotify`)
     Inotify,
     /// FS-Event backend (mac)
     Fsevent,
@@ -465,7 +484,11 @@ pub trait Watcher {
 }
 
 /// The recommended [`Watcher`] implementation for the current platform
-#[cfg(any(target_os = "linux", target_os = "android"))]
+#[cfg(any(
+    target_os = "linux",
+    target_os = "android",
+    all(target_os = "freebsd", feature = "freebsd_inotify"),
+))]
 pub type RecommendedWatcher = INotifyWatcher;
 /// The recommended [`Watcher`] implementation for the current platform
 #[cfg(all(target_os = "macos", not(feature = "macos_kqueue")))]
@@ -475,7 +498,7 @@ pub type RecommendedWatcher = FsEventWatcher;
 pub type RecommendedWatcher = ReadDirectoryChangesWatcher;
 /// The recommended [`Watcher`] implementation for the current platform
 #[cfg(any(
-    target_os = "freebsd",
+    all(target_os = "freebsd", not(feature = "freebsd_inotify")),
     target_os = "openbsd",
     target_os = "netbsd",
     target_os = "dragonfly",

--- a/notify/src/lib.rs
+++ b/notify/src/lib.rs
@@ -15,9 +15,9 @@
 //! List of compilation features, see below for details
 //!
 //! - `serde` for serialization of events
-//! - `macos_fsevent` enabled by default, for fsevent backend on macos
-//! - `macos_kqueue` for kqueue backend on macos
-//! - `freebsd_inotify` enabled by default; native inotify as FreeBSD recommended backend (15.0+). Disable default features on FreeBSD 14.x to use kqueue.
+//! - `macos_fsevent` (default) for the FSEvents backend on macOS
+//! - `macos_kqueue` for the kqueue backend on macOS
+//! - `freebsd_inotify` for native inotify on FreeBSD 15.0+
 //! - `serialization-compat-6` restores the serialization behavior of notify 6, off by default
 //!
 //! ### Serde
@@ -328,7 +328,7 @@ impl EventHandler for std::sync::mpsc::Sender<Result<Event>> {
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 #[non_exhaustive]
 pub enum WatcherKind {
-    /// inotify backend (Linux, Android, FreeBSD 15+ with `freebsd_inotify`)
+    /// Inotify backend (Linux, Android, and FreeBSD 15+ with `freebsd_inotify`)
     Inotify,
     /// FS-Event backend (mac)
     Fsevent,


### PR DESCRIPTION


<!-- 
## Contribution Agreement
By contributing, you agree to the license terms (CC Zero 1.0 for notify crate, MIT/Apache 2.0 for the rest) and the code of conduct in CODE_OF_CONDUCT.md.

## Changelog
Add an entry to CHANGELOG.md if applicable. Create a new section `## notify (unreleased)` if not already present.

## Testing
The test suite will run after creating this PR. If builds fail, you must either fix the errors, ask for help, or provide a detailed explanation of why failures are expected. If you don't, a maintainer may prompt you, but it will take longer for your contribution to be reviewed.

## Code Quality
Running `cargo fmt` and `cargo clippy` is appreciated but not required.

You can delete this comment after reading.
-->

## Description
    FreeBSD 15.0+ provides in-kernel inotify(2) and libc wrappers. Enable
    the freebsd_inotify feature by default so INotifyWatcher is
    RecommendedWatcher on FreeBSD (same as Linux/Android), keep kqueue
    available, and bump inotify to 0.11.4.
    
    FreeBSD 14.x has no inotify in base: build with default-features = false
    to use kqueue. Native linkage is handled in inotify-sys 0.1.8.
    
    Test adjustments for FreeBSD event semantics:
    - set_file_mtime accepts any Modify (Linux: IN_MODIFY, FreeBSD: IN_ATTRIB)
    - hardlink write-through test is Linux-only (dirent- vs inode-centric)
    
    CI: FreeBSD 15.1 with defaults; FreeBSD 14.4 with --no-default-features.
    Document the platform split in README/changelog.


## Related Issues
<!-- Link any related issues -->
