### PR TITLE
feat(freebsd): auto-select backend (kqueue/inotify) by version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -147,7 +147,7 @@ jobs:
         if: matrix.rust == 'stable'
         run: cargo test --workspace --exclude examples --verbose ${{ matrix.features }} --features tokio
 
-  # FreeBSD 14 tests the default kqueue backend; FreeBSD 15 tests native inotify.
+  # Verify automatic backend selection on both supported FreeBSD releases.
   freebsd:
     name: FreeBSD ${{ matrix.release }} (${{ matrix.backend }}) - ${{ matrix.rust }}
     runs-on: ubuntu-latest
@@ -160,10 +160,8 @@ jobs:
         include:
           - backend: kqueue
             release: "14.4"
-            cargo_args: ""
           - backend: inotify
             release: "15.1"
-            cargo_args: "--features freebsd_inotify"
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
@@ -183,9 +181,9 @@ jobs:
             . $HOME/.cargo/env
             cargo --version
             rustc --version
-            cargo build --verbose ${{ matrix.cargo_args }}
-            cargo build --examples --verbose ${{ matrix.cargo_args }}
-            cargo test --verbose ${{ matrix.cargo_args }}
+            cargo build --verbose
+            cargo build --examples --verbose
+            cargo test --verbose
 
   # Android cross-compilation
   android:

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ We follow these MSRV rules:
 ## Platforms
 
 - Linux / Android: inotify
-- FreeBSD: kqueue (default) or inotify, see features
+- FreeBSD: inotify when built natively on 15.0+; kqueue otherwise (use `freebsd_inotify` for cross-builds)
 - macOS: FSEvents (default) or kqueue, see features
 - Windows: ReadDirectoryChangesW
 - iOS / NetBSD / OpenBSD / DragonflyBSD: kqueue

--- a/notify-debouncer-full/src/lib.rs
+++ b/notify-debouncer-full/src/lib.rs
@@ -50,7 +50,8 @@
 //! The following crate features can be configured in your Cargo dependency:
 //!
 //! - `macos_fsevent` (default) enables notify's FSEvents backend on macOS
-//! - `freebsd_inotify` enables notify's native inotify backend on FreeBSD 15+
+//! - `freebsd_inotify` enables notify's inotify backend on FreeBSD 15+
+//!   - inotify is automatically enabled when built natively, this feature is only needed for cross-compilation
 //! - `macos_kqueue` enables notify's kqueue backend on macOS
 //! - `serde` enables serialization support in notify-types
 //! - `web-time` uses `web_time::Instant` for debounced events

--- a/notify-debouncer-mini/src/lib.rs
+++ b/notify-debouncer-mini/src/lib.rs
@@ -46,7 +46,8 @@
 //! The following crate features can be configured in your Cargo dependency:
 //!
 //! - `macos_fsevent` (default) enables notify's FSEvents backend on macOS
-//! - `freebsd_inotify` enables notify's native inotify backend on FreeBSD 15+
+//! - `freebsd_inotify` enables notify's inotify backend on FreeBSD 15+
+//!   - inotify is automatically enabled when built natively, this feature is only needed for cross-compilation
 //! - `macos_kqueue` enables notify's kqueue backend on macOS
 //! - `serde` enables serialization support in notify-types
 //! - `crossbeam-channel`, `flume`, `futures`, and `tokio` enable the corresponding

--- a/notify/CHANGELOG.md
+++ b/notify/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## unreleased
 
