### PR TITLE
feat(freebsd): select inotify on 14.5+

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -63,7 +63,7 @@ body:
       description: Which backend is being used?
       options:
         - Unknown/Auto-detected
-        - inotify (Linux/Android/FreeBSD 15+)
+        - inotify (Linux/Android/FreeBSD 14.5+)
         - FSEvents (macOS)
         - kqueue (macOS/iOS/BSDs)
         - ReadDirectoryChangesW (Windows)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -147,7 +147,7 @@ jobs:
         if: matrix.rust == 'stable'
         run: cargo test --workspace --exclude examples --verbose ${{ matrix.features }} --features tokio
 
-  # Verify automatic backend selection on both supported FreeBSD releases.
+  # Verify automatic backend selection: kqueue before 14.5, inotify on 14.5+.
   freebsd:
     name: FreeBSD ${{ matrix.release }} (${{ matrix.backend }}) - ${{ matrix.rust }}
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ We follow these MSRV rules:
 ## Platforms
 
 - Linux / Android: inotify
-- FreeBSD: inotify when built natively on 15.0+; kqueue otherwise (use `freebsd_inotify` for cross-builds)
+- FreeBSD: inotify when built natively on 14.5+; kqueue otherwise (use `freebsd_inotify` for cross-builds)
 - macOS: FSEvents (default) or kqueue, see features
 - Windows: ReadDirectoryChangesW
 - iOS / NetBSD / OpenBSD / DragonflyBSD: kqueue

--- a/notify-debouncer-full/src/lib.rs
+++ b/notify-debouncer-full/src/lib.rs
@@ -50,7 +50,7 @@
 //! The following crate features can be configured in your Cargo dependency:
 //!
 //! - `macos_fsevent` (default) enables notify's FSEvents backend on macOS
-//! - `freebsd_inotify` enables notify's inotify backend on FreeBSD 15+
+//! - `freebsd_inotify` enables notify's inotify backend on FreeBSD 14.5+
 //!   - inotify is automatically enabled when built natively, this feature is only needed for cross-compilation
 //! - `macos_kqueue` enables notify's kqueue backend on macOS
 //! - `serde` enables serialization support in notify-types

--- a/notify-debouncer-mini/src/lib.rs
+++ b/notify-debouncer-mini/src/lib.rs
@@ -46,7 +46,7 @@
 //! The following crate features can be configured in your Cargo dependency:
 //!
 //! - `macos_fsevent` (default) enables notify's FSEvents backend on macOS
-//! - `freebsd_inotify` enables notify's inotify backend on FreeBSD 15+
+//! - `freebsd_inotify` enables notify's inotify backend on FreeBSD 14.5+
 //!   - inotify is automatically enabled when built natively, this feature is only needed for cross-compilation
 //! - `macos_kqueue` enables notify's kqueue backend on macOS
 //! - `serde` enables serialization support in notify-types

--- a/notify/CHANGELOG.md
+++ b/notify/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## unreleased
 
