### PR TITLE
poll: stop the tests from depending on second boundaries

### DIFF
--- a/notify/src/poll.rs
+++ b/notify/src/poll.rs
@@ -773,6 +773,20 @@ mod tests {
         poll_watcher_channel()
     }
 
+    /// Dates a path's write time an hour ahead. `PathData::mtime` has whole-second resolution
+    /// and is compared before the content hash, so a change to an entry is reported as
+    /// `Metadata(WriteTime)` unless its recorded write time is one that nothing happening
+    /// afterwards can exceed.
+    fn set_write_time_ahead(path: &std::path::Path) {
+        let ahead = std::time::SystemTime::now() + std::time::Duration::from_secs(3600);
+        std::fs::File::options()
+            .write(true)
+            .open(path)
+            .expect("open to set write time")
+            .set_modified(ahead)
+            .expect("set write time");
+    }
+
     #[test]
     fn poll_watcher_is_send_and_sync() {
         fn check<T: Send + Sync>() {}
@@ -879,7 +893,10 @@ mod tests {
         rx.sleep_until_exists(&path);
         rx.sleep_until_walkdir_returns_set(tmpdir.path(), [&path]);
 
-        rx.wait_ordered_exact([expected(&path).create_any()]);
+        rx.wait_unordered_exact([
+            expected(&path).create_any(),
+            expected(tmpdir.path()).modify_meta_mtime().optional(),
+        ]);
     }
 
     #[test]
@@ -895,7 +912,10 @@ mod tests {
         rx.sleep_until_exists(&path);
         rx.sleep_until_walkdir_returns_set(tmpdir.path(), [&path]);
 
-        rx.wait_ordered_exact([expected(&path).create_any()]);
+        rx.wait_unordered_exact([
+            expected(&path).create_any(),
+            expected(tmpdir.path()).modify_meta_mtime().optional(),
+        ]);
     }
 
     #[test]
@@ -909,7 +929,9 @@ mod tests {
         rx.sleep_until_exists(&path);
         rx.sleep_until_walkdir_returns_set(tmpdir.path(), [&path]);
 
+        set_write_time_ahead(&path);
         watcher.watch_recursively(&tmpdir);
+
         std::fs::write(&path, b"123").expect("Unable to write");
 
         assert!(
@@ -938,7 +960,10 @@ mod tests {
         rx.sleep_while_parent_contains(&path);
         rx.sleep_until_walkdir_returns_set::<&str>(tmpdir.path(), []);
 
-        rx.wait_ordered_exact([expected(&path).remove_any()]);
+        rx.wait_unordered_exact([
+            expected(&path).remove_any(),
+            expected(tmpdir.path()).modify_meta_mtime().optional(),
+        ]);
     }
 
     #[test]
@@ -968,6 +993,7 @@ mod tests {
         rx.wait_unordered_exact([
             expected(&path).remove_any(),
             expected(&new_path).create_any(),
+            expected(tmpdir.path()).modify_meta_mtime().optional(),
         ]);
     }
 
@@ -982,6 +1008,8 @@ mod tests {
         rx.sleep_until_parent_contains(&overwritten_file);
         rx.sleep_until_exists(&overwritten_file);
         rx.sleep_until_walkdir_returns_set(tmpdir.path(), [overwritten_file.clone()]);
+
+        set_write_time_ahead(&overwritten_file);
 
         watcher.watch_nonrecursively(&tmpdir);
 

--- a/notify/src/test.rs
+++ b/notify/src/test.rs
@@ -646,8 +646,10 @@ mod expect {
     pub struct Unordered(Vec<(usize, ExpectedEvent)>);
 
     impl ExpectedEvents for Unordered {
+        // A queue holding nothing but optional expectations must not keep the waiter blocking
+        // on an event that may never arrive.
         fn is_empty(&self) -> bool {
-            self.0.is_empty()
+            self.0.iter().all(|(_, expected)| expected.is_optional())
         }
 
         fn expected(&mut self, event: &Event) -> Option<ExpectedEvent> {
@@ -673,7 +675,7 @@ mod expect {
 
     impl ExpectedEvents for Ordered {
         fn is_empty(&self) -> bool {
-            self.0.is_empty()
+            self.0.iter().all(|expected| expected.is_optional())
         }
 
         fn expected(&mut self, event: &Event) -> Option<ExpectedEvent> {

--- a/notify/tests/poll-watcher-hashing.rs
+++ b/notify/tests/poll-watcher-hashing.rs
@@ -56,9 +56,12 @@ impl TestHarness {
     pub fn setup() -> Self {
         let tempdir = tempfile::tempdir().unwrap();
 
+        // Manual polling: `write_file_keep_time` restores the write time in a second syscall
+        // after the write, and a background scan landing in between would see the new content
+        // with a new write time and report `Metadata(WriteTime)` instead of `Data`.
         let config = Config::default()
             .with_compare_contents(true)
-            .with_poll_interval(Duration::from_millis(10));
+            .with_manual_polling();
         let (tx, rx) = sync::mpsc::channel();
         let watcher = PollWatcher::new(
             move |event: notify::Result<Event>| {
@@ -116,11 +119,23 @@ impl TestHarness {
     }
 
     fn expect_recv<P: AsRef<Path>>(&self, expected_path: P, expected_kind: EventKind) {
-        let actual = self
-            .rx
-            .recv_timeout(Duration::from_secs(15))
-            .unwrap()
-            .expect("Watch I/O error not expected under test");
+        self.watcher.poll_blocking().expect("poll");
+
+        let watched_dir = vec![self.testdir.path().to_path_buf()];
+        let actual = loop {
+            let event = self
+                .rx
+                .recv_timeout(Duration::from_secs(15))
+                .unwrap()
+                .expect("Watch I/O error not expected under test");
+            // Creating an entry bumps the containing directory's own write time, and the scan
+            // reports a directory before the entries inside it. That event is not what this
+            // test is about.
+            if event.paths != watched_dir {
+                break event;
+            }
+        };
+
         assert_eq!(actual.paths, vec![expected_path.as_ref().to_path_buf()]);
         assert_eq!(expected_kind, actual.kind);
     }


### PR DESCRIPTION
PathData::mtime has whole-second resolution and is compared before the content hash, so the kind of event a change produces depends on whether it crossed a wall-clock second. Six poll tests asserted one of the two outcomes and failed about one run in ten under the load of the full suite.

Mutating a watched directory bumps its own write time, so create_file, create_dir, remove_file and rename_file can get an extra Modify(Metadata(WriteTime)) for the directory; accept it as optional. modify_file and create_write_overwrite leave an entry with both new contents and a new write time, reported as Data within a second and as Metadata(WriteTime) across one. Set that entry's write time an hour ahead before the baseline scan and the comparison always falls through to the hash. Restoring the old write time after the change is not enough: on macOS the scan can still stat the write time of the change.

poll-watcher-hashing.rs did restore it, but polled every 10ms, so a scan could land between the write and the restore. Poll it manually instead and skip the directory's own event. Trailing optional expectations also needed a harness fix, since is_empty counted a queue holding only optionals as non-empty and the waiter blocked until it timed out.

Sleeping a second before each mutation fails all six tests before this change and passes after.
