### PR TITLE
paths: drop the reported-path ancestor search

### DIFF
--- a/notify/src/inotify.rs
+++ b/notify/src/inotify.rs
@@ -801,9 +801,6 @@ impl EventLoop {
                             is_recursive,
                             watch_self,
                             Some(&existing_watch.metadata),
-                            self.watches
-                                .iter()
-                                .map(|(path, watch)| (path, &watch.metadata)),
                         )
                     } else {
                         WatchMetadata {
@@ -1333,6 +1330,45 @@ mod tests {
             .expect("grandchild still covered by recursive parent");
         assert!(!grandchild_watch.metadata.is_user_watch);
         assert!(grandchild_watch.metadata.is_recursive);
+    }
+
+    #[test]
+    fn outer_recursive_watch_respells_inherited_entries_only() {
+        let tmpdir = tempfile::tempdir().unwrap();
+        let root = tmpdir.path().to_path_buf();
+        let child = root.join("child");
+        let grandchild = child.join("grandchild");
+        std::fs::create_dir_all(&grandchild).unwrap();
+
+        let mut event_loop = test_event_loop();
+
+        event_loop
+            .add_watch(
+                WatchPath::from_parts(child.clone(), PathBuf::from("reported-child")),
+                recursive_watch(),
+                true,
+            )
+            .expect("watch child recursively under its own spelling");
+        event_loop
+            .add_watch(WatchPath::new(&root).unwrap(), recursive_watch(), true)
+            .expect("watch root recursively");
+
+        // The outer walk reaches both entries, but only the inherited one takes its spelling:
+        // an explicit watch keeps whatever the user asked for, so the two halves of the same
+        // subtree end up reported under different roots.
+        let child_watch = event_loop.watches.get(&child).expect("child watch");
+        assert!(child_watch.metadata.is_user_watch);
+        assert_eq!(
+            child_watch.metadata.reported_path,
+            PathBuf::from("reported-child")
+        );
+
+        let grandchild_watch = event_loop
+            .watches
+            .get(&grandchild)
+            .expect("grandchild watch");
+        assert!(!grandchild_watch.metadata.is_user_watch);
+        assert_eq!(grandchild_watch.metadata.reported_path, grandchild);
     }
 
     #[test]

--- a/notify/src/kqueue.rs
+++ b/notify/src/kqueue.rs
@@ -476,13 +476,7 @@ impl EventLoop {
             .add_filename(&path.absolute, event_filter, filter_flags)
             .map_err(|e| Error::io(e).add_path(path.requested.clone()))?;
         let existing_watch = self.watches.get(&path.absolute);
-        let watch = Watch::new(
-            &path,
-            is_recursive,
-            is_user_watch,
-            existing_watch,
-            self.watches.iter(),
-        );
+        let watch = Watch::new(&path, is_recursive, is_user_watch, existing_watch);
         self.watches.insert(path.absolute, watch);
 
         Ok(())
@@ -830,6 +824,40 @@ mod tests {
             .expect("grandchild still covered by recursive parent");
         assert!(!grandchild_watch.is_user_watch);
         assert!(grandchild_watch.is_recursive);
+
+        Ok(())
+    }
+
+    #[test]
+    fn outer_recursive_watch_respells_inherited_entries_only()
+    -> std::result::Result<(), Box<dyn std::error::Error>> {
+        let dir = tempfile::tempdir()?;
+        let child = dir.path().join("child");
+        let grandchild = child.join("grandchild");
+        std::fs::create_dir_all(&grandchild)?;
+
+        let mut event_loop = test_event_loop()?;
+
+        event_loop.add_watch(
+            WatchPath::from_parts(child.clone(), PathBuf::from("reported-child")),
+            true,
+            true,
+        )?;
+        event_loop.add_watch(WatchPath::new(dir.path())?, true, true)?;
+
+        // The outer walk reaches both entries, but only the inherited one takes its spelling:
+        // an explicit watch keeps whatever the user asked for, so the two halves of the same
+        // subtree end up reported under different roots.
+        let child_watch = event_loop.watches.get(&child).expect("child watch");
+        assert!(child_watch.is_user_watch);
+        assert_eq!(child_watch.reported_path, PathBuf::from("reported-child"));
+
+        let grandchild_watch = event_loop
+            .watches
+            .get(&grandchild)
+            .expect("grandchild watch");
+        assert!(!grandchild_watch.is_user_watch);
+        assert_eq!(grandchild_watch.reported_path, grandchild);
 
         Ok(())
     }

--- a/notify/src/paths.rs
+++ b/notify/src/paths.rs
@@ -40,39 +40,22 @@ impl WatchPath {
 }
 
 impl WatchMetadata {
-    pub(crate) fn new<'a, I>(
+    pub(crate) fn new(
         path: &WatchPath,
         is_recursive: bool,
         is_user_watch: bool,
         existing_watch: Option<&Self>,
-        user_roots: I,
-    ) -> Self
-    where
-        I: IntoIterator<Item = (&'a PathBuf, &'a Self)>,
-    {
-        let existing_reported_path = existing_watch.map(|watch| watch.reported_path.clone());
+    ) -> Self {
         let existing_is_user_watch = existing_watch.is_some_and(|watch| watch.is_user_watch);
         let existing_user_is_recursive =
             existing_watch.is_some_and(|watch| watch.user_is_recursive);
         let existing_is_recursive = existing_watch.is_some_and(|watch| watch.is_recursive);
 
-        let reported_path = if is_user_watch {
-            path.requested.clone()
-        } else if existing_is_user_watch {
-            existing_reported_path.unwrap_or_else(|| path.requested.clone())
-        } else {
-            user_roots
-                .into_iter()
-                .filter(|(candidate, watch)| {
-                    watch.is_user_watch
-                        && watch.user_is_recursive
-                        && path.absolute.starts_with(candidate)
-                })
-                .max_by_key(|(candidate, _)| candidate.as_os_str().len())
-                .map_or_else(
-                    || path.requested.clone(),
-                    |(root, watch)| reported_path(root, &watch.reported_path, &path.absolute),
-                )
+        let reported_path = match existing_watch {
+            Some(existing) if !is_user_watch && existing.is_user_watch => {
+                existing.reported_path.clone()
+            }
+            _ => path.requested.clone(),
         };
 
         Self {


### PR DESCRIPTION
Every watch knows what to call its path in events: watch "logs" and you
get "logs/app.txt", not the absolute path. When we walk a recursive
watch the walker already knows the right name for each entry and passes
it in. WatchMetadata::new ignored that and went looking through every
watch we have to work the same name out again.

On kqueue that happens for every entry in the walk, which gets slow
quickly. Metadata for one root plus N entries, release build:

    10k     65 ms   ->  5 ms
    50k     2.5 s   ->  15 ms
    100k    10.5 s  ->  30 ms

The search was doing one useful thing though. Watch "logs", then watch
"/repo" around it, and the outer walk would rename logs/access to
"/repo/logs/access". That name sticks even after "/repo" is unwatched.
So the walk now handles that itself: WalkRoots notices when it walks
into an existing recursive user watch and names everything below after
that one. Same rule as before, just a small stack instead of a scan per
entry.

Two small things change. inotify gives brand new directories under a
nested watch the right name straight away, and entries found at runtime
keep the name their parent gave them, where the search could flip them
to the outer spelling later on.

Tests: the nested case (unwatch included) on inotify and kqueue, a late
create event for a directory the user has since watched by name, and
unit tests for WalkRoots in paths.rs that run everywhere.

Signed-off-by: Daan De Meyer <daan@amutable.com>