-- FEATURE: [FreeBSD] select native inotify automatically when building on FreeBSD 15.0+ and kqueue otherwise. The `freebsd_inotify` feature enables inotify when cross-compiling for FreeBSD 15.0+.
+- FEATURE: [FreeBSD] select native inotify automatically when building on FreeBSD 14.5+ and kqueue otherwise. The `freebsd_inotify` feature enables inotify when cross-compiling for FreeBSD 14.5+.
 - DEPS: bump `inotify` to 0.11.4 for native FreeBSD support
 - FEATURE: [macOS] add `Config::with_fsevent_latency` to configure FSEvents stream latency [#930]
 - FIX: [linux] coalesce duplicate inotify cleanup events and handle kernel-removed descriptors without spurious `EINVAL` or `WatchNotFound` logs

--- a/notify/Cargo.toml
+++ b/notify/Cargo.toml
@@ -22,7 +22,7 @@ default = ["macos_fsevent"]
 serde = ["notify-types/serde"]
 macos_kqueue = ["kqueue", "mio"]
 macos_fsevent = ["objc2-core-foundation", "objc2-core-services"]
-# Force native inotify when cross-compiling for FreeBSD 15+.
+# Force native inotify when cross-compiling for FreeBSD 14.5+.
 freebsd_inotify = []
 serialization-compat-6 = ["notify-types/serialization-compat-6"]
 tokio = ["dep:tokio"]

--- a/notify/build.rs
+++ b/notify/build.rs
@@ -1,10 +1,12 @@
 use std::{env, process::Command};
 
-const FREEBSD_INOTIFY_MIN_MAJOR: u32 = 15;
+include!("src/freebsd_version.rs");
+
 const FREEBSD_VERSION_COMMAND: &str = "/bin/freebsd-version";
 
 fn main() {
     println!("cargo::rerun-if-changed=build.rs");
+    println!("cargo::rerun-if-changed=src/freebsd_version.rs");
     println!("cargo::rustc-check-cfg=cfg(notify_freebsd_inotify)");
 
     if env::var("CARGO_CFG_TARGET_OS").as_deref() != Ok("freebsd") {
@@ -20,15 +22,15 @@ fn main() {
     if native_build {
         println!("cargo::rerun-if-changed={FREEBSD_VERSION_COMMAND}");
     }
-    let version_supported = native_build
-        && freebsd_major_version().is_some_and(|major| major >= FREEBSD_INOTIFY_MIN_MAJOR);
+    let version_supported =
+        native_build && freebsd_release().is_some_and(|release| release >= FREEBSD_INOTIFY_MIN);
 
     if feature_enabled || version_supported {
         println!("cargo::rustc-cfg=notify_freebsd_inotify");
     }
 }
 
-fn freebsd_major_version() -> Option<u32> {
+fn freebsd_release() -> Option<(u32, u32)> {
     let output = Command::new(FREEBSD_VERSION_COMMAND)
         .arg("-u")
         .output()
@@ -37,11 +39,5 @@ fn freebsd_major_version() -> Option<u32> {
         return None;
     }
 
-    std::str::from_utf8(&output.stdout)
-        .ok()?
-        .trim()
-        .split('.')
-        .next()?
-        .parse()
-        .ok()
+    parse_freebsd_release(std::str::from_utf8(&output.stdout).ok()?)
 }

--- a/notify/src/freebsd_version.rs
+++ b/notify/src/freebsd_version.rs
@@ -1,0 +1,13 @@
+/// Native inotify shipped in FreeBSD 14.5 and later (including 15.0+).
+const FREEBSD_INOTIFY_MIN: (u32, u32) = (14, 5);
+
+/// Parse `freebsd-version -u` output, e.g. `14.5-RELEASE-p1` → `(14, 5)`.
+fn parse_freebsd_release(output: &str) -> Option<(u32, u32)> {
+    let (major_str, rest) = output.trim().split_once('.')?;
+    let major = major_str.parse().ok()?;
+    let minor_len = rest
+        .find(|c: char| !c.is_ascii_digit())
+        .unwrap_or(rest.len());
+    let minor = rest.get(..minor_len)?.parse().ok()?;
+    Some((major, minor))
+}

--- a/notify/src/inotify.rs
+++ b/notify/src/inotify.rs
@@ -1,4 +1,4 @@
-//! Inotify watcher implementation for Linux, Android, and FreeBSD 15.0+.
+//! Inotify watcher implementation for Linux, Android, and FreeBSD 14.5+.
 //!
 //! The inotify API provides a mechanism for monitoring filesystem events.  Inotify can be used to
 //! monitor individual files, or to monitor directories.  When a directory is monitored, inotify

--- a/notify/src/lib.rs
+++ b/notify/src/lib.rs
@@ -17,12 +17,12 @@
 //! - `serde` for serialization of events
 //! - `macos_fsevent` (default) for the FSEvents backend on macOS
 //! - `macos_kqueue` for the kqueue backend on macOS
-//! - `freebsd_inotify` enables notify's inotify backend on FreeBSD 15+
+//! - `freebsd_inotify` enables notify's inotify backend on FreeBSD 14.5+
 //!   - inotify is automatically enabled when built natively, this feature is only needed for cross-compilation
 //! - `serialization-compat-6` restores the serialization behavior of notify 6, off by default
 //!
-//! Native FreeBSD builds use inotify on 15.0+ and kqueue on older releases. When
-//! cross-compiling for FreeBSD 15.0+, enable `freebsd_inotify` explicitly.
+//! Native FreeBSD builds use inotify on 14.5+ and kqueue on older releases. When
+//! cross-compiling for FreeBSD 14.5+, enable `freebsd_inotify` explicitly.
 //!
 //! ### Serde
 //!
@@ -332,7 +332,7 @@ impl EventHandler for std::sync::mpsc::Sender<Result<Event>> {
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 #[non_exhaustive]
 pub enum WatcherKind {
-    /// Inotify backend (Linux, Android, and FreeBSD 15+)
+    /// Inotify backend (Linux, Android, and FreeBSD 14.5+)
     Inotify,
     /// FS-Event backend (mac)
     Fsevent,
@@ -621,6 +621,35 @@ mod tests {
         assert_debug_impl!(WatcherKind);
     }
 
+    include!("freebsd_version.rs");
+
+    fn freebsd_inotify_supported(output: &str) -> bool {
+        parse_freebsd_release(output).is_some_and(|release| release >= FREEBSD_INOTIFY_MIN)
+    }
+
+    #[test]
+    fn freebsd_inotify_release_threshold() {
+        for (version, expected) in [
+            ("13.5-RELEASE", false),
+            ("14.4-RELEASE", false),
+            ("14.4-RELEASE-p3", false),
+            ("14.4-STABLE", false),
+            ("14.5-BETA1", true),
+            ("14.5-RELEASE", true),
+            ("14.5-RELEASE-p1", true),
+            ("14.5-STABLE", true),
+            ("14.6-RELEASE", true),
+            ("15.0-RELEASE", true),
+            ("15.1-RELEASE", true),
+            ("16.0-CURRENT", true),
+        ] {
+            assert_eq!(freebsd_inotify_supported(version), expected, "{version}");
+        }
+        assert_eq!(parse_freebsd_release(""), None);
+        assert_eq!(parse_freebsd_release("14"), None);
+        assert_eq!(parse_freebsd_release("14."), None);
+    }
+
     #[cfg(target_os = "freebsd")]
     #[test]
     fn recommended_watcher_matches_freebsd_version() {
@@ -631,14 +660,7 @@ mod tests {
         assert!(output.status.success(), "freebsd-version failed");
 
         let version = std::str::from_utf8(&output.stdout).expect("parse freebsd-version output");
-        let major = version
-            .trim()
-            .split('.')
-            .next()
-            .expect("find FreeBSD major version")
-            .parse::<u32>()
-            .expect("parse FreeBSD major version");
-        let expected = if cfg!(feature = "freebsd_inotify") || major >= 15 {
+        let expected = if cfg!(feature = "freebsd_inotify") || freebsd_inotify_supported(version) {
             WatcherKind::Inotify
         } else {
             WatcherKind::Kqueue


### PR DESCRIPTION
## Description

Follow-up to #972: native inotify ships in FreeBSD 14.5 (syscalls and libc wrappers) thanks to @markjdb, not only 15.0+.

Autoselect now compares `freebsd-version -u` as `(major, minor) >= (14, 5)` so native builds on 14.5+ use inotify and older 14.x stays on kqueue. The `freebsd_inotify` feature still forces inotify for cross-compiles targeting 14.5+.

CI is unchanged: 14.4 covers kqueue, 15.1 covers inotify as it will be some time before the 14.4 builder ages out and the coverage testing is still useful.

## Related Issues

- #972
- #952