### PR TITLE
fix(inotify): report subdirectories found by the recursive catch-up walk

### DIFF
--- a/notify/CHANGELOG.md
+++ b/notify/CHANGELOG.md
@@ -14,7 +14,9 @@
 - CHANGE: [macOS] improve FSEvents callback performance by avoiding unnecessary allocations and repeated handler locking
 - FIX: [macOS] refuse to create FSEvents streams whose combined path count would make macOS close a file descriptor this process owns
 - PERF: [kqueue] avoid filesystem walks for recursive kqueue unwatch
+- FIX: [linux] emit a create event for every subdirectory of a directory tree that appears inside a recursive watch in one go, instead of only its topmost directory [#727]
 
+[#727]: https://github.com/notify-rs/notify/issues/727
 [#930]: https://github.com/notify-rs/notify/pull/930
 [#935]: https://github.com/notify-rs/notify/issues/935
 [#958]: https://github.com/notify-rs/notify/pull/958

--- a/notify/src/inotify.rs
+++ b/notify/src/inotify.rs
@@ -168,6 +168,15 @@ enum WatchRemoval {
     DescriptorAlreadyRemoved,
 }
 
+/// Whether the catch-up walk of a recursive watch reports the entries it finds as created.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum ReportCreated {
+    /// Report nothing. The caller asked for this tree, so its existing contents are not news.
+    Nothing,
+    /// Report every directory below the walk root as created.
+    BelowWalkRoot,
+}
+
 #[inline]
 fn unmount_event(path: PathBuf) -> Event {
     Event::new(EventKind::Remove(RemoveKind::Other))
@@ -574,7 +583,7 @@ impl EventLoop {
         }
 
         for path in add_watches {
-            if let Err(add_watch_error) = self.add_watch(path, true, false) {
+            if let Err(add_watch_error) = self.add_watch_for_new_dir(path) {
                 // The handler should be notified if we have reached the limit.
                 // Otherwise, the user might expect that a recursive watch
                 // is continuing to work correctly, but it's not.
@@ -637,7 +646,7 @@ impl EventLoop {
                                 reported_path(&ancestor_path, &ancestor_reported_path, &absolute);
                             WatchPath::from_parts(absolute, requested)
                         });
-                    self.add_watches_for_paths(entries, true, false)?;
+                    self.add_watches_for_paths(entries, true, false, ReportCreated::Nothing)?;
                 }
             }
         }
@@ -648,14 +657,34 @@ impl EventLoop {
             return self.add_single_watch(path, false, true);
         }
 
-        let root = path.clone();
-        let entries = WalkDir::new(&root.absolute)
+        self.add_watches_for_tree(path, is_recursive, watch_self, ReportCreated::Nothing)
+    }
+
+    /// Watches a directory that appeared inside an existing recursive watch.
+    ///
+    /// The kernel reports the creation of that directory only. Subdirectories it already contains
+    /// by the time the watch is installed - what a single `create_dir_all("a/b/c")` call leaves
+    /// behind - were created before any watch covered them, so the catch-up walk is the only place
+    /// an event for them can come from.
+    fn add_watch_for_new_dir(&mut self, path: WatchPath) -> Result<()> {
+        self.add_watches_for_tree(path, true, false, ReportCreated::BelowWalkRoot)
+    }
+
+    /// Watches `root` and every directory below it.
+    fn add_watches_for_tree(
+        &mut self,
+        root: WatchPath,
+        is_recursive: bool,
+        watch_self: bool,
+        report_created: ReportCreated,
+    ) -> Result<()> {
+        let entries = WalkDir::new(root.absolute.clone())
             .follow_links(self.follow_links)
             .into_iter()
             .filter_map(filter_dir)
             .map(move |entry| root.child(entry.into_path()));
 
-        self.add_watches_for_paths(entries, is_recursive, watch_self)
+        self.add_watches_for_paths(entries, is_recursive, watch_self, report_created)
     }
 
     fn add_watches_for_paths<I>(
@@ -663,19 +692,37 @@ impl EventLoop {
         paths: I,
         is_recursive: bool,
         mut watch_self: bool,
+        report_created: ReportCreated,
     ) -> Result<()>
     where
         I: IntoIterator<Item = WatchPath>,
     {
+        // The walk root is the path the caller already knows about, either because the user asked
+        // for it or because the kernel announced it, so it is never reported here.
+        let mut at_walk_root = true;
+
         for path in paths {
+            let created_path = (!at_walk_root && report_created == ReportCreated::BelowWalkRoot)
+                .then(|| path.requested.clone());
             match self.add_single_watch(path, is_recursive, watch_self) {
-                Ok(()) => {}
+                // Report only once the watch is in place, so that a handler reacting to the new
+                // directory cannot make a change that nothing is watching for yet.
+                Ok(()) => {
+                    if let Some(created_path) = created_path {
+                        let event = Event::new(EventKind::Create(CreateKind::Folder))
+                            .add_path(created_path);
+                        if self.event_kind_mask.matches(&event.kind) {
+                            self.event_handler.handle_event(Ok(event));
+                        }
+                    }
+                }
                 // TOCTOU: a subdirectory can disappear between walkdir listing it and us adding an
                 // inotify watch for it. This should not fail the overall recursive watch call.
                 Err(err) if !watch_self && matches!(err.kind, ErrorKind::PathNotFound) => {}
                 Err(err) => return Err(err),
             }
             watch_self = false;
+            at_walk_root = false;
         }
 
         Ok(())
@@ -1016,7 +1063,7 @@ mod tests {
         Config, Error, ErrorKind, Event, EventKind, EventLoop, INotifyWatcher, RecursiveMode,
         Result, WatchPath, Watcher,
     };
-    use notify_types::event::{EventKindMask, RemoveKind};
+    use notify_types::event::{CreateKind, EventKindMask, RemoveKind};
 
     use crate::test::*;
 
@@ -1085,11 +1132,41 @@ mod tests {
                 .map(|path| WatchPath::new(&path).unwrap()),
             true,
             true,
+            super::ReportCreated::Nothing,
         );
         assert!(
             result.is_ok(),
             "expected recursive watch to succeed, got: {result:?}"
         );
+    }
+
+    /// Watching a path is not a change, so a tree that is already there must stay unreported,
+    /// unlike one that appears inside an established recursive watch.
+    #[test]
+    fn watching_a_directory_does_not_report_its_existing_contents() {
+        let tmpdir = tempfile::tempdir().unwrap();
+        let root = tmpdir.path().to_path_buf();
+        std::fs::create_dir_all(root.join("1/2/3")).expect("create nested dirs");
+
+        let (tx, rx) = mpsc::channel();
+        let inotify = super::inotify_sys::Inotify::init().unwrap();
+        let mut event_loop = EventLoop::new(
+            inotify,
+            Box::new(move |event| tx.send(event).unwrap()),
+            &Config::default(),
+        )
+        .unwrap();
+        event_loop
+            .add_watch(WatchPath::new(&root).unwrap(), true, true)
+            .expect("watch recursively");
+        event_loop.handle_inotify();
+
+        let created = rx
+            .try_iter()
+            .map(|event| event.expect("unexpected error from the watcher"))
+            .filter(|event| matches!(event.kind, EventKind::Create(CreateKind::Folder)))
+            .collect::<Vec<_>>();
+        assert!(created.is_empty(), "unexpected create events: {created:#?}");
     }
 
     #[test]
@@ -1998,7 +2075,6 @@ mod tests {
     }
 
     #[test]
-    #[ignore = "see https://github.com/notify-rs/notify/issues/727"]
     fn recursive_creation() {
         let tmpdir = testdir();
         let nested1 = tmpdir.path().join("1");


### PR DESCRIPTION
## Description

Watching a directory recursively and then creating a nested tree in one call only reports the topmost directory:

```rust
watcher.watch(path, RecursiveMode::Recursive).unwrap();
std::fs::create_dir_all(path.join("1/2/3/4/5/6/7/8/9/10")).unwrap();
```

Before this change the only create event is `Create(Folder)` for `path/1`. The nine directories below it are never reported, even though the watcher demonstrably walks into all of them — with `EventKindMask::ALL` you can see `Access(Open)`/`Access(Close)` for every level.

### Cause

The kernel reports the creation of `1` and nothing else: `2` through `10` are created before the watch for `1` exists, so no inotify event is ever generated for them. `EventLoop::handle_inotify` reacts to the CREATE event by queueing `1` into `add_watches` and then calling `add_watch(path, true, false)`, which runs a `WalkDir` catch-up scan and installs a watch on every directory it finds. That scan is the only thing in the process that ever learns those directories exist, and it discarded that knowledge — it registered the watches and reported nothing. This is the TOCTOU window the surrounding comments already acknowledge, just observed from the event side rather than the watch side.

This is the diagnosis @riberk gave in #727 ("I think, the way to solve it may be raising events while scanning the dirs"); the issue has sat unclaimed since.

### Fix

`add_watches_for_paths` now takes a `ReportCreated` flag. When the walk was triggered by an inotify CREATE/MOVED_TO event, every directory the walk finds *below its root* is reported as `Create(Folder)`, after its watch is installed so that a handler reacting to the event cannot make a change nothing is watching for yet. The walk root itself is skipped because the kernel already announced it.

This is the right layer because the catch-up walk is the only place that ever observes these paths; nothing downstream can reconstruct them.

Deliberately unchanged:

- **The initial `watch()` call stays silent.** Watching a path is not a change, so a pre-existing tree must not be reported. `add_watch` passes `ReportCreated::Nothing`, and a new test pins that.
- **Files are not reported.** The walk only yields directories (`filter_dir`), and widening it would turn moving a large tree into a watched directory into a per-file event storm. Directory count already bounds the work done here, so the event volume stays proportional to the watches being installed.
- Other backends are untouched.

## Verification

Fail-before (fix reverted, tests kept):

```
test inotify::tests::watching_a_directory_does_not_report_its_existing_contents ... ok
test inotify::tests::recursive_creation ... FAILED
thread 'inotify::tests::recursive_creation' panicked at notify/src/test.rs:70:27:
Recv error: Timeout. Watcher: Inotify. State: ExpectedState {
test result: FAILED. 1 passed; 1 failed; 0 ignored; 0 measured; 82 filtered out; finished in 1.00s
```

Pass-after:

```
test inotify::tests::recursive_creation ... ok
test inotify::tests::watching_a_directory_does_not_report_its_existing_contents ... ok
test result: ok. 2 passed; 0 failed; 0 ignored; 0 measured; 82 filtered out
```

`cargo test --workspace --all-features --no-fail-fast`, three consecutive runs, all identical: `notify` lib 85 passed / 0 failed / 1 ignored, everything else green except `tests/serialise-events.rs` (6 failures, `left: String("any"), right: Object {"type": String("any")}`) which fails the same way on a clean checkout of d285062 and is unrelated to this change.

`cargo fmt --all -- --check` and `cargo clippy --all-targets --all-features -- -D warnings` are clean.

## Tests

- `recursive_creation` already existed, marked `#[ignore = "see .../issues/727"]`, and now passes — the `#[ignore]` is removed.
- `watching_a_directory_does_not_report_its_existing_contents` is new: it recursively watches a directory that already contains `1/2/3` and asserts no create events are emitted. Making `add_watch` report its own walk fails this test.

## Related Issues

Fixes #727

## Note

#970 also refactors `add_watches_for_paths`, so one of these two will need a trivial rebase over the other.