-- FEATURE: [FreeBSD] add native inotify support on FreeBSD 15.0+ behind the `freebsd_inotify` feature. kqueue remains the default backend.
+- FEATURE: [FreeBSD] select native inotify automatically when building on FreeBSD 15.0+ and kqueue otherwise. The `freebsd_inotify` feature enables inotify when cross-compiling for FreeBSD 15.0+.
 - DEPS: bump `inotify` to 0.11.4 for native FreeBSD support
 - FEATURE: [macOS] add `Config::with_fsevent_latency` to configure FSEvents stream latency [#930]
 - FIX: [linux] coalesce duplicate inotify cleanup events and handle kernel-removed descriptors without spurious `EINVAL` or `WatchNotFound` logs

--- a/notify/Cargo.toml
+++ b/notify/Cargo.toml
@@ -22,8 +22,8 @@ default = ["macos_fsevent"]
 serde = ["notify-types/serde"]
 macos_kqueue = ["kqueue", "mio"]
 macos_fsevent = ["objc2-core-foundation", "objc2-core-services"]
-# Opt-in native inotify backend for FreeBSD 15+.
-freebsd_inotify = ["dep:inotify"]
+# Force native inotify when cross-compiling for FreeBSD 15+.
+freebsd_inotify = []
 serialization-compat-6 = ["notify-types/serialization-compat-6"]
 tokio = ["dep:tokio"]
 futures = ["dep:futures"]
@@ -72,9 +72,9 @@ windows-sys = { workspace = true, features = [
   "Win32_System_IO",
 ] }
 
-# Keep kqueue available when the inotify backend is enabled.
+# Both backends must be available for build-time selection.
 [target.'cfg(target_os="freebsd")'.dependencies]
-inotify = { workspace = true, default-features = false, optional = true }
+inotify = { workspace = true, default-features = false }
 kqueue.workspace = true
 mio.workspace = true
 

--- a/notify/build.rs
+++ b/notify/build.rs
@@ -1,0 +1,47 @@
+use std::{env, process::Command};
+
+const FREEBSD_INOTIFY_MIN_MAJOR: u32 = 15;
+const FREEBSD_VERSION_COMMAND: &str = "/bin/freebsd-version";
+
+fn main() {
+    println!("cargo::rerun-if-changed=build.rs");
+    println!("cargo::rustc-check-cfg=cfg(notify_freebsd_inotify)");
+
+    if env::var("CARGO_CFG_TARGET_OS").as_deref() != Ok("freebsd") {
+        return;
+    }
+
+    let feature_enabled = env::var_os("CARGO_FEATURE_FREEBSD_INOTIFY").is_some();
+    // freebsd-version describes the host, so only use it for native builds.
+    let native_build = matches!(
+        (env::var("HOST"), env::var("TARGET")),
+        (Ok(host), Ok(target)) if host == target
+    );
+    if native_build {
+        println!("cargo::rerun-if-changed={FREEBSD_VERSION_COMMAND}");
+    }
+    let version_supported = native_build
+        && freebsd_major_version().is_some_and(|major| major >= FREEBSD_INOTIFY_MIN_MAJOR);
+
+    if feature_enabled || version_supported {
+        println!("cargo::rustc-cfg=notify_freebsd_inotify");
+    }
+}
+
+fn freebsd_major_version() -> Option<u32> {
+    let output = Command::new(FREEBSD_VERSION_COMMAND)
+        .arg("-u")
+        .output()
+        .ok()?;
+    if !output.status.success() {
+        return None;
+    }
+
+    std::str::from_utf8(&output.stdout)
+        .ok()?
+        .trim()
+        .split('.')
+        .next()?
+        .parse()
+        .ok()
+}

--- a/notify/src/inotify.rs
+++ b/notify/src/inotify.rs
@@ -1343,6 +1343,13 @@ mod tests {
         );
     }
 
+    // FIXME: FreeBSD 15.1 does not generate IN_IGNORED unless IN_DELETE_SELF was requested.
+    // Remove this ignore once CI uses a release containing the fix:
+    // https://cgit.freebsd.org/src/commit/?id=242c9c86c8cad6aa29bc1af9161d4f0eec45f29b
+    #[cfg_attr(
+        target_os = "freebsd",
+        ignore = "FreeBSD 15.1 does not generate IN_IGNORED unconditionally"
+    )]
     #[test]
     fn ignored_event_removes_watch_when_remove_events_are_filtered_out() {
         let tmpdir = tempfile::tempdir().expect("tmpdir");

--- a/notify/src/lib.rs
+++ b/notify/src/lib.rs
@@ -17,8 +17,12 @@
 //! - `serde` for serialization of events
 //! - `macos_fsevent` (default) for the FSEvents backend on macOS
 //! - `macos_kqueue` for the kqueue backend on macOS
-//! - `freebsd_inotify` for native inotify on FreeBSD 15.0+
+//! - `freebsd_inotify` enables notify's inotify backend on FreeBSD 15+
+//!   - inotify is automatically enabled when built natively, this feature is only needed for cross-compilation
 //! - `serialization-compat-6` restores the serialization behavior of notify 6, off by default
+//!
+//! Native FreeBSD builds use inotify on 15.0+ and kqueue on older releases. When
+//! cross-compiling for FreeBSD 15.0+, enable `freebsd_inotify` explicitly.
 //!
 //! ### Serde
 //!
@@ -185,7 +189,7 @@ pub(crate) type Sender<T> = std::sync::mpsc::Sender<T>;
 #[cfg(any(
     target_os = "linux",
     target_os = "android",
-    all(target_os = "freebsd", feature = "freebsd_inotify"),
+    all(target_os = "freebsd", notify_freebsd_inotify),
     target_os = "windows",
 ))]
 pub(crate) type BoundSender<T> = std::sync::mpsc::SyncSender<T>;
