### PR TITLE
perf(windows): reduce fs::metadata calls when adding a watch

### DIFF
--- a/notify/src/windows.rs
+++ b/notify/src/windows.rs
@@ -287,8 +287,13 @@ impl ReadDirectoryChangesServer {
         is_recursive: bool,
         separator_style: SeparatorStyle,
     ) -> Result<PathBuf> {
+        let metadata = path.absolute.metadata();
         // path must exist and be either a file or directory
-        if !path.absolute.is_dir() && !path.absolute.is_file() {
+        if metadata
+            .as_ref()
+            .map(|m| !m.is_dir() && !m.is_file())
+            .unwrap_or(true)
+        {
             return Err(
                 Error::generic("Input watch path is neither a file nor a directory.")
                     .add_path(path.requested),
@@ -296,7 +301,7 @@ impl ReadDirectoryChangesServer {
         }
 
         let (watching_file, dir_target) = {
-            if path.absolute.is_dir() {
+            if metadata.map(|m| m.is_dir()).unwrap_or(false) {
                 (false, path.absolute.clone())
             } else {
                 // emulate file watching by watching the parent directory
@@ -818,12 +823,6 @@ impl ReadDirectoryChangesWatcher {
     fn watch_inner(&mut self, path: &Path, recursive_mode: RecursiveMode) -> Result<()> {
         let separator_style = SeparatorStyle::resolve(self.windows_path_separator_style, path);
         let pb = WatchPath::new(path)?;
-        // path must exist and be either a file or directory
-        if !pb.absolute.is_dir() && !pb.absolute.is_file() {
-            return Err(Error::generic(
-                "Input watch path is neither a file nor a directory.",
-            ));
-        }
         self.send_action_require_ack(
             Action::Watch(pb.clone(), recursive_mode, separator_style),
             &pb.absolute,


### PR DESCRIPTION
## Description

On Windows, `watch_inner` checks that the path is a file or a directory before sending the request to the watcher thread, and `add_watch` then performs the exact same check again, plus one more `is_dir` call to decide between file and directory watching. Each `is_dir`/`is_file` call is a separate `fs::metadata` syscall, so a single watch request ends up doing up to five of them.

This PR removes the duplicated client-side check and reuses one `metadata` result in `add_watch`, reducing it to a single call. This mainly matters for applications that watch many individual files. As a side effect, the error for a non-existent path now includes the path, since it is reported by the watcher thread.

Ported from the rolldown fork: rolldown/notify@d44e3277f166ee58b07aee3cefd204bedd30015d.

## Additional review notes

Part of the same effort as #980: upstreaming small changes from the rolldown fork.

## Related Issues

None.