@@ -198,7 +202,7 @@ pub(crate) fn unbounded<T>() -> (Sender<T>, Receiver<T>) {
 #[cfg(any(
     target_os = "linux",
     target_os = "android",
-    all(target_os = "freebsd", feature = "freebsd_inotify"),
+    all(target_os = "freebsd", notify_freebsd_inotify),
     target_os = "windows",
 ))]
 #[inline]
@@ -211,7 +215,7 @@ pub use crate::fsevent::FsEventWatcher;
 #[cfg(any(
     target_os = "linux",
     target_os = "android",
-    all(target_os = "freebsd", feature = "freebsd_inotify"),
+    all(target_os = "freebsd", notify_freebsd_inotify),
 ))]
 pub use crate::inotify::INotifyWatcher;
 #[cfg(any(
@@ -233,7 +237,7 @@ pub mod fsevent;
 #[cfg(any(
     target_os = "linux",
     target_os = "android",
-    all(target_os = "freebsd", feature = "freebsd_inotify"),
+    all(target_os = "freebsd", notify_freebsd_inotify),
 ))]
 pub mod inotify;
 #[cfg(any(
@@ -328,7 +332,7 @@ impl EventHandler for std::sync::mpsc::Sender<Result<Event>> {
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 #[non_exhaustive]
 pub enum WatcherKind {
-    /// Inotify backend (Linux, Android, and FreeBSD 15+ with `freebsd_inotify`)
+    /// Inotify backend (Linux, Android, and FreeBSD 15+)
     Inotify,
     /// FS-Event backend (mac)
     Fsevent,
@@ -487,7 +491,7 @@ pub trait Watcher {
 #[cfg(any(
     target_os = "linux",
     target_os = "android",
-    all(target_os = "freebsd", feature = "freebsd_inotify"),
+    all(target_os = "freebsd", notify_freebsd_inotify),
 ))]
 pub type RecommendedWatcher = INotifyWatcher;
 /// The recommended [`Watcher`] implementation for the current platform
@@ -498,7 +502,7 @@ pub type RecommendedWatcher = FsEventWatcher;
 pub type RecommendedWatcher = ReadDirectoryChangesWatcher;
 /// The recommended [`Watcher`] implementation for the current platform
 #[cfg(any(
-    all(target_os = "freebsd", not(feature = "freebsd_inotify")),
+    all(target_os = "freebsd", not(notify_freebsd_inotify)),
     target_os = "openbsd",
     target_os = "netbsd",
     target_os = "dragonfly",
@@ -601,6 +605,32 @@ mod tests {
         assert_debug_impl!(RecommendedWatcher);
         assert_debug_impl!(RecursiveMode);
         assert_debug_impl!(WatcherKind);
+    }
+
+    #[cfg(target_os = "freebsd")]
+    #[test]
+    fn recommended_watcher_matches_freebsd_version() {
+        let output = std::process::Command::new("/bin/freebsd-version")
+            .arg("-u")
+            .output()
+            .expect("run freebsd-version");
+        assert!(output.status.success(), "freebsd-version failed");
+
+        let version = std::str::from_utf8(&output.stdout).expect("parse freebsd-version output");
+        let major = version
+            .trim()
+            .split('.')
+            .next()
+            .expect("find FreeBSD major version")
+            .parse::<u32>()
+            .expect("parse FreeBSD major version");
+        let expected = if cfg!(feature = "freebsd_inotify") || major >= 15 {
+            WatcherKind::Inotify
+        } else {
+            WatcherKind::Kqueue
+        };
+
+        assert_eq!(RecommendedWatcher::kind(), expected);
     }
 
     fn iter_with_timeout(rx: &mpsc::Receiver<Result<Event>>) -> impl Iterator<Item = Event> + '_ {


### PR DESCRIPTION
<!-- 
## Contribution Agreement
By contributing, you agree to the license terms (CC Zero 1.0 for notify crate, MIT/Apache 2.0 for the rest) and the code of conduct in CODE_OF_CONDUCT.md.

## Changelog
Add an entry to CHANGELOG.md if applicable. Create a new section `## notify (unreleased)` if not already present.

## Testing
The test suite will run after creating this PR. If builds fail, you must either fix the errors, ask for help, or provide a detailed explanation of why failures are expected. If you don't, a maintainer may prompt you, but it will take longer for your contribution to be reviewed.

## Code Quality
Running `cargo fmt` and `cargo clippy` is appreciated but not required.

You can delete this comment after reading.
-->

## Description
<!-- Describe your changes here -->

A follow-up for https://github.com/notify-rs/notify/pull/952#issuecomment-5148297291

## Related Issues
<!-- Link any related issues -->
